### PR TITLE
feat: add explicit AI provider selection with connectivity tests

### DIFF
--- a/src/api/handlers/admin.go
+++ b/src/api/handlers/admin.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -279,6 +280,69 @@ func mergeLogsByTimestamp(a, b []services.LogEntry) []services.LogEntry {
 	merged = append(merged, a[i:]...)
 	merged = append(merged, b[j:]...)
 	return merged
+}
+
+// TestAnthropicConnection validates the Anthropic API key by listing models.
+func (h *AdminHandler) TestAnthropicConnection(c *gin.Context) {
+	apiKey := services.GetSetting(services.SettingAnthropicAPIKey)
+	if apiKey == "" {
+		c.JSON(http.StatusOK, gin.H{"available": false, "message": "Anthropic API key is not configured"})
+		return
+	}
+
+	req, err := http.NewRequestWithContext(c.Request.Context(), "GET", "https://api.anthropic.com/v1/models", nil)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"available": false, "message": "Failed to create request"})
+		return
+	}
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"available": false, "message": fmt.Sprintf("Connection failed: %s", err.Error())})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		c.JSON(http.StatusOK, gin.H{"available": true, "message": "Anthropic API key is valid"})
+	} else {
+		body, _ := io.ReadAll(resp.Body)
+		msg := string(body)
+		if len(msg) > 200 {
+			msg = msg[:200]
+		}
+		c.JSON(http.StatusOK, gin.H{"available": false, "message": fmt.Sprintf("API returned HTTP %d: %s", resp.StatusCode, msg)})
+	}
+}
+
+// TestSearXNGConnection validates the SearXNG endpoint is reachable.
+func (h *AdminHandler) TestSearXNGConnection(c *gin.Context) {
+	searxngURL := services.GetSetting(services.SettingSearXNGURL)
+	if searxngURL == "" {
+		c.JSON(http.StatusOK, gin.H{"available": false, "message": "SearXNG URL is not configured"})
+		return
+	}
+
+	req, err := http.NewRequestWithContext(c.Request.Context(), "GET", searxngURL, nil)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"available": false, "message": "Invalid URL"})
+		return
+	}
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"available": false, "message": fmt.Sprintf("Connection failed: %s", err.Error())})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+		c.JSON(http.StatusOK, gin.H{"available": true, "message": fmt.Sprintf("SearXNG is reachable at %s", searxngURL)})
+	} else {
+		c.JSON(http.StatusOK, gin.H{"available": false, "message": fmt.Sprintf("SearXNG returned HTTP %d", resp.StatusCode)})
+	}
 }
 
 // ExportAllData exports all coins and images as a zip archive

--- a/src/api/handlers/agent.go
+++ b/src/api/handlers/agent.go
@@ -28,6 +28,43 @@ func NewAgentHandler(repo *repository.AgentRepository, userRepo *repository.User
 	}
 }
 
+// resolveLLMConfig reads the explicit AIProvider setting and builds LLMConfig.
+// Returns an error message if the provider is not configured.
+func resolveLLMConfig() (services.LLMConfig, string) {
+	provider := services.GetSetting(services.SettingAIProvider)
+	if provider == "" {
+		return services.LLMConfig{}, "AI provider not configured. Please select Anthropic or Ollama in Admin Settings."
+	}
+
+	cfg := services.LLMConfig{
+		Provider:   provider,
+		OllamaURL:  services.GetSetting(services.SettingOllamaURL),
+		SearXNGURL: services.GetSetting(services.SettingSearXNGURL),
+	}
+
+	switch provider {
+	case "anthropic":
+		cfg.APIKey = services.GetSetting(services.SettingAnthropicAPIKey)
+		cfg.Model = services.GetSetting(services.SettingAnthropicModel)
+		if cfg.APIKey == "" {
+			return services.LLMConfig{}, "Anthropic API key is required. Configure it in Admin Settings."
+		}
+	case "ollama":
+		cfg.Model = services.GetSetting(services.SettingOllamaModel)
+		if cfg.OllamaURL == "" {
+			return services.LLMConfig{}, "Ollama URL is required. Configure it in Admin Settings."
+		}
+	default:
+		return services.LLMConfig{}, "Invalid AI provider. Please select Anthropic or Ollama in Admin Settings."
+	}
+
+	if cfg.Model == "" {
+		cfg.Model = "claude-sonnet-4-20250514"
+	}
+
+	return cfg, ""
+}
+
 // Chat request/response types
 
 type AgentChatRequest struct {
@@ -196,21 +233,11 @@ func (h *AgentHandler) ChatStream(c *gin.Context) {
 		return
 	}
 
-	// Determine LLM provider based on available settings
-	provider := "anthropic"
-	apiKey := services.GetSetting(services.SettingAnthropicAPIKey)
-	model := services.GetSetting(services.SettingAnthropicModel)
-	ollamaURL := services.GetSetting(services.SettingOllamaURL)
-	ollamaModel := services.GetSetting(services.SettingOllamaModel)
-	searxngURL := services.GetSetting(services.SettingSearXNGURL)
-
-	if apiKey == "" && ollamaURL != "" {
-		provider = "ollama"
-		model = ollamaModel
-	}
-
-	if model == "" {
-		model = "claude-sonnet-4-20250514"
+	// Resolve LLM provider from explicit setting
+	llmCfg, errMsg := resolveLLMConfig()
+	if errMsg != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errMsg})
+		return
 	}
 
 	// Build history for the proxy
@@ -229,13 +256,7 @@ func (h *AgentHandler) ChatStream(c *gin.Context) {
 	}
 
 	proxyReq := services.AgentChatProxyRequest{
-		LLM: services.LLMConfig{
-			Provider:   provider,
-			APIKey:     apiKey,
-			Model:      model,
-			OllamaURL:  ollamaURL,
-			SearXNGURL: searxngURL,
-		},
+		LLM: llmCfg,
 		User: services.UserContextProxy{
 			UserID:  userID,
 			ZipCode: zipCode,
@@ -252,6 +273,17 @@ func (h *AgentHandler) ChatStream(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Agent service unavailable"})
 		}
 	}
+}
+
+// AgentStatus returns the current AI provider configuration status.
+func (h *AgentHandler) AgentStatus(c *gin.Context) {
+	provider := services.GetSetting(services.SettingAIProvider)
+	configured := provider == "anthropic" || provider == "ollama"
+
+	c.JSON(http.StatusOK, gin.H{
+		"provider":   provider,
+		"configured": configured,
+	})
 }
 
 // ListModels returns the list of available Anthropic models.
@@ -451,20 +483,11 @@ func (h *AgentHandler) EstimateValue(c *gin.Context) {
 		return
 	}
 
-	// Determine LLM provider based on available settings
-	provider := "anthropic"
-	apiKey := services.GetSetting(services.SettingAnthropicAPIKey)
-	model := services.GetSetting(services.SettingAnthropicModel)
-	ollamaURL := services.GetSetting(services.SettingOllamaURL)
-	ollamaModel := services.GetSetting(services.SettingOllamaModel)
-
-	if apiKey == "" && ollamaURL != "" {
-		provider = "ollama"
-		model = ollamaModel
-	}
-
-	if model == "" {
-		model = "claude-sonnet-4-20250514"
+	// Resolve LLM provider from explicit setting
+	llmCfg, errMsg := resolveLLMConfig()
+	if errMsg != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errMsg})
+		return
 	}
 
 	var zipCode string
@@ -514,13 +537,7 @@ func (h *AgentHandler) EstimateValue(c *gin.Context) {
 	userMessage := fmt.Sprintf("Please estimate the current market value of this coin:\n\n%s", strings.Join(parts, "\n"))
 
 	proxyReq := services.PortfolioReviewProxyRequest{
-		LLM: services.LLMConfig{
-			Provider:   provider,
-			APIKey:     apiKey,
-			Model:      model,
-			OllamaURL:  ollamaURL,
-			SearXNGURL: services.GetSetting(services.SettingSearXNGURL),
-		},
+		LLM: llmCfg,
 		User: services.UserContextProxy{
 			UserID:  userID,
 			ZipCode: zipCode,

--- a/src/api/handlers/analysis.go
+++ b/src/api/handlers/analysis.go
@@ -114,18 +114,11 @@ func (h *AnalysisHandler) Analyze(c *gin.Context) {
 		return
 	}
 
-	// Determine LLM provider
-	provider := "ollama"
-	apiKey := services.GetSetting(services.SettingAnthropicAPIKey)
-	model := services.GetSetting(services.SettingOllamaModel)
-	ollamaURL := services.GetSetting(services.SettingOllamaURL)
-
-	if apiKey != "" {
-		provider = "anthropic"
-		model = services.GetSetting(services.SettingAnthropicModel)
-		if model == "" {
-			model = "claude-sonnet-4-20250514"
-		}
+	// Resolve LLM provider from explicit setting
+	llmCfg, errMsg := resolveLLMConfig()
+	if errMsg != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errMsg})
+		return
 	}
 
 	var purchasePrice, currentValue float64
@@ -137,12 +130,7 @@ func (h *AnalysisHandler) Analyze(c *gin.Context) {
 	}
 
 	proxyReq := services.AnalyzeProxyRequest{
-		LLM: services.LLMConfig{
-			Provider:  provider,
-			APIKey:    apiKey,
-			Model:     model,
-			OllamaURL: ollamaURL,
-		},
+		LLM: llmCfg,
 		Coin: services.CoinDataProxy{
 			ID:            int(coin.ID),
 			Name:          coin.Name,

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -191,6 +191,7 @@ func main() {
 		protected.GET("/agent/prompt", agentHandler.GetPrompt)
 		protected.GET("/agent/valuation-prompt", agentHandler.GetValuationPrompt)
 		protected.GET("/agent/portfolio-summary", agentHandler.PortfolioSummary)
+		protected.GET("/agent/status", agentHandler.AgentStatus)
 
 		conversationRepo := repository.NewConversationRepository(database.DB)
 		convHandler := handlers.NewConversationHandler(conversationRepo)
@@ -259,6 +260,8 @@ func main() {
 		admin.GET("/settings/defaults", adminHandler.GetSettingDefaults)
 		admin.PUT("/settings", adminHandler.UpdateSettings)
 		admin.GET("/logs", adminHandler.GetLogs)
+		admin.GET("/test-anthropic", adminHandler.TestAnthropicConnection)
+		admin.GET("/test-searxng", adminHandler.TestSearXNGConnection)
 	}
 
 	log.Printf("Starting server on :%s", cfg.Port)

--- a/src/api/services/settings_service.go
+++ b/src/api/services/settings_service.go
@@ -6,6 +6,7 @@ import (
 )
 
 const (
+	SettingAIProvider           = "AIProvider"
 	SettingOllamaURL            = "OllamaURL"
 	SettingOllamaModel          = "OllamaModel"
 	SettingObversePrompt        = "ObversePrompt"
@@ -44,6 +45,7 @@ Include store name, coin description, price, grade, reference numbers, dates, an
 Return ONLY the extracted text, no commentary.`
 
 var settingDefaults = map[string]string{
+	SettingAIProvider:           "",
 	SettingOllamaURL:            "http://localhost:11434",
 	SettingOllamaModel:          "llava",
 	SettingObversePrompt:        DefaultObversePrompt,
@@ -56,6 +58,7 @@ var settingDefaults = map[string]string{
 	SettingAnthropicModel:      "claude-sonnet-4-20250514",
 	SettingAgentPrompt:         "",
 	SettingValuationPrompt:     "",
+	SettingSearXNGURL:          "",
 }
 
 var settingsDB *gorm.DB
@@ -74,8 +77,9 @@ func GetSetting(key string) string {
 		}
 		return ""
 	}
-	// Treat empty prompt settings as unset so the default is used
-	if setting.Value == "" {
+	// Treat empty prompt settings as unset so the default is used.
+	// AIProvider intentionally allows empty (means unconfigured).
+	if setting.Value == "" && key != SettingAIProvider {
 		if def, ok := settingDefaults[key]; ok {
 			return def
 		}

--- a/src/web/src/api/client.ts
+++ b/src/web/src/api/client.ts
@@ -311,6 +311,16 @@ export const getAdminLogs = (limit = 500, level?: string) => {
   return api.get<{ logs: LogEntry[]; count: number; logLevel: string }>('/admin/logs', { params })
 }
 
+type ConnectivityResult = { available: boolean; message: string }
+export const testAnthropicConnection = () =>
+  api.get<ConnectivityResult>('/admin/test-anthropic')
+export const testSearXNGConnection = () =>
+  api.get<ConnectivityResult>('/admin/test-searxng')
+
+// Agent status
+export const getAgentStatus = () =>
+  api.get<{ provider: string; configured: boolean }>('/agent/status')
+
 // WebAuthn
 export const webauthnRegisterBegin = () =>
   api.post('/auth/webauthn/register/begin')

--- a/src/web/src/components/CoinSearchChat.vue
+++ b/src/web/src/components/CoinSearchChat.vue
@@ -18,6 +18,12 @@
         </div>
       </div>
 
+      <!-- Unconfigured provider banner -->
+      <div v-if="!providerConfigured" class="provider-banner">
+        <AlertTriangle :size="16" />
+        <span>AI provider not configured. <a href="/admin" @click="$emit('close')">Go to Admin Settings</a> to select Anthropic or Ollama.</span>
+      </div>
+
       <div class="chat-messages" ref="messagesEl">
         <div v-if="messages.length === 0" class="chat-intro">
           <Bot :size="32" />
@@ -91,11 +97,11 @@
         <input
           v-model="input"
           class="chat-input"
-          placeholder="Describe the coins you're looking for..."
-          :disabled="loading"
+          :placeholder="providerConfigured ? 'Describe the coins you\'re looking for...' : 'Configure AI provider in Admin Settings'"
+          :disabled="loading || !providerConfigured"
           ref="inputEl"
         />
-        <button type="submit" class="send-btn" :disabled="!input.trim() || loading">
+        <button type="submit" class="send-btn" :disabled="!input.trim() || loading || !providerConfigured">
           <SendHorizontal :size="18" />
         </button>
       </form>
@@ -105,9 +111,9 @@
 
 <script setup lang="ts">
 import { ref, nextTick, onMounted, onBeforeUnmount, computed } from 'vue'
-import { agentChatStream, createCoin, proxyImage, scrapeImage, uploadImage, saveConversation, getPortfolioSummary } from '@/api/client'
+import { agentChatStream, createCoin, proxyImage, scrapeImage, uploadImage, saveConversation, getPortfolioSummary, getAgentStatus } from '@/api/client'
 import type { CoinSuggestion, AgentChatMessage, Category, Material } from '@/types'
-import { Bot, X, SendHorizontal, CirclePlus, ExternalLink, Save } from 'lucide-vue-next'
+import { Bot, X, SendHorizontal, CirclePlus, ExternalLink, Save, AlertTriangle } from 'lucide-vue-next'
 import DOMPurify from 'dompurify'
 
 interface ChatMsg {
@@ -137,6 +143,7 @@ const conversationId = ref<number | null>(null)
 const saving = ref(false)
 const scrapedImages = ref<Map<string, string>>(new Map())
 const saveLabel = ref('Save')
+const providerConfigured = ref(true)  // assume configured until checked
 
 const VALID_CATEGORIES = ['Roman', 'Greek', 'Byzantine', 'Modern', 'Other']
 const VALID_MATERIALS = ['Gold', 'Silver', 'Bronze', 'Copper', 'Electrum', 'Other']
@@ -388,7 +395,7 @@ function handleImgError(e: Event) {
   img.style.display = 'none'
 }
 
-onMounted(() => {
+onMounted(async () => {
   inputEl.value?.focus()
   if (props.loadConversation) {
     conversationId.value = props.loadConversation.id
@@ -396,6 +403,13 @@ onMounted(() => {
       messages.value = JSON.parse(props.loadConversation.messages)
       scrollToBottom()
     } catch { /* ignore parse errors */ }
+  }
+  // Check if AI provider is configured
+  try {
+    const res = await getAgentStatus()
+    providerConfigured.value = res.data.configured
+  } catch {
+    providerConfigured.value = true // don't block on network error
   }
   // Handle iOS keyboard resizing the visual viewport
   if (window.visualViewport) {
@@ -464,6 +478,24 @@ function handleViewportResize() {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.provider-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: rgba(231, 176, 60, 0.1);
+  border-bottom: 1px solid rgba(231, 176, 60, 0.3);
+  color: #e7b03c;
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
+.provider-banner a {
+  color: var(--accent-gold, #d4a843);
+  text-decoration: underline;
+  font-weight: 600;
 }
 
 .chat-save {

--- a/src/web/src/pages/AdminPage.vue
+++ b/src/web/src/pages/AdminPage.vue
@@ -62,138 +62,192 @@
         </table>
       </section>
 
-      <!-- Ollama / AI Tab -->
+      <!-- AI Tab -->
       <section v-if="activeTab === 'ai'" class="admin-section card">
         <h2>AI Configuration</h2>
         <form @submit.prevent="saveSettings">
+          <!-- Provider Selection -->
           <div class="form-group">
-            <label class="form-label">Ollama URL</label>
-            <input v-model="settings.OllamaURL" class="form-input" placeholder="http://localhost:11434" />
-          </div>
-          <div class="form-group">
-            <label class="form-label">Vision Model</label>
-            <input v-model="settings.OllamaModel" class="form-input" placeholder="llava" />
-            <span class="form-hint">e.g. llava, llama3.2-vision, bakllava</span>
-          </div>
-          <div class="form-group">
-            <label class="form-label">Request Timeout (seconds)</label>
-            <input v-model="settings.OllamaTimeout" class="form-input" type="number" min="10" max="1800" step="10" />
-            <span class="form-hint">Time limit for AI analysis calls. Default: 300 (5 minutes)</span>
-          </div>
-          <div class="form-group">
-            <label class="form-label">SearXNG URL</label>
-            <input v-model="settings.SearXNGURL" class="form-input" placeholder="http://localhost:8888" />
-            <span class="form-hint">Web search engine for Ollama mode. Only needed when using Ollama as the LLM provider.</span>
-          </div>
-          <div class="form-group">
-            <label class="form-label">Anthropic API Key</label>
-            <input v-model="settings.AnthropicAPIKey" class="form-input" type="password" placeholder="Enter your Anthropic API key" />
-            <span class="form-hint">Required for the AI coin search agent. Get a key at <a href="https://console.anthropic.com/" target="_blank" rel="noopener">console.anthropic.com</a></span>
-          </div>
-          <div class="form-group">
-            <label class="form-label">Anthropic Model</label>
-            <select v-model="settings.AnthropicModel" class="form-input">
-              <option v-for="m in anthropicModels" :key="m.id" :value="m.id">{{ m.name }}</option>
-            </select>
-            <span class="form-hint">Model used for the coin search agent</span>
-          </div>
-          <div class="form-group">
-            <div class="prompt-header">
-              <label class="form-label">Agent Search Prompt</label>
-              <button
-                type="button"
-                class="btn btn-ghost btn-xs"
-                :disabled="settings.AgentPrompt === agentPromptDefault"
-                @click="settings.AgentPrompt = agentPromptDefault"
-              >Revert to Default</button>
+            <label class="form-label">AI Provider</label>
+            <div class="provider-toggle">
+              <label class="provider-option" :class="{ active: settings.AIProvider === 'anthropic' }">
+                <input type="radio" v-model="settings.AIProvider" value="anthropic" />
+                <span class="provider-label">Anthropic (Recommended)</span>
+                <span class="provider-desc">Claude models with built-in web search</span>
+              </label>
+              <label class="provider-option" :class="{ active: settings.AIProvider === 'ollama' }">
+                <input type="radio" v-model="settings.AIProvider" value="ollama" />
+                <span class="provider-label">Ollama</span>
+                <span class="provider-desc">Self-hosted models. Requires SearXNG for web search.</span>
+              </label>
             </div>
-            <textarea
-              v-model="settings.AgentPrompt"
-              class="form-textarea"
-              rows="8"
-            />
-            <span class="form-hint">System prompt for the AI coin search agent. Controls how it searches and formats results.</span>
+            <p v-if="!settings.AIProvider" class="provider-warning">
+              Please select an AI provider to enable agent features.
+            </p>
           </div>
-          <div class="form-group">
-            <div class="prompt-header">
-              <label class="form-label">Value Estimator Prompt</label>
-              <button
-                type="button"
-                class="btn btn-ghost btn-xs"
-                :disabled="settings.ValuationPrompt === valuationPromptDefault"
-                @click="settings.ValuationPrompt = valuationPromptDefault"
-              >Revert to Default</button>
+
+          <!-- Anthropic Settings -->
+          <template v-if="settings.AIProvider === 'anthropic'">
+            <div class="form-group">
+              <label class="form-label">Anthropic API Key</label>
+              <input v-model="settings.AnthropicAPIKey" class="form-input" type="password" placeholder="Enter your Anthropic API key" />
+              <span class="form-hint">Get a key at <a href="https://console.anthropic.com/" target="_blank" rel="noopener">console.anthropic.com</a></span>
             </div>
-            <textarea
-              v-model="settings.ValuationPrompt"
-              class="form-textarea"
-              rows="8"
-            />
-            <span class="form-hint">System prompt for the AI value estimator. Controls how it researches and estimates coin values.</span>
-          </div>
-          <div class="form-group">
-            <div class="prompt-header">
-              <label class="form-label">Obverse Analysis Prompt</label>
-              <button
-                type="button"
-                class="btn btn-ghost btn-xs"
-                :disabled="settings.ObversePrompt === settingDefaults.ObversePrompt"
-                @click="settings.ObversePrompt = settingDefaults.ObversePrompt"
-              >Revert to Default</button>
+            <div class="form-group">
+              <label class="form-label">Anthropic Model</label>
+              <select v-model="settings.AnthropicModel" class="form-input">
+                <option v-for="m in anthropicModels" :key="m.id" :value="m.id">{{ m.name }}</option>
+              </select>
             </div>
-            <textarea
-              v-model="settings.ObversePrompt"
-              class="form-textarea"
-              rows="6"
-            />
-            <span class="form-hint">Prompt for obverse image analysis. Coin context (name, category, denomination) is appended automatically.</span>
-          </div>
-          <div class="form-group">
-            <div class="prompt-header">
-              <label class="form-label">Reverse Analysis Prompt</label>
-              <button
-                type="button"
-                class="btn btn-ghost btn-xs"
-                :disabled="settings.ReversePrompt === settingDefaults.ReversePrompt"
-                @click="settings.ReversePrompt = settingDefaults.ReversePrompt"
-              >Revert to Default</button>
+            <div class="connectivity-actions">
+              <button type="button" class="btn btn-secondary btn-sm" :disabled="anthropicTesting" @click="testAnthropicConn">
+                {{ anthropicTesting ? 'Testing...' : 'Test Anthropic API' }}
+              </button>
+              <div v-if="anthropicTestResult" class="connectivity-result" :class="{ success: anthropicTestOk, error: !anthropicTestOk }">
+                <span class="connectivity-icon">{{ anthropicTestOk ? '&#x25CF;' : '&#x25CF;' }}</span>
+                {{ anthropicTestResult }}
+              </div>
             </div>
-            <textarea
-              v-model="settings.ReversePrompt"
-              class="form-textarea"
-              rows="6"
-            />
-            <span class="form-hint">Prompt for reverse image analysis. Coin context (name, category, denomination) is appended automatically.</span>
-          </div>
-          <div class="form-group">
-            <div class="prompt-header">
-              <label class="form-label">Text Extraction Prompt</label>
-              <button
-                type="button"
-                class="btn btn-ghost btn-xs"
-                :disabled="settings.TextExtractionPrompt === settingDefaults.TextExtractionPrompt"
-                @click="settings.TextExtractionPrompt = settingDefaults.TextExtractionPrompt"
-              >Revert to Default</button>
+          </template>
+
+          <!-- Ollama Settings -->
+          <template v-if="settings.AIProvider === 'ollama'">
+            <div class="form-group">
+              <label class="form-label">Ollama URL</label>
+              <input v-model="settings.OllamaURL" class="form-input" placeholder="http://localhost:11434" />
             </div>
-            <textarea
-              v-model="settings.TextExtractionPrompt"
-              class="form-textarea"
-              rows="6"
-            />
-            <span class="form-hint">Prompt for extracting text from store card images.</span>
-          </div>
+            <div class="form-group">
+              <label class="form-label">Vision Model</label>
+              <input v-model="settings.OllamaModel" class="form-input" placeholder="llava" />
+              <span class="form-hint">e.g. llava, llama3.2-vision, bakllava</span>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Request Timeout (seconds)</label>
+              <input v-model="settings.OllamaTimeout" class="form-input" type="number" min="10" max="1800" step="10" />
+              <span class="form-hint">Time limit for AI analysis calls. Default: 300 (5 minutes)</span>
+            </div>
+            <div class="form-group">
+              <label class="form-label">SearXNG URL</label>
+              <input v-model="settings.SearXNGURL" class="form-input" placeholder="http://localhost:8888" />
+              <span class="form-hint">Required for web search features (coin search, coin shows, valuations).</span>
+              <p v-if="settings.AIProvider === 'ollama' && !settings.SearXNGURL" class="provider-warning">
+                Web search features require a SearXNG instance. Configure the URL or switch to Anthropic.
+              </p>
+            </div>
+            <div class="connectivity-actions">
+              <button type="button" class="btn btn-secondary btn-sm" :disabled="ollamaTesting" @click="testOllamaConnection">
+                {{ ollamaTesting ? 'Testing...' : 'Test Ollama' }}
+              </button>
+              <button v-if="settings.SearXNGURL" type="button" class="btn btn-secondary btn-sm" :disabled="searxngTesting" @click="testSearxngConn">
+                {{ searxngTesting ? 'Testing...' : 'Test SearXNG' }}
+              </button>
+            </div>
+            <div v-if="ollamaTestResult" class="connectivity-result" :class="{ success: ollamaTestOk, error: !ollamaTestOk }">
+              <span class="connectivity-icon">{{ ollamaTestOk ? '&#x25CF;' : '&#x25CF;' }}</span>
+              {{ ollamaTestResult }}
+            </div>
+            <div v-if="searxngTestResult" class="connectivity-result" :class="{ success: searxngTestOk, error: !searxngTestOk }">
+              <span class="connectivity-icon">{{ searxngTestOk ? '&#x25CF;' : '&#x25CF;' }}</span>
+              {{ searxngTestResult }}
+            </div>
+          </template>
+
+          <!-- Shared Prompt Settings (visible when a provider is selected) -->
+          <template v-if="settings.AIProvider">
+            <hr class="section-divider" />
+            <h3 class="subsection-title">Prompts</h3>
+            <div class="form-group">
+              <div class="prompt-header">
+                <label class="form-label">Agent Search Prompt</label>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs"
+                  :disabled="settings.AgentPrompt === agentPromptDefault"
+                  @click="settings.AgentPrompt = agentPromptDefault"
+                >Revert to Default</button>
+              </div>
+              <textarea
+                v-model="settings.AgentPrompt"
+                class="form-textarea"
+                rows="8"
+              />
+              <span class="form-hint">System prompt for the AI coin search agent. Controls how it searches and formats results.</span>
+            </div>
+            <div class="form-group">
+              <div class="prompt-header">
+                <label class="form-label">Value Estimator Prompt</label>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs"
+                  :disabled="settings.ValuationPrompt === valuationPromptDefault"
+                  @click="settings.ValuationPrompt = valuationPromptDefault"
+                >Revert to Default</button>
+              </div>
+              <textarea
+                v-model="settings.ValuationPrompt"
+                class="form-textarea"
+                rows="8"
+              />
+              <span class="form-hint">System prompt for the AI value estimator. Controls how it researches and estimates coin values.</span>
+            </div>
+            <div class="form-group">
+              <div class="prompt-header">
+                <label class="form-label">Obverse Analysis Prompt</label>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs"
+                  :disabled="settings.ObversePrompt === settingDefaults.ObversePrompt"
+                  @click="settings.ObversePrompt = settingDefaults.ObversePrompt"
+                >Revert to Default</button>
+              </div>
+              <textarea
+                v-model="settings.ObversePrompt"
+                class="form-textarea"
+                rows="6"
+              />
+              <span class="form-hint">Prompt for obverse image analysis. Coin context is appended automatically.</span>
+            </div>
+            <div class="form-group">
+              <div class="prompt-header">
+                <label class="form-label">Reverse Analysis Prompt</label>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs"
+                  :disabled="settings.ReversePrompt === settingDefaults.ReversePrompt"
+                  @click="settings.ReversePrompt = settingDefaults.ReversePrompt"
+                >Revert to Default</button>
+              </div>
+              <textarea
+                v-model="settings.ReversePrompt"
+                class="form-textarea"
+                rows="6"
+              />
+              <span class="form-hint">Prompt for reverse image analysis. Coin context is appended automatically.</span>
+            </div>
+            <div class="form-group">
+              <div class="prompt-header">
+                <label class="form-label">Text Extraction Prompt</label>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs"
+                  :disabled="settings.TextExtractionPrompt === settingDefaults.TextExtractionPrompt"
+                  @click="settings.TextExtractionPrompt = settingDefaults.TextExtractionPrompt"
+                >Revert to Default</button>
+              </div>
+              <textarea
+                v-model="settings.TextExtractionPrompt"
+                class="form-textarea"
+                rows="6"
+              />
+              <span class="form-hint">Prompt for extracting text from store card images.</span>
+            </div>
+          </template>
+
           <p v-if="settingsMsg" class="msg" :class="{ error: settingsError }">{{ settingsMsg }}</p>
           <div class="ai-actions">
             <button type="submit" class="btn btn-primary btn-sm" :disabled="settingsSaving">
               {{ settingsSaving ? 'Saving...' : 'Save AI Settings' }}
             </button>
-            <button type="button" class="btn btn-secondary btn-sm" :disabled="ollamaTesting" @click="testOllamaConnection">
-              {{ ollamaTesting ? 'Testing...' : 'Test Connectivity' }}
-            </button>
-          </div>
-          <div v-if="ollamaTestResult" class="connectivity-result" :class="{ success: ollamaTestOk, error: !ollamaTestOk }">
-            <span class="connectivity-icon">{{ ollamaTestOk ? '●' : '●' }}</span>
-            {{ ollamaTestResult }}
           </div>
         </form>
       </section>
@@ -291,6 +345,7 @@ import {
   getUsers, deleteUser, resetUserPassword,
   getAppSettings, getAppSettingDefaults, updateAppSettings, getAdminLogs, getOllamaStatus,
   getAnthropicModels, getAgentPrompt, getValuationPrompt,
+  testAnthropicConnection, testSearXNGConnection,
 } from '@/api/client'
 import type { AnthropicModel } from '@/api/client'
 import { LOG_LEVELS } from '@/types'
@@ -380,6 +435,7 @@ async function handleResetPassword() {
 
 // Settings
 const settings = ref<AppSettings>({
+  AIProvider: '',
   OllamaURL: 'http://localhost:11434',
   OllamaModel: 'llava',
   ObversePrompt: '',
@@ -390,6 +446,7 @@ const settings = ref<AppSettings>({
   LogLevel: 'info',
 })
 const settingDefaults = ref<AppSettings>({
+  AIProvider: '',
   OllamaURL: '',
   OllamaModel: '',
   ObversePrompt: '',
@@ -405,6 +462,12 @@ const settingsSaving = ref(false)
 const ollamaTesting = ref(false)
 const ollamaTestResult = ref('')
 const ollamaTestOk = ref(false)
+const anthropicTesting = ref(false)
+const anthropicTestResult = ref('')
+const anthropicTestOk = ref(false)
+const searxngTesting = ref(false)
+const searxngTestResult = ref('')
+const searxngTestOk = ref(false)
 const anthropicModels = ref<AnthropicModel[]>([
   { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4' },
   { id: 'claude-haiku-4-20250414', name: 'Claude Haiku 4' },
@@ -477,6 +540,36 @@ async function testOllamaConnection() {
     ollamaTestResult.value = 'Failed to check Ollama status'
   } finally {
     ollamaTesting.value = false
+  }
+}
+
+async function testAnthropicConn() {
+  anthropicTesting.value = true
+  anthropicTestResult.value = ''
+  try {
+    const res = await testAnthropicConnection()
+    anthropicTestOk.value = res.data.available
+    anthropicTestResult.value = res.data.message
+  } catch {
+    anthropicTestOk.value = false
+    anthropicTestResult.value = 'Failed to test Anthropic connection'
+  } finally {
+    anthropicTesting.value = false
+  }
+}
+
+async function testSearxngConn() {
+  searxngTesting.value = true
+  searxngTestResult.value = ''
+  try {
+    const res = await testSearXNGConnection()
+    searxngTestOk.value = res.data.available
+    searxngTestResult.value = res.data.message
+  } catch {
+    searxngTestOk.value = false
+    searxngTestResult.value = 'Failed to test SearXNG connection'
+  } finally {
+    searxngTesting.value = false
   }
 }
 
@@ -705,6 +798,79 @@ onUnmounted(() => {
 
 .connectivity-icon {
   font-size: 0.7rem;
+}
+
+/* Provider Toggle */
+.provider-toggle {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.provider-option {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1rem;
+  border: 2px solid var(--border-subtle, #333);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.provider-option:hover {
+  border-color: var(--accent-gold, #d4a843);
+}
+
+.provider-option.active {
+  border-color: var(--accent-gold, #d4a843);
+  background: rgba(212, 168, 67, 0.08);
+}
+
+.provider-option input[type="radio"] {
+  display: none;
+}
+
+.provider-label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.provider-desc {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #999);
+}
+
+.provider-warning {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(231, 176, 60, 0.1);
+  border: 1px solid rgba(231, 176, 60, 0.3);
+  border-radius: 6px;
+  color: #e7b03c;
+  font-size: 0.85rem;
+}
+
+.section-divider {
+  border: none;
+  border-top: 1px solid var(--border-subtle, #333);
+  margin: 1.5rem 0;
+}
+
+.subsection-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.connectivity-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 /* Modal */

--- a/src/web/src/types/index.ts
+++ b/src/web/src/types/index.ts
@@ -157,6 +157,7 @@ export interface UserInfo {
 }
 
 export interface AppSettings {
+  AIProvider: string
   OllamaURL: string
   OllamaModel: string
   ObversePrompt: string


### PR DESCRIPTION
- Add AIProvider setting (anthropic/ollama) — empty means unconfigured
- Replace implicit provider fallback logic with explicit setting read
- Return 400 with helpful message when provider is not configured
- Admin Settings: radio toggle for provider with conditional fields
- Per-provider connectivity test buttons (Anthropic API, Ollama, SearXNG)
- Ollama mode shows SearXNG warning when URL is missing
- Agent chat: banner + disabled input when provider is unconfigured
- Shared helper resolveLLMConfig() eliminates duplicated provider logic