### PR TITLE
Fix image scraping: always scrape sourceUrl first, agent imageUrl as …

### DIFF
--- a/src/api/handlers/images.go
+++ b/src/api/handlers/images.go
@@ -430,7 +430,7 @@ func (h *ImageHandler) ScrapeImage(c *gin.Context) {
 
 	imageURL := extractImageFromHTML(doc)
 	if imageURL == "" {
-		logger.Debug("images", "No image found on page %s", pageURL)
+		logger.Info("images", "No og:image or meta image found on page %s", pageURL)
 		c.JSON(http.StatusOK, gin.H{"imageUrl": ""})
 		return
 	}
@@ -451,7 +451,7 @@ func (h *ImageHandler) ScrapeImage(c *gin.Context) {
 		}
 	}
 
-	logger.Debug("images", "Scraped image URL from %s: %s", pageURL, imageURL)
+	logger.Info("images", "Scraped image URL from %s: %s", pageURL, imageURL)
 	c.JSON(http.StatusOK, gin.H{"imageUrl": imageURL})
 }
 

--- a/src/web/src/components/CoinSearchChat.vue
+++ b/src/web/src/components/CoinSearchChat.vue
@@ -244,9 +244,36 @@ async function addToWishlist(coin: CoinSuggestion, idx: string) {
     // Try to download and attach coin image as obverse
     let imageAttached = false
 
-    // First try: use agent-provided imageUrl
-    if (coin.imageUrl) {
+    // Primary: scrape og:image from the listing page (most reliable)
+    if (coin.sourceUrl) {
       try {
+        // Check if we already scraped this URL during preview
+        let scrapedUrl = scrapedImages.value.get(coin.sourceUrl) || ''
+        if (!scrapedUrl) {
+          const scraped = await scrapeImage(coin.sourceUrl)
+          scrapedUrl = scraped.data.imageUrl || ''
+        }
+        if (scrapedUrl) {
+          console.log('[agent] Downloading scraped image:', scrapedUrl)
+          const imgRes = await proxyImage(scrapedUrl)
+          const blob = imgRes.data as Blob
+          if (blob.size > 0) {
+            const ext = blob.type.includes('png') ? '.png' : '.jpg'
+            const file = new File([blob], `obverse${ext}`, { type: blob.type || 'image/jpeg' })
+            await uploadImage(created.data.id, file, 'obverse', true)
+            imageAttached = true
+            console.log('[agent] Image attached via scraping')
+          }
+        }
+      } catch (err) {
+        console.warn('[agent] Scrape-based image failed for', coin.sourceUrl, err)
+      }
+    }
+
+    // Fallback: try agent-provided imageUrl directly
+    if (!imageAttached && coin.imageUrl) {
+      try {
+        console.log('[agent] Trying agent imageUrl:', coin.imageUrl)
         const imgRes = await proxyImage(coin.imageUrl)
         const blob = imgRes.data as Blob
         if (blob.size > 0) {
@@ -254,29 +281,15 @@ async function addToWishlist(coin: CoinSuggestion, idx: string) {
           const file = new File([blob], `obverse${ext}`, { type: blob.type || 'image/jpeg' })
           await uploadImage(created.data.id, file, 'obverse', true)
           imageAttached = true
+          console.log('[agent] Image attached via agent imageUrl')
         }
-      } catch {
-        console.warn('Direct image download failed for', coin.imageUrl)
+      } catch (err) {
+        console.warn('[agent] Agent imageUrl download failed:', coin.imageUrl, err)
       }
     }
 
-    // Fallback: scrape image from the listing page URL
-    if (!imageAttached && coin.sourceUrl) {
-      try {
-        const scraped = await scrapeImage(coin.sourceUrl)
-        const scrapedUrl = scraped.data.imageUrl
-        if (scrapedUrl) {
-          const imgRes = await proxyImage(scrapedUrl)
-          const blob = imgRes.data as Blob
-          if (blob.size > 0) {
-            const ext = blob.type.includes('png') ? '.png' : '.jpg'
-            const file = new File([blob], `obverse${ext}`, { type: blob.type || 'image/jpeg' })
-            await uploadImage(created.data.id, file, 'obverse', true)
-          }
-        }
-      } catch {
-        console.warn('Image scrape fallback failed for', coin.sourceUrl)
-      }
+    if (!imageAttached) {
+      console.warn('[agent] No image could be attached for coin:', coin.name)
     }
 
     addedSet.value.add(idx)
@@ -309,27 +322,40 @@ function proxyImageUrl(url: string): string {
 }
 
 function getSuggestionImageUrl(coin: CoinSuggestion): string {
-  if (coin.imageUrl) return proxyImageUrl(coin.imageUrl)
-
-  // If no imageUrl but we have a sourceUrl, try scraping
+  // Always prefer scraped image from sourceUrl (og:image is most reliable)
   if (coin.sourceUrl) {
     const cached = scrapedImages.value.get(coin.sourceUrl)
     if (cached) return proxyImageUrl(cached)
     if (cached === undefined) {
-      // Mark as loading (empty string = in-progress)
       scrapedImages.value.set(coin.sourceUrl, '')
       scrapeImage(coin.sourceUrl).then((res) => {
         if (res.data.imageUrl) {
+          console.log('[agent] Scraped image from', coin.sourceUrl, '→', res.data.imageUrl)
           scrapedImages.value.set(coin.sourceUrl, res.data.imageUrl)
+        } else if (coin.imageUrl) {
+          // Scrape returned nothing — fall back to agent-provided URL
+          console.log('[agent] Scrape empty, using agent imageUrl:', coin.imageUrl)
+          scrapedImages.value.set(coin.sourceUrl, coin.imageUrl)
         }
-      }).catch(() => { /* ignore */ })
+      }).catch(() => {
+        // Scrape failed — fall back to agent-provided URL
+        if (coin.imageUrl) {
+          console.log('[agent] Scrape failed, using agent imageUrl:', coin.imageUrl)
+          scrapedImages.value.set(coin.sourceUrl, coin.imageUrl)
+        }
+      })
     }
+    return ''
   }
+
+  // No sourceUrl — try agent imageUrl directly
+  if (coin.imageUrl) return proxyImageUrl(coin.imageUrl)
   return ''
 }
 
 function handleImgError(e: Event) {
   const img = e.target as HTMLImageElement
+  console.warn('[agent] Image failed to load:', img.src)
   img.style.display = 'none'
 }
 


### PR DESCRIPTION
…fallback

The previous approach only triggered scraping when the agent's imageUrl was empty. In practice, the LLM still provides imageUrl values (broken page URLs or CDN links requiring auth), so the scraping code was never reached.

Changes:
- Preview images: always scrape og:image from sourceUrl as primary approach; fall back to agent imageUrl only if scraping returns nothing
- Add to wishlist: same priority — scrape first, agent URL second
- Reuse cached scraped URLs to avoid duplicate requests
- Add console.log statements for debugging the full image flow
- Upgrade server-side scrape logging to Info level