### PR TITLE
Add server-side image scraping fallback for agent suggestions

### DIFF
--- a/src/api/go.mod
+++ b/src/api/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
 	golang.org/x/crypto v0.49.0
+	golang.org/x/net v0.51.0
 	gorm.io/gorm v1.30.5
 )
 
@@ -60,7 +61,6 @@ require (
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/src/api/handlers/agent.go
+++ b/src/api/handlers/agent.go
@@ -137,8 +137,8 @@ Important Rules:
 4. Include the actual listed price, not an estimate or a past realized price.
 5. Mention the dealer/auction house reputation if known.
 6. Flag any concerns about authenticity or condition.
-7. ALWAYS include an imageUrl for every coin suggestion — use the direct image URL (ending in .jpg, .png, etc.) from the listing page. The image is saved as the coin's obverse photo when added to the wishlist. Only omit imageUrl if absolutely no image exists.
-8. For imageUrl, prefer direct image file URLs (e.g., https://example.com/images/coin123.jpg) rather than page URLs. Look at the coin photo's actual src attribute from the listing.
+7. For imageUrl: if you can see a direct image URL (ending in .jpg, .png, etc.) in your search results, include it. If you cannot find a direct image URL — for example because the page uses dynamic/lazy image loading — set imageUrl to an empty string "". The system will automatically extract the image from the listing page. Do NOT skip a coin suggestion just because you cannot find its image URL.
+8. The sourceUrl is the most important link — always provide the direct URL to the listing page. The system uses it to extract images automatically when imageUrl is unavailable.
 
 After searching, provide an enthusiastic but informative response about what you found. Include a JSON block with structured coin suggestions. The JSON block MUST be wrapped in ` + "```json" + ` and ` + "```" + ` markers.
 
@@ -151,7 +151,7 @@ The JSON should be an array of objects with these fields:
 - material: One of "Gold", "Silver", "Bronze", "Copper", "Electrum", or "Other"
 - denomination: Coin denomination (e.g., "Denarius", "Tetradrachm")
 - estPrice: Actual listed price from the listing (e.g., "$150", "$200-300") — NOT a past realized price
-- imageUrl: Direct URL to the coin image file (e.g., .jpg/.png) — required for wishlist integration
+- imageUrl: Direct URL to the coin image file if available, or empty string "" if not found (the system will auto-extract from the listing page)
 - sourceUrl: Direct URL to the actual listing page (required — must be a real link from your search)
 - sourceName: Name of the dealer, auction house, or website
 

--- a/src/api/handlers/images.go
+++ b/src/api/handlers/images.go
@@ -15,6 +15,7 @@ import (
 	"github.com/briandenicola/ancient-coins-api/models"
 	"github.com/briandenicola/ancient-coins-api/services"
 	"github.com/gin-gonic/gin"
+	"golang.org/x/net/html"
 )
 
 type ImageHandler struct {
@@ -363,4 +364,188 @@ func (h *ImageHandler) ProxyImage(c *gin.Context) {
 	c.Header("Content-Type", contentType)
 	c.Status(http.StatusOK)
 	io.Copy(c.Writer, io.LimitReader(resp.Body, maxSize))
+}
+
+// ScrapeImage fetches a web page and extracts the primary image URL from meta tags.
+//
+//	@Summary		Scrape image URL from a web page
+//	@Description	Fetches a web page and extracts image URL from og:image, twitter:image, or other meta tags. Useful as a fallback when direct image URLs are unavailable.
+//	@Tags			Images
+//	@Produce		json
+//	@Param			url	query		string	true	"Web page URL to scrape"
+//	@Success		200	{object}	map[string]string
+//	@Failure		400	{object}	ErrorResponse
+//	@Failure		401	{object}	ErrorResponse
+//	@Failure		502	{object}	ErrorResponse
+//	@Security		BearerAuth
+//	@Router			/scrape-image [get]
+func (h *ImageHandler) ScrapeImage(c *gin.Context) {
+	logger := services.AppLogger
+
+	pageURL := c.Query("url")
+	if pageURL == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "url parameter is required"})
+		return
+	}
+
+	if !strings.HasPrefix(pageURL, "http://") && !strings.HasPrefix(pageURL, "https://") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "URL must start with http:// or https://"})
+		return
+	}
+
+	logger.Debug("images", "Scraping image from page %s", pageURL)
+
+	req, err := http.NewRequest("GET", pageURL, nil)
+	if err != nil {
+		logger.Warn("images", "Failed to build scrape request for %s: %v", pageURL, err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to build request"})
+		return
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Warn("images", "Failed to fetch page %s: %v", pageURL, err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to fetch page"})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		logger.Warn("images", "Scrape page %s returned HTTP %d", pageURL, resp.StatusCode)
+		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("Remote server returned %d", resp.StatusCode)})
+		return
+	}
+
+	// Limit HTML reading to 2MB
+	limitedBody := io.LimitReader(resp.Body, 2*1024*1024)
+	doc, err := html.Parse(limitedBody)
+	if err != nil {
+		logger.Warn("images", "Failed to parse HTML from %s: %v", pageURL, err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to parse page HTML"})
+		return
+	}
+
+	imageURL := extractImageFromHTML(doc)
+	if imageURL == "" {
+		logger.Debug("images", "No image found on page %s", pageURL)
+		c.JSON(http.StatusOK, gin.H{"imageUrl": ""})
+		return
+	}
+
+	// Resolve relative URLs
+	if strings.HasPrefix(imageURL, "//") {
+		imageURL = "https:" + imageURL
+	} else if strings.HasPrefix(imageURL, "/") {
+		// Extract base URL from page URL
+		parts := strings.SplitN(pageURL, "://", 2)
+		if len(parts) == 2 {
+			slashIdx := strings.Index(parts[1], "/")
+			if slashIdx > 0 {
+				imageURL = parts[0] + "://" + parts[1][:slashIdx] + imageURL
+			} else {
+				imageURL = parts[0] + "://" + parts[1] + imageURL
+			}
+		}
+	}
+
+	logger.Debug("images", "Scraped image URL from %s: %s", pageURL, imageURL)
+	c.JSON(http.StatusOK, gin.H{"imageUrl": imageURL})
+}
+
+// extractImageFromHTML walks the HTML tree looking for image URLs in meta tags.
+// Priority: og:image > twitter:image > link[rel=image_src] > first large <img>.
+func extractImageFromHTML(doc *html.Node) string {
+	var ogImage, twitterImage, linkImage, firstImg string
+
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			switch n.Data {
+			case "meta":
+				var property, name, content string
+				for _, a := range n.Attr {
+					switch a.Key {
+					case "property":
+						property = strings.ToLower(a.Val)
+					case "name":
+						name = strings.ToLower(a.Val)
+					case "content":
+						content = a.Val
+					}
+				}
+				if content != "" {
+					if property == "og:image" || property == "og:image:url" {
+						ogImage = content
+					} else if name == "twitter:image" || property == "twitter:image" {
+						twitterImage = content
+					}
+				}
+			case "link":
+				var rel, href string
+				for _, a := range n.Attr {
+					switch a.Key {
+					case "rel":
+						rel = strings.ToLower(a.Val)
+					case "href":
+						href = a.Val
+					}
+				}
+				if rel == "image_src" && href != "" {
+					linkImage = href
+				}
+			case "img":
+				if firstImg == "" {
+					var src string
+					var width, height int
+					for _, a := range n.Attr {
+						switch a.Key {
+						case "src":
+							src = a.Val
+						case "data-src":
+							if src == "" {
+								src = a.Val
+							}
+						case "width":
+							w, _ := strconv.Atoi(a.Val)
+							width = w
+						case "height":
+							h, _ := strconv.Atoi(a.Val)
+							height = h
+						}
+					}
+					// Only use img tags that appear to be content images (not tiny icons)
+					if src != "" && (width >= 100 || height >= 100 || (width == 0 && height == 0)) {
+						lower := strings.ToLower(src)
+						isIcon := strings.Contains(lower, "icon") ||
+							strings.Contains(lower, "logo") ||
+							strings.Contains(lower, "favicon") ||
+							strings.Contains(lower, "sprite") ||
+							strings.Contains(lower, "pixel") ||
+							strings.Contains(lower, "spacer")
+						if !isIcon {
+							firstImg = src
+						}
+					}
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	if ogImage != "" {
+		return ogImage
+	}
+	if twitterImage != "" {
+		return twitterImage
+	}
+	if linkImage != "" {
+		return linkImage
+	}
+	return firstImg
 }

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -144,6 +144,7 @@ func main() {
 		protected.POST("/coins/:id/images/base64", imageHandler.UploadBase64)
 		protected.DELETE("/coins/:id/images/:imageId", imageHandler.Delete)
 		protected.GET("/proxy-image", imageHandler.ProxyImage)
+		protected.GET("/scrape-image", imageHandler.ScrapeImage)
 
 		analysisHandler := handlers.NewAnalysisHandler()
 		protected.POST("/coins/:id/analyze", analysisHandler.Analyze)

--- a/src/web/src/api/client.ts
+++ b/src/web/src/api/client.ts
@@ -271,6 +271,8 @@ export const changePassword = (currentPassword: string, newPassword: string) =>
 export const exportCollection = () => api.get('/user/export', { responseType: 'blob' })
 export const proxyImage = (url: string) =>
   api.get('/proxy-image', { params: { url }, responseType: 'blob' })
+export const scrapeImage = (url: string) =>
+  api.get<{ imageUrl: string }>('/scrape-image', { params: { url } })
 export const importCollection = (coins: Coin[]) => api.post('/user/import', coins)
 
 // API Keys

--- a/src/web/src/components/CoinSearchChat.vue
+++ b/src/web/src/components/CoinSearchChat.vue
@@ -43,8 +43,8 @@
           <!-- Suggestions after assistant message -->
           <div v-if="msg.role === 'assistant' && msg.suggestions?.length" class="suggestions-grid">
             <div v-for="(coin, j) in msg.suggestions" :key="j" class="suggestion-card">
-              <div class="suggestion-img" v-if="coin.imageUrl">
-                <img :src="proxyImageUrl(coin.imageUrl)" :alt="coin.name" @error="handleImgError" />
+              <div class="suggestion-img" v-if="getSuggestionImageUrl(coin)">
+                <img :src="getSuggestionImageUrl(coin)" :alt="coin.name" @error="handleImgError" />
               </div>
               <div class="suggestion-body">
                 <h4>{{ coin.name }}</h4>
@@ -99,7 +99,7 @@
 
 <script setup lang="ts">
 import { ref, nextTick, onMounted, computed } from 'vue'
-import { agentChatStream, createCoin, proxyImage, uploadImage, saveConversation } from '@/api/client'
+import { agentChatStream, createCoin, proxyImage, scrapeImage, uploadImage, saveConversation } from '@/api/client'
 import type { CoinSuggestion, AgentChatMessage, Category, Material } from '@/types'
 import { Bot, X, SendHorizontal, CirclePlus, ExternalLink, Save } from 'lucide-vue-next'
 
@@ -128,6 +128,7 @@ const messagesEl = ref<HTMLElement>()
 const inputEl = ref<HTMLInputElement>()
 const conversationId = ref<number | null>(null)
 const saving = ref(false)
+const scrapedImages = ref<Map<string, string>>(new Map())
 const saveLabel = ref('Save')
 
 const VALID_CATEGORIES = ['Roman', 'Greek', 'Byzantine', 'Modern', 'Other']
@@ -240,7 +241,10 @@ async function addToWishlist(coin: CoinSuggestion, idx: string) {
       currentValue: parsePrice(coin.estPrice),
     })
 
-    // Download and attach coin image as obverse
+    // Try to download and attach coin image as obverse
+    let imageAttached = false
+
+    // First try: use agent-provided imageUrl
     if (coin.imageUrl) {
       try {
         const imgRes = await proxyImage(coin.imageUrl)
@@ -249,9 +253,29 @@ async function addToWishlist(coin: CoinSuggestion, idx: string) {
           const ext = blob.type.includes('png') ? '.png' : '.jpg'
           const file = new File([blob], `obverse${ext}`, { type: blob.type || 'image/jpeg' })
           await uploadImage(created.data.id, file, 'obverse', true)
+          imageAttached = true
         }
       } catch {
-        console.warn('Image download failed for', coin.imageUrl)
+        console.warn('Direct image download failed for', coin.imageUrl)
+      }
+    }
+
+    // Fallback: scrape image from the listing page URL
+    if (!imageAttached && coin.sourceUrl) {
+      try {
+        const scraped = await scrapeImage(coin.sourceUrl)
+        const scrapedUrl = scraped.data.imageUrl
+        if (scrapedUrl) {
+          const imgRes = await proxyImage(scrapedUrl)
+          const blob = imgRes.data as Blob
+          if (blob.size > 0) {
+            const ext = blob.type.includes('png') ? '.png' : '.jpg'
+            const file = new File([blob], `obverse${ext}`, { type: blob.type || 'image/jpeg' })
+            await uploadImage(created.data.id, file, 'obverse', true)
+          }
+        }
+      } catch {
+        console.warn('Image scrape fallback failed for', coin.sourceUrl)
       }
     }
 
@@ -282,6 +306,26 @@ function formatMessage(text: string): string {
 function proxyImageUrl(url: string): string {
   if (!url) return ''
   return `/api/proxy-image?url=${encodeURIComponent(url)}`
+}
+
+function getSuggestionImageUrl(coin: CoinSuggestion): string {
+  if (coin.imageUrl) return proxyImageUrl(coin.imageUrl)
+
+  // If no imageUrl but we have a sourceUrl, try scraping
+  if (coin.sourceUrl) {
+    const cached = scrapedImages.value.get(coin.sourceUrl)
+    if (cached) return proxyImageUrl(cached)
+    if (cached === undefined) {
+      // Mark as loading (empty string = in-progress)
+      scrapedImages.value.set(coin.sourceUrl, '')
+      scrapeImage(coin.sourceUrl).then((res) => {
+        if (res.data.imageUrl) {
+          scrapedImages.value.set(coin.sourceUrl, res.data.imageUrl)
+        }
+      }).catch(() => { /* ignore */ })
+    }
+  }
+  return ''
 }
 
 function handleImgError(e: Event) {


### PR DESCRIPTION
The LLM agent often can't find direct image URLs because dealer sites use dynamic/lazy image loading. This adds a fallback approach:

- New GET /api/scrape-image endpoint: fetches a listing page and extracts image URL from og:image, twitter:image, link[rel=image_src], or first large <img> tag (these work even on JS-heavy sites)
- Frontend addToWishlist: tries agent imageUrl first, falls back to scraping the sourceUrl for an image
- Preview images in chat: auto-scrape sourceUrl when imageUrl is missing
- Agent prompt updated: no longer demands direct image URLs, tells the LLM the system handles image extraction automatically