### PR TITLE
docs: improve copilot instructions and add Playwright MCP config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 
 ## Project Overview
 
-Ancient Coins is a full-stack PWA for managing a personal coin collection. Go/Gin API backend with Vue 3/TypeScript frontend, SQLite database, and a Python LangGraph multi-agent service for AI features.
+Ancient Coins is a full-stack PWA for managing a personal ancient coin collection. Go/Gin API backend with Vue 3/TypeScript frontend, SQLite database, and a Python LangGraph multi-agent service for AI features.
 
 | Layer | Tech | Path |
 |---|---|---|
@@ -14,7 +14,38 @@ Ancient Coins is a full-stack PWA for managing a personal coin collection. Go/Gi
 | Agent | Python 3.12, FastAPI, LangGraph, LangChain | `src/agent/` |
 | Build | Multi-stage Docker (2 containers) | `Dockerfile`, `src/agent/Dockerfile` |
 
-## Architecture (CRITICAL)
+## Build, Test, and Lint
+
+A [Taskfile](../Taskfile.yml) wraps common commands. Run `task --list` to see all targets.
+
+```bash
+# Go API (from src/api/)
+go build ./...                          # compile
+go vet ./...                            # lint
+go test -v ./...                        # all tests (architecture + unit)
+go test -v -run TestNoDirectDatabase .  # single test by name
+
+# Vue frontend (from src/web/)
+npm run build                           # production build (type-check + vite)
+npm run type-check                      # vue-tsc only
+npx vue-tsc --noEmit                    # alternative type check
+
+# Python agent (from src/agent/)
+pip install -e ".[dev]"                 # install with dev deps
+ruff check app/ tests/                  # lint
+pytest tests/ -v                        # all tests
+pytest tests/test_foo.py::test_bar -v   # single test
+
+# Task runner shortcuts (from repo root)
+task build                              # build API + web
+task test                               # Go tests
+task up                                 # API + web dev servers
+task up-all                             # API + web + agent dev servers
+task test-agent                         # Python tests
+task lint-agent                         # Python lint
+```
+
+## Architecture
 
 See `docs/ARCHITECTURE.md` for full details.
 
@@ -24,49 +55,17 @@ See `docs/ARCHITECTURE.md` for full details.
 Handler → Service → Repository → Database
 ```
 
-**Rules (enforced by architecture_test.go):**
+**Rules (enforced by `architecture_test.go`):**
 
 1. **Only `main.go` imports the `database` package.** All other packages receive `*gorm.DB` or a repository/service via constructor injection.
 2. **Handlers are thin.** Parse request, call service/repo, return response. No business logic, no raw SQL.
-3. **Services contain business logic.** Orchestrate repos, enforce domain rules. HTTP-agnostic (no gin.Context).
+3. **Services contain business logic.** Orchestrate repos, enforce domain rules. HTTP-agnostic (no `gin.Context`).
 4. **Repositories own all DB access.** Every GORM query lives in `src/api/repository/`.
 5. **Multi-step writes use transactions** (`r.db.Transaction()`).
 6. **Never leak internal errors to clients.** Log server-side, return generic messages.
 7. **Go API contains zero LLM/agent logic.** All AI inference is proxied to the Python agent service.
 
-### Multi-Agent Architecture (Python)
-
-```
-Vue SPA → Go API (8080) → Python Agent Service (8081)
-```
-
-The Python agent is a **stateless** FastAPI service — it has no database access. All configuration (API keys, models, prompts, user context) is passed per-request from the Go API.
-
-**Team Structure:**
-
-| Team | Purpose | Pipeline |
-|---|---|---|
-| Team 1: Coin Search | Find coins for sale | Search → Fetch dealer pages → Format |
-| Team 2: Coin Shows | Find upcoming events | Search → Verify dates future → Format |
-| Team 3: Coin Analysis | Analyze coin images | Vision model analysis → Format |
-| Team 4: Portfolio Review | Assess collection | Read holdings → Valuate (via Team 1) → Analyze |
-
-**Key Design Rules:**
-- Search agents pass only tool-returned data downstream — never invented details
-- Verification agents confirm every URL is live and every date is in the future
-- All worker agent outputs conform to a defined schema — no free-form text
-- Top-level supervisor enforces max iteration count to prevent loops
-
-### AI Provider Configuration
-
-Users explicitly choose one AI provider in Admin Settings:
-
-- **Anthropic (Recommended)** — Claude models with built-in `web_search` tool
-- **Ollama** — Self-hosted models, requires external SearXNG for web search
-
-The `AIProvider` setting must be set before agent features work. The agent chat shows a configuration banner when it's empty. The `resolveLLMConfig()` helper in `handlers/agent.go` reads the explicit setting — there is no implicit fallback.
-
-### Package Import Rules
+**Package import rules:**
 
 | Package | May import |
 |---|---|
@@ -76,36 +75,61 @@ The `AIProvider` setting must be set before agent features work. The agent chat 
 | `models/` | Standard library only |
 | `middleware/` | `models/`, `gorm.io/gorm` |
 
-### Adding a New API Feature
+**DI wiring in `main.go`:** `config.Load()` → `database.Connect()` → construct repos → construct services → construct handlers → register routes. Three route groups: `api` (public auth), `protected` (JWT required), `admin` (JWT + admin role).
 
-1. Model in `src/api/models/` → add to AutoMigrate in `database/database.go`
-2. Repository methods in `src/api/repository/*_repository.go`
-3. Service logic (if needed) in `src/api/services/*_service.go`
-4. Thin handler in `src/api/handlers/`
-5. Wire in `src/api/main.go` (create repo → service → handler, register routes)
-6. Run `go test ./...` to verify architecture rules pass
+### Multi-Agent Architecture (Python)
 
-## Code Style
+```
+Vue SPA → Go API (8080) → Python Agent Service (8081)
+```
+
+The Python agent is a **stateless** FastAPI service — no database access. All configuration (API keys, models, prompts, user context) is passed per-request from the Go API. SSE streams flow Python → Go → Vue (Go proxies the byte stream via `services/agent_proxy.go`).
+
+**Team pipelines:**
+
+| Team | Pipeline |
+|---|---|
+| Coin Search | Search → Fetch dealer pages → Format |
+| Coin Shows | Search → Verify dates are future → Format |
+| Coin Analysis | Vision model analysis → Format |
+| Portfolio Review | Read holdings → Valuate → Analyze |
+
+**Key design rules:**
+- Search agents pass only tool-returned data downstream — never invented details
+- Verification agents confirm every URL is live and every date is in the future
+- All worker agent outputs conform to a defined Pydantic schema — no free-form text
+- Top-level supervisor (`app/supervisor.py`) enforces max iteration count to prevent loops
+
+### AI Provider Configuration
+
+Users choose one provider in Admin Settings (`AIProvider` key):
+
+- **Anthropic** — Claude models. Web search uses Claude's built-in `web_search_20250305` tool.
+- **Ollama** — Self-hosted models. Web search uses a `create_react_agent` with SearXNG tool.
+
+**Important:** Anthropic's `web_search` is NOT available by default on `ChatAnthropic`. Use `get_search_model()` from `app/llm/provider.py` (which calls `bind_tools`) for any agent node that needs web search. Use `get_chat_model()` for nodes that don't search.
+
+## Code Conventions
 
 ### Go
-- Standard Go conventions (gofmt, go vet)
-- Constructor injection for all dependencies
+- Constructor injection for all dependencies (`NewXxxHandler(repo, service)` pattern)
 - Sentinel errors in services (e.g., `ErrNotFound`, `ErrInvalidCredentials`)
-- Use GORM scopes from `repository/scopes.go` instead of repeating Where clauses
+- Use GORM scopes from `repository/scopes.go` (`OwnedBy`, `OwnedByID`, `ActiveCollection`, `PublicCoins`, `ByCoinID`) instead of repeating `.Where()` clauses
 - Swagger annotations on all public handler methods
+- Settings use key-value `AppSetting` model; constants and defaults live in `services/settings_service.go`
 
 ### Python (Agent)
-- Pydantic models for all request/response schemas
+- Pydantic models for all request/response schemas (in `app/models/`)
 - LangGraph `StateGraph` for team pipelines
 - `create_react_agent()` for tool-using agents
 - Structured logging via `app/logging_config.py` (ring buffer + stdout)
-- Ruff for linting, pytest for tests
 
 ### TypeScript / Vue
 - `<script setup lang="ts">` with Composition API
-- Always use optional chaining (`?.`) and nullish coalescing (`??`) on array index access
-- Docker build uses stricter TS checking than local vue-tsc
-- All API calls go through `src/web/src/api/client.ts`
+- **Always** use optional chaining (`?.`) and nullish coalescing (`??`) on array index access — Docker builds use stricter TS checking than local `vue-tsc`
+- All API calls go through `src/web/src/api/client.ts` (Axios with JWT interceptor and 401 refresh queue)
+- Agent chat streaming uses `fetch` + manual SSE parsing, not Axios
+- `sanitizeCoin()` in the API client normalizes `''`/`undefined` → `null` before sending
 - CSS variables: `--accent-gold`, `--bg-card`, `--border-subtle`, `--text-primary`
 - Icons: `lucide-vue-next`
 
@@ -114,78 +138,14 @@ The `AIProvider` setting must be set before agent features work. The agent chat 
 - Dark theme is default
 - PWA-compatible — test on mobile viewports
 
-## Build and Test
+### Adding a New API Feature
 
-```bash
-# Go API
-cd src/api
-go build ./...        # compile
-go vet ./...          # lint
-go test -v ./...      # architecture tests
-
-# Vue frontend
-cd src/web
-npm run build         # production build
-npx vue-tsc --noEmit  # type check
-
-# Python agent
-cd src/agent
-ruff check app/ tests/  # lint
-pytest tests/ -q         # tests
-
-# All
-task build            # build API + web
-task test             # run Go tests
-task up               # run API + web dev servers
-```
-
-## Deployment
-
-Two Docker containers orchestrated via `docker-compose.yaml`:
-
-| Container | Image | Port | Purpose |
-|---|---|---|---|
-| `app` | `<user>/ancient-coins:latest` | 8080 | Go API + Vue SPA |
-| `agent` | `<user>/ancient-coins-agent:latest` | 8081 | Python LangGraph agent |
-
-External services (not deployed by us):
-- **Ollama** — self-hosted LLM (only if Ollama provider selected)
-- **SearXNG** — web search engine (only needed for Ollama mode)
-
-CI builds and pushes both images via GitHub Actions. `docker-compose` only references images — no local builds.
-
-## Environment
-
-| Variable | Default | Description |
-|---|---|---|
-| `JWT_SECRET` | (generated) | JWT signing key (min 32 chars) |
-| `DB_PATH` | `./ancientcoins.db` | SQLite database path |
-| `PORT` | `8080` | HTTP server port |
-| `UPLOAD_DIR` | `./uploads` | Image upload directory |
-| `WEBAUTHN_RP_ID` | `localhost` | WebAuthn Relying Party ID |
-| `WEBAUTHN_ORIGIN` | `http://localhost:8080` | WebAuthn origin |
-| `AGENT_SERVICE_URL` | `http://agent:8081` | Python agent service URL |
-| `AGENT_LOG_LEVEL` | `INFO` | Python agent log level |
-
-### Admin-Managed Settings (stored in DB)
-
-| Key | Purpose |
-|---|---|
-| `AIProvider` | Explicit provider choice: `anthropic` or `ollama` (empty = unconfigured) |
-| `AnthropicAPIKey` | API key for Claude models |
-| `AnthropicModel` | Claude model (e.g., `claude-sonnet-4-20250514`) |
-| `OllamaURL` | Ollama server URL |
-| `OllamaModel` | Vision model name (e.g., `llava`) |
-| `OllamaTimeout` | Request timeout in seconds |
-| `SearXNGURL` | SearXNG search engine URL (required for Ollama web search) |
-| `NumistaAPIKey` | Numista catalog API key |
-| `CoinSearchPrompt` | System prompt for coin search agent |
-| `CoinShowsPrompt` | System prompt for coin shows agent |
-| `ValuationPrompt` | System prompt for value estimator |
-| `ObversePrompt` | Prompt for obverse image analysis |
-| `ReversePrompt` | Prompt for reverse image analysis |
-| `TextExtractionPrompt` | Prompt for OCR text extraction |
-| `LogLevel` | Application log level |
+1. Model in `src/api/models/` → add to `AutoMigrate` in `database/database.go`
+2. Repository in `src/api/repository/*_repository.go`
+3. Service (if business logic needed) in `src/api/services/*_service.go`
+4. Thin handler in `src/api/handlers/` with `NewXxxHandler()` constructor
+5. Wire in `src/api/main.go` (create repo → service → handler, register routes under correct group)
+6. Run `go test ./...` to verify architecture rules pass
 
 ## Commit Convention
 

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
- Add single-test commands, task runner shortcuts, and dev install steps
- Document get_search_model() vs get_chat_model() gotcha
- Add DI wiring flow and frontend SSE/sanitization patterns
- Trim exhaustive env/settings tables (discoverable from code)
- Add .vscode/mcp.json with Playwright MCP server