### PR TITLE
Add pull-to-refresh on all pages in PWA mode

### DIFF
--- a/src/web/src/components/PullToRefresh.vue
+++ b/src/web/src/components/PullToRefresh.vue
@@ -1,0 +1,71 @@
+<template>
+  <div ref="pullContainer" :style="pullDistance > 0 ? `transform: translateY(${pullDistance}px); transition: none` : ''">
+    <div
+      class="pull-indicator"
+      :class="{ visible: pullDistance > 0 || refreshing, refreshing }"
+      :style="`top: ${-50 + pullDistance * 0.6}px; opacity: ${Math.min(pullDistance / 60, 1)}`"
+    >
+      <div class="pull-spinner" :style="refreshing ? '' : `transform: rotate(${pullDistance * 3}deg)`"></div>
+      <span class="pull-text">{{ refreshing ? 'Refreshing...' : pullDistance >= 60 ? 'Release to refresh' : 'Pull to refresh' }}</span>
+    </div>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { usePullToRefresh } from '@/composables/usePullToRefresh'
+
+const props = defineProps<{
+  onRefresh: () => Promise<void>
+}>()
+
+const pullContainer = ref<HTMLElement | null>(null)
+const { pullDistance, refreshing } = usePullToRefresh(pullContainer, props.onRefresh)
+</script>
+
+<style scoped>
+.pull-indicator {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-full);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+  z-index: 100;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.pull-indicator.visible {
+  pointer-events: auto;
+}
+
+.pull-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--border-subtle);
+  border-top-color: var(--accent-gold);
+  border-radius: 50%;
+}
+
+.pull-indicator.refreshing .pull-spinner {
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.pull-text {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+</style>

--- a/src/web/src/pages/FollowersPage.vue
+++ b/src/web/src/pages/FollowersPage.vue
@@ -1,4 +1,5 @@
 <template>
+  <PullToRefresh :on-refresh="handleRefresh">
   <div class="container">
     <div class="page-header">
       <h1><Users :size="24" /> Followers</h1>
@@ -230,11 +231,13 @@
       </div>
     </Teleport>
   </div>
+  </PullToRefresh>
 </template>
 
 <script setup lang="ts">
 import { ref, watch, nextTick, onMounted } from 'vue'
 import { Users, UserPlus, Search, X, Eye, Check, ShieldOff } from 'lucide-vue-next'
+import PullToRefresh from '@/components/PullToRefresh.vue'
 import {
   getFollowers, getFollowing, searchUsers, followUser, unfollowUser,
   acceptFollower, blockFollower, unblockFollower, getBlockedUsers,
@@ -378,6 +381,10 @@ watch(showSearchModal, (open) => {
     nextTick(() => searchInputRef.value?.focus())
   }
 })
+
+async function handleRefresh() {
+  await loadData()
+}
 
 onMounted(() => {
   loadData()

--- a/src/web/src/pages/SettingsPage.vue
+++ b/src/web/src/pages/SettingsPage.vue
@@ -1,4 +1,5 @@
 <template>
+  <PullToRefresh :on-refresh="handleRefresh">
   <div class="container">
     <div class="page-header">
       <h1>Settings</h1>
@@ -637,12 +638,14 @@
       />
     </div>
   </div>
+  </PullToRefresh>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted, type Component } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import PullToRefresh from '@/components/PullToRefresh.vue'
 import {
   changePassword, exportCollection, importCollection,
   generateApiKey, listApiKeys, revokeApiKey,
@@ -1086,6 +1089,14 @@ async function handleDeleteConversation(id: number) {
   } catch {
     alert('Failed to delete conversation')
   }
+}
+
+async function handleRefresh() {
+  await Promise.all([
+    loadApiKeys(),
+    loadConversations(),
+    supportsWebAuthn ? loadCredentials() : Promise.resolve(),
+  ])
 }
 
 onMounted(() => {

--- a/src/web/src/pages/SoldPage.vue
+++ b/src/web/src/pages/SoldPage.vue
@@ -1,4 +1,5 @@
 <template>
+  <PullToRefresh :on-refresh="handleRefresh">
   <div class="container">
     <div class="page-header">
       <h1>Sold Coins</h1>
@@ -17,13 +18,19 @@
       <p>When you sell coins from your collection, they'll appear here with their sale history.</p>
     </div>
   </div>
+  </PullToRefresh>
 </template>
 
 <script setup lang="ts">
 import { useCoinsStore } from '@/stores/coins'
 import CoinCard from '@/components/CoinCard.vue'
+import PullToRefresh from '@/components/PullToRefresh.vue'
 
 const store = useCoinsStore()
 
 store.fetchCoins({ sold: 'true', sort: 'updated_at', order: 'desc' })
+
+async function handleRefresh() {
+  await store.fetchCoins({ sold: 'true', sort: 'updated_at', order: 'desc' })
+}
 </script>

--- a/src/web/src/pages/StatsPage.vue
+++ b/src/web/src/pages/StatsPage.vue
@@ -1,4 +1,5 @@
 <template>
+  <PullToRefresh :on-refresh="handleRefresh">
   <div class="container">
     <div class="page-header">
       <h1>Collection Stats</h1>
@@ -204,11 +205,13 @@
       </div>
     </div>
   </div>
+  </PullToRefresh>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
 import { useCoinsStore } from '@/stores/coins'
+import PullToRefresh from '@/components/PullToRefresh.vue'
 
 const store = useCoinsStore()
 const stats = computed(() => store.stats)
@@ -285,6 +288,10 @@ function formatCurrency(value: number) {
 
 function formatShortDate(dateStr: string) {
   return new Date(dateStr).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: '2-digit' })
+}
+
+async function handleRefresh() {
+  await Promise.all([store.fetchStats(), store.fetchValueHistory()])
 }
 
 onMounted(() => {

--- a/src/web/src/pages/TimelinePage.vue
+++ b/src/web/src/pages/TimelinePage.vue
@@ -1,4 +1,5 @@
 <template>
+  <PullToRefresh :on-refresh="loadCoins">
   <div class="container">
     <div class="page-header">
       <h1><Clock :size="24" /> Collection Timeline</h1>
@@ -88,6 +89,7 @@
       </div>
     </div>
   </div>
+  </PullToRefresh>
 </template>
 
 <script setup lang="ts">
@@ -96,6 +98,7 @@ import { Clock, Image as ImageIcon } from 'lucide-vue-next'
 import { getCoins } from '@/api/client'
 import type { Coin } from '@/types'
 import { CATEGORY_COLORS } from '@/types'
+import PullToRefresh from '@/components/PullToRefresh.vue'
 
 const loading = ref(true)
 const allCoins = ref<Coin[]>([])


### PR DESCRIPTION
Created reusable PullToRefresh component wrapping the existing usePullToRefresh composable with the standard pull indicator UI.

Added to: Sold, Stats, Followers, Settings, Timeline pages. (Collection/Gallery already had pull-to-refresh built in.)