### PR TITLE
Fix double-recording on apply estimate, add manual value journal entry

### DIFF
--- a/src/api/handlers/coins.go
+++ b/src/api/handlers/coins.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -243,7 +244,7 @@ func (h *CoinHandler) Update(c *gin.Context) {
 		return
 	}
 
-	// Track manual value changes
+	// Track value changes — skip if applied from AI estimate (already recorded)
 	if updates.CurrentValue != nil {
 		newVal := *updates.CurrentValue
 		oldVal := 0.0
@@ -251,13 +252,21 @@ func (h *CoinHandler) Update(c *gin.Context) {
 			oldVal = *oldValue
 		}
 		if newVal != oldVal {
-			database.DB.Create(&models.CoinValueHistory{
-				CoinID:     existing.ID,
-				UserID:     userID,
-				Value:      newVal,
-				Confidence: "manual",
-				RecordedAt: time.Now(),
-			})
+			source := c.Query("source")
+			if source != "estimate" {
+				database.DB.Create(&models.CoinValueHistory{
+					CoinID:     existing.ID,
+					UserID:     userID,
+					Value:      newVal,
+					Confidence: "manual",
+					RecordedAt: time.Now(),
+				})
+				database.DB.Create(&models.CoinJournal{
+					CoinID: existing.ID,
+					UserID: userID,
+					Entry:  fmt.Sprintf("Current value updated manually: $%.2f", newVal),
+				})
+			}
 		}
 	}
 

--- a/src/web/src/api/client.ts
+++ b/src/web/src/api/client.ts
@@ -121,7 +121,8 @@ function sanitizeCoin(coin: Partial<Coin>): Partial<Coin> {
 
 export const getCoin = (id: number) => api.get<Coin>(`/coins/${id}`)
 export const createCoin = (coin: Partial<Coin>) => api.post<Coin>('/coins', sanitizeCoin(coin))
-export const updateCoin = (id: number, coin: Partial<Coin>) => api.put<Coin>(`/coins/${id}`, sanitizeCoin(coin))
+export const updateCoin = (id: number, coin: Partial<Coin>, params?: Record<string, string>) =>
+  api.put<Coin>(`/coins/${id}`, sanitizeCoin(coin), { params })
 export const purchaseCoin = (id: number) => api.post<Coin>(`/coins/${id}/purchase`)
 export const sellCoin = (id: number, soldPrice: number | null, soldTo: string) =>
   api.post<Coin>(`/coins/${id}/sell`, { soldPrice, soldTo })

--- a/src/web/src/pages/CoinDetailPage.vue
+++ b/src/web/src/pages/CoinDetailPage.vue
@@ -137,25 +137,6 @@
               Purchased {{ new Date(coin.purchaseDate).toLocaleDateString() }}
               <span v-if="coin.purchaseLocation"> from {{ coin.purchaseLocation }}</span>
             </div>
-            <div v-if="coinValueHistory.length" class="value-history-list">
-              <h4>Value History</h4>
-              <div
-                v-for="entry in visibleValueHistory"
-                :key="entry.id"
-                class="value-history-entry"
-              >
-                <span class="vh-date">{{ formatJournalDate(entry.recordedAt) }}</span>
-                <span class="vh-value">{{ formatCurrency(entry.value) }}</span>
-                <span :class="['confidence-badge', `confidence-${entry.confidence}`]">{{ entry.confidence }}</span>
-              </div>
-              <button
-                v-if="coinValueHistory.length > 5"
-                class="btn btn-ghost btn-xs"
-                @click="showAllValueHistory = !showAllValueHistory"
-              >
-                {{ showAllValueHistory ? 'Show less' : `Show all (${coinValueHistory.length})` }}
-              </button>
-            </div>
           </div>
 
           <div class="estimate-section">
@@ -374,14 +355,6 @@ const estimating = ref(false)
 const valueEstimate = ref<ValueEstimate | null>(null)
 const estimateError = ref('')
 const coinValueHistory = ref<CoinValueHistoryType[]>([])
-const showAllValueHistory = ref(false)
-
-const visibleValueHistory = computed(() => {
-  const sorted = [...coinValueHistory.value].sort((a, b) =>
-    new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime()
-  )
-  return showAllValueHistory.value ? sorted : sorted.slice(0, 5)
-})
 
 const md = new MarkdownIt({ html: false })
 
@@ -640,9 +613,8 @@ async function handleEstimateValue() {
 async function applyEstimate() {
   if (!coin.value || !valueEstimate.value) return
   try {
-    await updateCoin(coin.value.id, { currentValue: valueEstimate.value.estimatedValue })
+    await updateCoin(coin.value.id, { currentValue: valueEstimate.value.estimatedValue }, { source: 'estimate' })
     await store.fetchCoin(coin.value.id)
-    loadValueHistory(coin.value.id)
     valueEstimate.value = null
   } catch {
     alert('Failed to update coin value')
@@ -794,44 +766,6 @@ function formatCurrency(value: number) {
   margin-top: 0.5rem;
   font-size: 0.8rem;
   color: var(--text-muted);
-}
-
-.value-history-list {
-  margin-top: 0.75rem;
-  border-top: 1px solid var(--border-subtle);
-  padding-top: 0.75rem;
-}
-
-.value-history-list h4 {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  margin: 0 0 0.5rem;
-}
-
-.value-history-entry {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border-subtle);
-  font-size: 0.85rem;
-}
-
-.value-history-entry:last-of-type {
-  border-bottom: none;
-}
-
-.vh-date {
-  color: var(--text-muted);
-  min-width: 140px;
-}
-
-.vh-value {
-  font-weight: 600;
-  color: var(--text-primary);
-  flex: 1;
 }
 
 .notes-section p {


### PR DESCRIPTION
- Skip value history + journal recording in Update handler when source=estimate (AI estimate already recorded both in EstimateValue handler)
- Add journal entry on manual currentValue changes: 'Current value updated manually: \'
- Remove value history display from CoinDetailPage (journal covers it)
- Clean up unused visibleValueHistory computed, showAllValueHistory ref, and CSS