### PR TITLE
Always show View Collection link on Following tab

### DIFF
--- a/src/web/src/pages/FollowersPage.vue
+++ b/src/web/src/pages/FollowersPage.vue
@@ -72,7 +72,6 @@
             </div>
             <div class="user-card-actions">
               <router-link
-                v-if="user.isPublic"
                 :to="`/followers/${user.username}/gallery`"
                 class="btn btn-secondary btn-sm"
               >


### PR DESCRIPTION
Accepted followers should always have gallery access regardless of the user's isPublic flag (backend already enforces via accepted follow status).