### PR TITLE
feat: add build-time version display to admin System tab

### DIFF
--- a/.github/workflows/docker-publish-beta.yml
+++ b/.github/workflows/docker-publish-beta.yml
@@ -44,5 +44,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,5 +44,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 # Build Vue frontend
 FROM node:24-alpine AS web-build
+ARG APP_VERSION=dev
+ARG BUILD_DATE=""
 WORKDIR /web
 COPY src/web/package.json src/web/package-lock.json* ./
 RUN npm ci
 COPY src/web/ .
 ENV VITE_API_BASE_URL=""
+ENV VITE_APP_VERSION=${APP_VERSION}
+ENV VITE_BUILD_DATE=${BUILD_DATE}
 RUN npm run build
 
 # Build Go API

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,8 +62,14 @@ tasks:
     vars:
       COMMIT_SHA:
         sh: git rev-parse --short HEAD
+      BUILD_DATE:
+        sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
     cmds:
-      - docker build -t {{.DOCKER_REPO}}/ancient-coins:{{.COMMIT_SHA}} -t {{.DOCKER_REPO}}/ancient-coins:latest .
+      - docker build
+        --build-arg APP_VERSION={{.COMMIT_SHA}}
+        --build-arg BUILD_DATE={{.BUILD_DATE}}
+        -t {{.DOCKER_REPO}}/ancient-coins:{{.COMMIT_SHA}}
+        -t {{.DOCKER_REPO}}/ancient-coins:latest .
 
   docker-run:
     desc: Run the Docker container locally

--- a/src/web/src/pages/AdminPage.vue
+++ b/src/web/src/pages/AdminPage.vue
@@ -177,6 +177,11 @@
             {{ settingsSaving ? 'Saving...' : 'Save System Settings' }}
           </button>
         </form>
+        <div class="version-info">
+          <span class="version-label">Version</span>
+          <span class="version-value">{{ appVersion }}</span>
+          <span v-if="buildDate" class="version-date">Built {{ buildDate }}</span>
+        </div>
       </section>
 
       <!-- Logs Tab -->
@@ -239,7 +244,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, type Component } from 'vue'
+import { ref, computed, onMounted, onUnmounted, type Component } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import {
   getUsers, deleteUser, resetUserPassword,
@@ -252,6 +257,21 @@ import { Users, Cpu, Wrench, ScrollText } from 'lucide-vue-next'
 const tabIcons: Record<string, Component> = { users: Users, ai: Cpu, system: Wrench, logs: ScrollText }
 
 const auth = useAuthStore()
+
+const rawVersion = import.meta.env.VITE_APP_VERSION || 'dev'
+const appVersion = computed(() => {
+  if (rawVersion === 'dev') return 'dev'
+  return rawVersion.length > 8 ? rawVersion.substring(0, 7) : rawVersion
+})
+const buildDate = computed(() => {
+  const raw = import.meta.env.VITE_BUILD_DATE
+  if (!raw) return ''
+  try {
+    return new Date(raw).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+  } catch {
+    return raw
+  }
+})
 
 const tabs = [
   { id: 'users', icon: 'users', label: 'Users' },
@@ -717,4 +737,30 @@ onUnmounted(() => {
 .log-debug .log-level-badge { color: #3498db; }
 .log-trace .log-level-badge { color: #7f8c8d; }
 .log-info .log-level-badge { color: #2ecc71; }
+
+.version-info {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.version-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.version-value {
+  font-family: 'Courier New', Courier, monospace;
+  color: var(--text-secondary);
+}
+
+.version-date {
+  margin-left: 0.25rem;
+}
 </style>


### PR DESCRIPTION
- Inject APP_VERSION (git SHA) and BUILD_DATE via Docker build args into VITE_APP_VERSION and VITE_BUILD_DATE environment variables
- Display version (short SHA) and build date in Admin → System tab
- Shows 'dev' when running locally without build args
- Update Dockerfile, Taskfile, and both GitHub Actions workflows to pass build args during Docker image builds