### PR TITLE
refactor: Phase B - extract 12 medium-risk section components

### DIFF
--- a/src/web/src/components/CoinSearchChat.vue
+++ b/src/web/src/components/CoinSearchChat.vue
@@ -32,67 +32,23 @@
           </div>
 
           <!-- Coin Show results -->
-          <div v-if="msg.role === 'assistant' && msg.suggestions?.length && isCoinShowResults(msg.suggestions)" class="suggestions-grid">
-            <div v-for="(show, j) in (msg.suggestions as CoinShow[])" :key="j" class="show-card">
-              <div class="show-body">
-                <a v-if="show.url" :href="show.url" target="_blank" rel="noopener" class="show-name-link">
-                  <h4>{{ show.name }} <ExternalLink :size="12" /></h4>
-                </a>
-                <h4 v-else>{{ show.name }}</h4>
-                <div class="show-details">
-                  <span v-if="show.dates" class="show-detail"><Calendar :size="13" /> {{ show.dates }}</span>
-                  <span v-if="show.venue" class="show-detail"><MapPin :size="13" /> {{ show.venue }}</span>
-                  <span v-if="show.location" class="show-detail-sub">{{ show.location }}</span>
-                  <span v-if="show.entryFee" class="show-detail"><Ticket :size="13" /> {{ show.entryFee }}</span>
-                </div>
-                <p v-if="show.description" class="show-desc">{{ show.description }}</p>
-                <div v-if="show.notableDealers?.length" class="show-dealers">
-                  <span v-for="(dealer, k) in show.notableDealers" :key="k" class="meta-tag">{{ dealer }}</span>
-                </div>
-                <button
-                  class="save-cal-btn"
-                  :disabled="savedShows.has(showKey(show)) || savingShow === showKey(show)"
-                  @click="saveShowToCalendar(show)"
-                >
-                  <CalendarPlus :size="13" />
-                  {{ savedShows.has(showKey(show)) ? 'Saved' : savingShow === showKey(show) ? 'Saving...' : 'Save to Calendar' }}
-                </button>
-              </div>
-            </div>
-          </div>
+          <CoinShowResultsGrid
+            v-if="msg.role === 'assistant' && msg.suggestions?.length && isCoinShowResults(msg.suggestions)"
+            :shows="(msg.suggestions as CoinShow[])"
+            :saved-shows="savedShows"
+            :saving-show="savingShow"
+            @save-show="saveShowToCalendar"
+          />
 
           <!-- Coin suggestions after assistant message -->
-          <div v-if="msg.role === 'assistant' && msg.suggestions?.length && !isCoinShowResults(msg.suggestions)" class="suggestions-grid">
-            <div v-for="(coin, j) in (msg.suggestions as CoinSuggestion[])" :key="j" class="suggestion-card">
-              <div class="suggestion-img" v-if="getSuggestionImageUrl(coin)">
-                <img :src="getSuggestionImageUrl(coin)" :alt="coin.name" @error="handleImgError" />
-              </div>
-              <div class="suggestion-body">
-                <h4>{{ coin.name }}</h4>
-                <p class="suggestion-desc">{{ coin.description }}</p>
-                <div class="suggestion-meta">
-                  <span v-if="coin.era" class="meta-tag">{{ coin.era }}</span>
-                  <span v-if="coin.material" class="meta-tag">{{ coin.material }}</span>
-                  <span v-if="coin.denomination" class="meta-tag">{{ coin.denomination }}</span>
-                </div>
-                <div class="suggestion-price" v-if="coin.estPrice">{{ coin.estPrice }}</div>
-                <div class="suggestion-actions">
-                  <a v-if="coin.sourceUrl" :href="coin.sourceUrl" target="_blank" rel="noopener" class="source-link">
-                    <ExternalLink :size="12" /> {{ coin.sourceName || 'Source' }}
-                  </a>
-                  <button
-                    v-if="coin.era || coin.material || coin.denomination"
-                    class="btn btn-primary btn-sm add-btn"
-                    :disabled="addingIdx === `${i}-${j}`"
-                    @click="addToWishlist(coin, `${i}-${j}`)"
-                  >
-                    <CirclePlus :size="14" />
-                    {{ addedSet.has(`${i}-${j}`) ? 'Added!' : addingIdx === `${i}-${j}` ? 'Adding...' : 'Add to Wishlist' }}
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
+          <CoinSuggestionGrid
+            v-if="msg.role === 'assistant' && msg.suggestions?.length && !isCoinShowResults(msg.suggestions)"
+            :suggestions="(msg.suggestions as CoinSuggestion[])"
+            :added-set="addedSet"
+            :adding-idx="addingIdx"
+            :message-index="i"
+            @add-to-wishlist="addToWishlist"
+          />
         </template>
 
         <div v-if="loading && !messages[messages.length-1]?.streaming" class="chat-bubble assistant">
@@ -117,13 +73,15 @@
 import { ref, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { agentChatStream, createCoin, proxyImage, scrapeImage, uploadImage, saveConversation, getPortfolioSummary, getAgentStatus, createCalendarEvent } from '@/api/client'
 import type { CoinSuggestion, CoinShow, AgentChatMessage, Category, Material } from '@/types'
-import { CirclePlus, ExternalLink, AlertTriangle, Calendar, MapPin, Ticket, CalendarPlus } from 'lucide-vue-next'
+import { AlertTriangle } from 'lucide-vue-next'
 import DOMPurify from 'dompurify'
 import { useDialog } from '@/composables/useDialog'
 import MarkdownIt from 'markdown-it'
 import ChatHeader from '@/components/chat/ChatHeader.vue'
 import ChatIntroPanel from '@/components/chat/ChatIntroPanel.vue'
 import ChatInputBar from '@/components/chat/ChatInputBar.vue'
+import CoinShowResultsGrid from '@/components/chat/CoinShowResultsGrid.vue'
+import CoinSuggestionGrid from '@/components/chat/CoinSuggestionGrid.vue'
 
 type ChatSuggestion = CoinSuggestion | CoinShow
 
@@ -467,49 +425,6 @@ async function saveShowToCalendar(show: CoinShow) {
   }
 }
 
-function proxyImageUrl(url: string): string {
-  if (!url) return ''
-  return `/api/proxy-image?url=${encodeURIComponent(url)}`
-}
-
-function getSuggestionImageUrl(coin: CoinSuggestion): string {
-  // Always prefer scraped image from sourceUrl (og:image is most reliable)
-  if (coin.sourceUrl) {
-    const cached = scrapedImages.value.get(coin.sourceUrl)
-    if (cached) return proxyImageUrl(cached)
-    if (cached === undefined) {
-      scrapedImages.value.set(coin.sourceUrl, '')
-      scrapeImage(coin.sourceUrl).then((res) => {
-        if (res.data.imageUrl) {
-          console.log('[agent] Scraped image from', coin.sourceUrl, '→', res.data.imageUrl)
-          scrapedImages.value.set(coin.sourceUrl, res.data.imageUrl)
-        } else if (coin.imageUrl) {
-          // Scrape returned nothing — fall back to agent-provided URL
-          console.log('[agent] Scrape empty, using agent imageUrl:', coin.imageUrl)
-          scrapedImages.value.set(coin.sourceUrl, coin.imageUrl)
-        }
-      }).catch(() => {
-        // Scrape failed — fall back to agent-provided URL
-        if (coin.imageUrl) {
-          console.log('[agent] Scrape failed, using agent imageUrl:', coin.imageUrl)
-          scrapedImages.value.set(coin.sourceUrl, coin.imageUrl)
-        }
-      })
-    }
-    return ''
-  }
-
-  // No sourceUrl — try agent imageUrl directly
-  if (coin.imageUrl) return proxyImageUrl(coin.imageUrl)
-  return ''
-}
-
-function handleImgError(e: Event) {
-  const img = e.target as HTMLImageElement
-  console.warn('[agent] Image failed to load:', img.src)
-  img.style.display = 'none'
-}
-
 onMounted(async () => {
   inputBarEl.value?.focus()
   if (props.loadConversation) {
@@ -722,233 +637,9 @@ function handleViewportResize() {
   50% { opacity: 0; }
 }
 
-.suggestions-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  width: 100%;
-}
-
-.suggestion-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  display: flex;
-  transition: border-color var(--transition-fast);
-}
-
-.suggestion-card:hover {
-  border-color: var(--accent-gold);
-}
-
-.suggestion-img {
-  width: 80px;
-  min-height: 80px;
-  flex-shrink: 0;
-  overflow: hidden;
-  background: var(--bg-body);
-}
-
-.suggestion-img img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.suggestion-body {
-  padding: 0.6rem 0.75rem;
-  flex: 1;
-  min-width: 0;
-}
-
-.suggestion-body h4 {
-  font-size: 0.85rem;
-  margin: 0 0 0.25rem;
-  color: var(--text-primary);
-  line-height: 1.3;
-}
-
-.suggestion-desc {
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-  margin: 0 0 0.4rem;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.suggestion-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.3rem;
-  margin-bottom: 0.4rem;
-}
-
-.meta-tag {
-  font-size: 0.7rem;
-  padding: 0.1rem 0.4rem;
-  border-radius: var(--radius-full);
-  background: var(--bg-body);
-  color: var(--text-muted);
-  border: 1px solid var(--border-subtle);
-}
-
-.suggestion-price {
-  font-size: 0.82rem;
-  font-weight: 600;
-  color: var(--accent-gold);
-  margin-bottom: 0.4rem;
-}
-
-.suggestion-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
-.source-link {
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  text-decoration: none;
-  display: flex;
-  align-items: center;
-  gap: 0.2rem;
-  transition: color var(--transition-fast);
-}
-
-.source-link:hover {
-  color: var(--accent-gold);
-}
-
-/* Coin Show cards */
-.show-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  transition: border-color var(--transition-fast);
-}
-
-.show-card:hover {
-  border-color: var(--accent-gold);
-}
-
-.show-body {
-  padding: 0.7rem 0.85rem;
-}
-
-.show-body h4 {
-  font-size: 0.88rem;
-  margin: 0 0 0.4rem;
-  color: var(--text-primary);
-  line-height: 1.3;
-}
-
-.show-name-link {
-  text-decoration: none;
-  color: inherit;
-}
-
-.show-name-link h4 {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  color: var(--accent-gold);
-  transition: color var(--transition-fast);
-}
-
-.show-name-link:hover h4 {
-  color: var(--accent-bronze);
-}
-
-.show-details {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  margin-bottom: 0.4rem;
-}
-
-.show-detail {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-}
-
-.show-detail-sub {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  padding-left: 1.5rem;
-}
-
-.show-desc {
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-  margin: 0 0 0.4rem;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.show-dealers {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-}
-
-.save-cal-btn {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.75rem;
-  padding: 0.3rem 0.65rem;
-  margin-top: 0.5rem;
-  background: transparent;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: all var(--transition-fast);
-  font-family: inherit;
-}
-
-.save-cal-btn:hover:not(:disabled) {
-  border-color: var(--accent-gold-dim);
-  color: var(--accent-gold);
-  background: var(--accent-gold-glow);
-}
-
-.save-cal-btn:disabled {
-  opacity: 0.6;
-  cursor: default;
-}
-
-.add-btn {
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-  font-size: 0.72rem;
-  padding: 0.3rem 0.6rem;
-  flex-shrink: 0;
-}
-
 @media (max-width: 640px) {
   .chat-drawer {
     width: 100%;
-  }
-
-  .suggestion-card {
-    flex-direction: column;
-  }
-
-  .suggestion-img {
-    width: 100%;
-    height: 120px;
   }
 }
 </style>

--- a/src/web/src/components/ImageInputPanel.vue
+++ b/src/web/src/components/ImageInputPanel.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="input-section card">
+    <h3>Load Image</h3>
+    <div class="input-methods">
+      <label class="drop-zone" :class="{ dragging }" @dragover.prevent="dragging = true"
+        @dragleave="dragging = false" @drop.prevent="onDrop">
+        <Upload :size="32" />
+        <span>Drop an image here or click to browse</span>
+        <input type="file" accept="image/*" hidden @change="onFileSelect" />
+      </label>
+      <div class="url-input-row">
+        <input v-model="url" type="url" class="form-input" placeholder="Or paste an image URL..."
+          @keydown.enter="onUrlLoad" />
+        <button class="btn btn-primary btn-sm" :disabled="!url || urlLoading" @click="onUrlLoad">
+          {{ urlLoading ? 'Loading...' : 'Fetch' }}
+        </button>
+      </div>
+      <p v-if="inputError" class="msg error">{{ inputError }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Upload } from 'lucide-vue-next'
+
+const props = defineProps<{
+  sourceImage: string | null
+  urlLoading: boolean
+  inputError: string
+}>()
+
+const emit = defineEmits<{
+  'file-select': [file: File]
+  'url-load': [url: string]
+  'drop': [file: File]
+}>()
+
+const dragging = ref(false)
+const url = ref('')
+
+function onFileSelect(e: Event) {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (file) emit('file-select', file)
+}
+
+function onDrop(e: DragEvent) {
+  dragging.value = false
+  const file = e.dataTransfer?.files?.[0]
+  if (file) emit('drop', file)
+}
+
+function onUrlLoad() {
+  if (!url.value) return
+  emit('url-load', url.value)
+}
+</script>
+
+<style scoped>
+.input-section h3 {
+  margin-bottom: 1rem;
+}
+
+.input-methods {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 2.5rem 1.5rem;
+  border: 2px dashed var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-align: center;
+}
+
+.drop-zone:hover,
+.drop-zone.dragging {
+  border-color: var(--accent-gold);
+  color: var(--accent-gold);
+  background: var(--accent-gold-glow);
+}
+
+.url-input-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.url-input-row .form-input {
+  flex: 1;
+}
+</style>

--- a/src/web/src/components/ImageProcessor.vue
+++ b/src/web/src/components/ImageProcessor.vue
@@ -1,25 +1,15 @@
 <template>
   <div class="image-processor">
     <!-- Step 1: Image Input -->
-    <div v-if="!sourceImage" class="input-section card">
-      <h3>Load Image</h3>
-      <div class="input-methods">
-        <label class="drop-zone" :class="{ dragging }" @dragover.prevent="dragging = true"
-          @dragleave="dragging = false" @drop.prevent="handleDrop">
-          <Upload :size="32" />
-          <span>Drop an image here or click to browse</span>
-          <input type="file" accept="image/*" hidden @change="handleFileSelect" />
-        </label>
-        <div class="url-input-row">
-          <input v-model="imageUrl" type="url" class="form-input" placeholder="Or paste an image URL..."
-            @keydown.enter="handleUrlLoad" />
-          <button class="btn btn-primary btn-sm" :disabled="!imageUrl || urlLoading" @click="handleUrlLoad">
-            {{ urlLoading ? 'Loading...' : 'Fetch' }}
-          </button>
-        </div>
-        <p v-if="inputError" class="msg error">{{ inputError }}</p>
-      </div>
-    </div>
+    <ImageInputPanel
+      v-if="!sourceImage"
+      :source-image="sourceImage"
+      :url-loading="urlLoading"
+      :input-error="inputError"
+      @file-select="loadImageFromFile"
+      @url-load="handleUrlLoad"
+      @drop="loadImageFromFile"
+    />
 
     <!-- Step 2: Processing & Preview -->
     <div v-if="sourceImage" class="processing-section">
@@ -137,10 +127,10 @@
 <script setup lang="ts">
 import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { removeBackground as removeBg } from '@imgly/background-removal'
-import { Upload } from 'lucide-vue-next'
 import { proxyImage, uploadImage, createCoin, getCoins } from '@/api/client'
 import { getCoin } from '@/api/client'
 import type { Coin } from '@/types'
+import ImageInputPanel from '@/components/ImageInputPanel.vue'
 
 const props = defineProps<{
   coinId?: number
@@ -152,10 +142,8 @@ const emit = defineEmits<{
 
 // Input state
 const sourceImage = ref<string | null>(null)
-const imageUrl = ref('')
 const urlLoading = ref(false)
 const inputError = ref('')
-const dragging = ref(false)
 
 // Processing state
 type Step = 'preview' | 'removing' | 'crop' | 'done'
@@ -217,23 +205,12 @@ function loadImageFromFile(file: File) {
   reader.readAsDataURL(file)
 }
 
-function handleFileSelect(e: Event) {
-  const file = (e.target as HTMLInputElement).files?.[0]
-  if (file) loadImageFromFile(file)
-}
-
-function handleDrop(e: DragEvent) {
-  dragging.value = false
-  const file = e.dataTransfer?.files?.[0]
-  if (file) loadImageFromFile(file)
-}
-
-async function handleUrlLoad() {
-  if (!imageUrl.value) return
+async function handleUrlLoad(url: string) {
+  if (!url) return
   inputError.value = ''
   urlLoading.value = true
   try {
-    const res = await proxyImage(imageUrl.value)
+    const res = await proxyImage(url)
     const blob = res.data as Blob
     const reader = new FileReader()
     reader.onload = (e) => {
@@ -611,47 +588,6 @@ onUnmounted(() => {
 .image-processor {
   max-width: 700px;
   margin: 0 auto;
-}
-
-.input-section h3 {
-  margin-bottom: 1rem;
-}
-
-.input-methods {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.drop-zone {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
-  padding: 2.5rem 1.5rem;
-  border: 2px dashed var(--border-subtle);
-  border-radius: var(--radius-md);
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: all var(--transition-fast);
-  text-align: center;
-}
-
-.drop-zone:hover,
-.drop-zone.dragging {
-  border-color: var(--accent-gold);
-  color: var(--accent-gold);
-  background: var(--accent-gold-glow);
-}
-
-.url-input-row {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.url-input-row .form-input {
-  flex: 1;
 }
 
 /* Steps */

--- a/src/web/src/components/admin/AdminLogsSection.vue
+++ b/src/web/src/components/admin/AdminLogsSection.vue
@@ -1,0 +1,142 @@
+<template>
+  <section class="admin-section card">
+    <h2>Application Logs</h2>
+    <div class="logs-toolbar">
+      <select :value="filter" class="form-select logs-filter" @change="$emit('update:filter', ($event.target as HTMLSelectElement).value); $emit('load')">
+        <option value="">All Levels</option>
+        <option v-for="level in ['TRACE','DEBUG','INFO','WARN','ERROR']" :key="level" :value="level">{{ level }}</option>
+      </select>
+      <button class="btn btn-secondary btn-sm" @click="$emit('load')" :disabled="loading">
+        {{ loading ? 'Loading...' : 'Refresh' }}
+      </button>
+      <button
+        class="btn btn-sm"
+        :class="autoRefresh ? 'btn-primary' : 'btn-secondary'"
+        @click="$emit('toggle-auto-refresh')"
+      >
+        {{ autoRefresh ? 'Auto ●' : 'Auto ○' }}
+      </button>
+      <button
+        class="btn btn-secondary btn-sm"
+        @click="$emit('export')"
+        :disabled="logs.length === 0"
+        title="Export logs as text file"
+      >
+        <Download :size="14" /> Export
+      </button>
+    </div>
+    <div class="logs-container">
+      <div v-if="logs.length === 0 && !loading" class="logs-empty">
+        No log entries. Click Refresh to load.
+      </div>
+      <div
+        v-for="(entry, i) in logs"
+        :key="i"
+        class="log-entry"
+        :class="logLevelClass(entry.level)"
+      >
+        <span class="log-time">{{ entry.timestamp.substring(11, 19) }}</span>
+        <span class="log-level-badge">{{ entry.level }}</span>
+        <span class="log-msg">{{ entry.message }}</span>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { LogEntry } from '@/types'
+import { Download } from 'lucide-vue-next'
+
+defineProps<{
+  logs: LogEntry[]
+  loading: boolean
+  filter: string
+  autoRefresh: boolean
+}>()
+
+defineEmits<{
+  load: []
+  'toggle-auto-refresh': []
+  export: []
+  'update:filter': [val: string]
+}>()
+
+function logLevelClass(level: string) {
+  switch (level) {
+    case 'ERROR': return 'log-error'
+    case 'WARN': return 'log-warn'
+    case 'DEBUG': return 'log-debug'
+    case 'TRACE': return 'log-trace'
+    default: return 'log-info'
+  }
+}
+</script>
+
+<style scoped>
+.logs-toolbar {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.logs-filter {
+  width: auto;
+  min-width: 120px;
+}
+
+.logs-container {
+  max-height: 500px;
+  overflow-y: auto;
+  background: var(--bg-body);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.logs-empty {
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-muted);
+  font-family: 'Inter', sans-serif;
+}
+
+.log-entry {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.15rem 0.25rem;
+  border-radius: 2px;
+}
+
+.log-entry:hover {
+  background: var(--bg-card);
+}
+
+.log-time {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.log-level-badge {
+  flex-shrink: 0;
+  min-width: 48px;
+  text-align: center;
+  font-weight: 600;
+  border-radius: 2px;
+  padding: 0 4px;
+}
+
+.log-msg {
+  word-break: break-word;
+}
+
+.log-error .log-level-badge { color: #e74c3c; }
+.log-error .log-msg { color: #e74c3c; }
+.log-warn .log-level-badge { color: #f39c12; }
+.log-debug .log-level-badge { color: #3498db; }
+.log-trace .log-level-badge { color: #7f8c8d; }
+.log-info .log-level-badge { color: #2ecc71; }
+</style>

--- a/src/web/src/components/admin/AdminSystemSection.vue
+++ b/src/web/src/components/admin/AdminSystemSection.vue
@@ -1,0 +1,90 @@
+<template>
+  <section class="admin-section card">
+    <h2>System Settings</h2>
+    <form @submit.prevent="$emit('save', { numistaApiKey: localNumistaApiKey, logLevel: localLogLevel })">
+      <div class="form-group">
+        <label class="form-label">Numista API Key</label>
+        <input v-model="localNumistaApiKey" class="form-input" type="password" placeholder="Enter your Numista API key" />
+        <span class="form-hint">Get a free key at <a href="https://en.numista.com/api/" target="_blank" rel="noopener">numista.com/api</a> (2,000 requests/month free)</span>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Log Level</label>
+        <select v-model="localLogLevel" class="form-select">
+          <option v-for="level in logLevels" :key="level" :value="level">{{ level }}</option>
+        </select>
+      </div>
+      <p v-if="msg" class="msg" :class="{ error }">{{ msg }}</p>
+      <button type="submit" class="btn btn-primary btn-sm" :disabled="saving">
+        {{ saving ? 'Saving...' : 'Save System Settings' }}
+      </button>
+    </form>
+    <div class="version-info">
+      <span class="version-label">Version</span>
+      <span class="version-value">{{ appVersion }}</span>
+      <span v-if="buildDate" class="version-date">Built {{ buildDate }}</span>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+const props = defineProps<{
+  numistaApiKey: string
+  logLevel: string
+  logLevels: readonly string[]
+  saving: boolean
+  msg: string
+  error: boolean
+  appVersion: string
+  buildDate: string
+}>()
+
+defineEmits<{
+  save: [settings: { numistaApiKey: string; logLevel: string }]
+}>()
+
+const localNumistaApiKey = ref(props.numistaApiKey)
+const localLogLevel = ref(props.logLevel)
+
+watch(() => props.numistaApiKey, (v) => { localNumistaApiKey.value = v })
+watch(() => props.logLevel, (v) => { localLogLevel.value = v })
+</script>
+
+<style scoped>
+.msg {
+  font-size: 0.85rem;
+  color: var(--accent-gold);
+  margin: 0.5rem 0;
+}
+
+.msg.error {
+  color: #e74c3c;
+}
+
+.version-info {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.version-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.version-value {
+  font-family: 'Courier New', Courier, monospace;
+  color: var(--text-secondary);
+}
+
+.version-date {
+  margin-left: 0.25rem;
+}
+</style>

--- a/src/web/src/components/admin/AdminUsersSection.vue
+++ b/src/web/src/components/admin/AdminUsersSection.vue
@@ -1,0 +1,115 @@
+<template>
+  <section class="admin-section card">
+    <h2>User Management</h2>
+    <div v-if="loading" class="loading-overlay"><div class="spinner"></div></div>
+    <table v-else class="users-table">
+      <thead>
+        <tr>
+          <th>Username</th>
+          <th>Role</th>
+          <th>Created</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="user in users" :key="user.id">
+          <td>
+            <span class="username">{{ user.username }}</span>
+            <span v-if="user.id === currentUserId" class="you-badge">(you)</span>
+          </td>
+          <td>
+            <span class="badge" :class="`badge-${user.role === 'admin' ? 'roman' : 'modern'}`">
+              {{ user.role }}
+            </span>
+          </td>
+          <td class="date-cell">{{ formatDate(user.createdAt) }}</td>
+          <td>
+            <div v-if="user.id !== currentUserId" class="action-btns">
+              <button class="btn btn-secondary btn-sm" @click="$emit('reset', user)">
+                Reset
+              </button>
+              <button class="btn btn-danger btn-sm" @click="$emit('delete', user)">
+                Delete
+              </button>
+            </div>
+            <span v-else class="text-muted">—</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { UserInfo } from '@/types'
+
+defineProps<{
+  users: UserInfo[]
+  loading: boolean
+  currentUserId: number
+}>()
+
+defineEmits<{
+  reset: [user: UserInfo]
+  delete: [user: UserInfo]
+}>()
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString()
+}
+</script>
+
+<style scoped>
+.users-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.users-table th,
+.users-table td {
+  text-align: left;
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.users-table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.username {
+  font-weight: 500;
+}
+
+.you-badge {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-left: 0.3rem;
+}
+
+.date-cell {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.action-btns {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.text-muted {
+  color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+  .users-table {
+    font-size: 0.85rem;
+  }
+  .action-btns {
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/web/src/components/chat/CoinShowResultsGrid.vue
+++ b/src/web/src/components/chat/CoinShowResultsGrid.vue
@@ -1,0 +1,171 @@
+<template>
+  <div class="suggestions-grid">
+    <div v-for="(show, j) in shows" :key="j" class="show-card">
+      <div class="show-body">
+        <a v-if="show.url" :href="show.url" target="_blank" rel="noopener" class="show-name-link">
+          <h4>{{ show.name }} <ExternalLink :size="12" /></h4>
+        </a>
+        <h4 v-else>{{ show.name }}</h4>
+        <div class="show-details">
+          <span v-if="show.dates" class="show-detail"><Calendar :size="13" /> {{ show.dates }}</span>
+          <span v-if="show.venue" class="show-detail"><MapPin :size="13" /> {{ show.venue }}</span>
+          <span v-if="show.location" class="show-detail-sub">{{ show.location }}</span>
+          <span v-if="show.entryFee" class="show-detail"><Ticket :size="13" /> {{ show.entryFee }}</span>
+        </div>
+        <p v-if="show.description" class="show-desc">{{ show.description }}</p>
+        <div v-if="show.notableDealers?.length" class="show-dealers">
+          <span v-for="(dealer, k) in show.notableDealers" :key="k" class="meta-tag">{{ dealer }}</span>
+        </div>
+        <button
+          class="save-cal-btn"
+          :disabled="savedShows.has(showKey(show)) || savingShow === showKey(show)"
+          @click="$emit('save-show', show)"
+        >
+          <CalendarPlus :size="13" />
+          {{ savedShows.has(showKey(show)) ? 'Saved' : savingShow === showKey(show) ? 'Saving...' : 'Save to Calendar' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { CoinShow } from '@/types'
+import { Calendar, MapPin, Ticket, CalendarPlus, ExternalLink } from 'lucide-vue-next'
+
+defineProps<{
+  shows: CoinShow[]
+  savedShows: Set<string>
+  savingShow: string | null
+}>()
+
+defineEmits<{
+  'save-show': [show: CoinShow]
+}>()
+
+function showKey(show: CoinShow): string {
+  return `${show.name}|${show.dates}`
+}
+</script>
+
+<style scoped>
+.suggestions-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  width: 100%;
+}
+
+.show-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: border-color var(--transition-fast);
+}
+
+.show-card:hover {
+  border-color: var(--accent-gold);
+}
+
+.show-body {
+  padding: 0.7rem 0.85rem;
+}
+
+.show-body h4 {
+  font-size: 0.88rem;
+  margin: 0 0 0.4rem;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+
+.show-name-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.show-name-link h4 {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--accent-gold);
+  transition: color var(--transition-fast);
+}
+
+.show-name-link:hover h4 {
+  color: var(--accent-bronze);
+}
+
+.show-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.4rem;
+}
+
+.show-detail {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.show-detail-sub {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  padding-left: 1.5rem;
+}
+
+.show-desc {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  margin: 0 0 0.4rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.show-dealers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.meta-tag {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-full);
+  background: var(--bg-body);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+
+.save-cal-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  padding: 0.3rem 0.65rem;
+  margin-top: 0.5rem;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  font-family: inherit;
+}
+
+.save-cal-btn:hover:not(:disabled) {
+  border-color: var(--accent-gold-dim);
+  color: var(--accent-gold);
+  background: var(--accent-gold-glow);
+}
+
+.save-cal-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+</style>

--- a/src/web/src/components/chat/CoinSuggestionGrid.vue
+++ b/src/web/src/components/chat/CoinSuggestionGrid.vue
@@ -1,0 +1,210 @@
+<template>
+  <div class="suggestions-grid">
+    <div v-for="(coin, j) in suggestions" :key="j" class="suggestion-card">
+      <div class="suggestion-img" v-if="getSuggestionImageUrl(coin)">
+        <img :src="getSuggestionImageUrl(coin)" :alt="coin.name" @error="handleImgError" />
+      </div>
+      <div class="suggestion-body">
+        <h4>{{ coin.name }}</h4>
+        <p class="suggestion-desc">{{ coin.description }}</p>
+        <div class="suggestion-meta">
+          <span v-if="coin.era" class="meta-tag">{{ coin.era }}</span>
+          <span v-if="coin.material" class="meta-tag">{{ coin.material }}</span>
+          <span v-if="coin.denomination" class="meta-tag">{{ coin.denomination }}</span>
+        </div>
+        <div class="suggestion-price" v-if="coin.estPrice">{{ coin.estPrice }}</div>
+        <div class="suggestion-actions">
+          <a v-if="coin.sourceUrl" :href="coin.sourceUrl" target="_blank" rel="noopener" class="source-link">
+            <ExternalLink :size="12" /> {{ coin.sourceName || 'Source' }}
+          </a>
+          <button
+            v-if="coin.era || coin.material || coin.denomination"
+            class="btn btn-primary btn-sm add-btn"
+            :disabled="addingIdx === `${messageIndex}-${j}`"
+            @click="$emit('add-to-wishlist', coin, `${messageIndex}-${j}`)"
+          >
+            <CirclePlus :size="14" />
+            {{ addedSet.has(`${messageIndex}-${j}`) ? 'Added!' : addingIdx === `${messageIndex}-${j}` ? 'Adding...' : 'Add to Wishlist' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { CoinSuggestion } from '@/types'
+import { CirclePlus, ExternalLink } from 'lucide-vue-next'
+import { scrapeImage } from '@/api/client'
+
+defineProps<{
+  suggestions: CoinSuggestion[]
+  addedSet: Set<string>
+  addingIdx: string | null
+  messageIndex: number
+}>()
+
+defineEmits<{
+  'add-to-wishlist': [coin: CoinSuggestion, key: string]
+}>()
+
+const scrapedImages = ref<Map<string, string>>(new Map())
+
+function proxyImageUrl(url: string): string {
+  if (!url) return ''
+  return `/api/proxy-image?url=${encodeURIComponent(url)}`
+}
+
+function getSuggestionImageUrl(coin: CoinSuggestion): string {
+  if (coin.sourceUrl) {
+    const cached = scrapedImages.value.get(coin.sourceUrl)
+    if (cached) return proxyImageUrl(cached)
+    if (cached === undefined) {
+      scrapedImages.value.set(coin.sourceUrl, '')
+      scrapeImage(coin.sourceUrl).then((res) => {
+        if (res.data.imageUrl) {
+          scrapedImages.value.set(coin.sourceUrl, res.data.imageUrl)
+        } else if (coin.imageUrl) {
+          scrapedImages.value.set(coin.sourceUrl, coin.imageUrl)
+        }
+      }).catch(() => {
+        if (coin.imageUrl) {
+          scrapedImages.value.set(coin.sourceUrl, coin.imageUrl)
+        }
+      })
+    }
+    return ''
+  }
+  if (coin.imageUrl) return proxyImageUrl(coin.imageUrl)
+  return ''
+}
+
+function handleImgError(e: Event) {
+  const img = e.target as HTMLImageElement
+  img.style.display = 'none'
+}
+</script>
+
+<style scoped>
+.suggestions-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  width: 100%;
+}
+
+.suggestion-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  transition: border-color var(--transition-fast);
+}
+
+.suggestion-card:hover {
+  border-color: var(--accent-gold);
+}
+
+.suggestion-img {
+  width: 80px;
+  min-height: 80px;
+  flex-shrink: 0;
+  overflow: hidden;
+  background: var(--bg-body);
+}
+
+.suggestion-img img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.suggestion-body {
+  padding: 0.6rem 0.75rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.suggestion-body h4 {
+  font-size: 0.85rem;
+  margin: 0 0 0.25rem;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+
+.suggestion-desc {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  margin: 0 0 0.4rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.suggestion-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-bottom: 0.4rem;
+}
+
+.meta-tag {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-full);
+  background: var(--bg-body);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+
+.suggestion-price {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--accent-gold);
+  margin-bottom: 0.4rem;
+}
+
+.suggestion-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.source-link {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  transition: color var(--transition-fast);
+}
+
+.source-link:hover {
+  color: var(--accent-gold);
+}
+
+.add-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  padding: 0.3rem 0.6rem;
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .suggestion-card {
+    flex-direction: column;
+  }
+
+  .suggestion-img {
+    width: 100%;
+    height: 120px;
+  }
+}
+</style>

--- a/src/web/src/components/coin/CoinActivityJournal.vue
+++ b/src/web/src/components/coin/CoinActivityJournal.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="journal-section">
+    <h3>Activity Journal</h3>
+    <div class="journal-add">
+      <input
+        v-model="input"
+        type="text"
+        class="form-input journal-input"
+        placeholder="e.g. Cleaned, sent to grading, displayed at show..."
+        @keyup.enter="handleAdd"
+      />
+      <button class="btn btn-primary btn-sm" :disabled="!input.trim()" @click="handleAdd">Add</button>
+    </div>
+    <div v-if="entries.length" class="journal-list">
+      <div v-for="entry in entries" :key="entry.id" class="journal-entry">
+        <div class="journal-entry-content">
+          <span class="journal-entry-text">{{ entry.entry }}</span>
+          <span class="journal-entry-date">{{ formatJournalDate(entry.createdAt) }}</span>
+        </div>
+        <button class="btn btn-ghost btn-xs" @click="$emit('delete', entry.id)">✕</button>
+      </div>
+    </div>
+    <p v-else class="journal-empty">No activity recorded yet.</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { CoinJournal } from '@/types'
+
+defineProps<{
+  entries: CoinJournal[]
+  coinId: number
+}>()
+
+const emit = defineEmits<{
+  add: [entry: string]
+  delete: [entryId: number]
+}>()
+
+const input = ref('')
+
+function handleAdd() {
+  if (!input.value.trim()) return
+  emit('add', input.value.trim())
+  input.value = ''
+}
+
+function formatJournalDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit',
+  })
+}
+</script>
+
+<style scoped>
+.journal-section {
+  margin-bottom: 1.5rem;
+}
+
+.journal-section h3 {
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.journal-add {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.journal-input {
+  flex: 1;
+}
+
+.journal-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.journal-entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.journal-entry-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.journal-entry-text {
+  font-size: 0.85rem;
+}
+
+.journal-entry-date {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.journal-empty {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.btn-ghost {
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.btn-ghost:hover {
+  color: #e74c3c;
+  border-color: #e74c3c;
+}
+
+.btn-xs {
+  padding: 0.15rem 0.45rem;
+  font-size: 0.7rem;
+  border-radius: var(--radius-sm);
+}
+</style>

--- a/src/web/src/components/coin/CoinDetailHeaderActions.vue
+++ b/src/web/src/components/coin/CoinDetailHeaderActions.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="detail-header">
+    <button class="btn btn-secondary btn-sm" @click="router.back()">← Back</button>
+    <div class="detail-actions">
+      <button v-if="isWishlist" class="btn btn-primary btn-sm" @click="$emit('purchase')">Mark as Purchased</button>
+      <button v-if="!isWishlist && !isSold" class="btn btn-secondary btn-sm" @click="$emit('sell')">Sell</button>
+      <router-link :to="`/edit/${coinId}`" class="btn btn-secondary btn-sm">Edit</router-link>
+      <button class="btn btn-danger btn-sm" @click="$emit('delete')">Delete</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+
+defineProps<{
+  isWishlist: boolean
+  isSold: boolean
+  coinId: number
+}>()
+
+defineEmits<{
+  purchase: []
+  sell: []
+  delete: []
+}>()
+
+const router = useRouter()
+</script>
+
+<style scoped>
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.detail-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+</style>

--- a/src/web/src/components/coin/CoinNumistaPanel.vue
+++ b/src/web/src/components/coin/CoinNumistaPanel.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="numista-section">
+    <div class="numista-header">
+      <h3>Numista Lookup</h3>
+      <button
+        class="btn btn-secondary btn-sm"
+        :disabled="searching"
+        @click="handleSearch"
+      >
+        {{ searching ? 'Searching...' : 'Search' }}
+      </button>
+    </div>
+    <p v-if="error" class="numista-error">{{ error }}</p>
+    <div v-if="results.length" class="numista-results">
+      <a
+        v-for="item in results"
+        :key="item.id"
+        :href="`https://en.numista.com/catalogue/pieces${item.id}.html`"
+        target="_blank"
+        rel="noopener"
+        class="numista-card"
+      >
+        <img v-if="item.obverse_thumbnail" :src="item.obverse_thumbnail" class="numista-thumb" />
+        <div class="numista-card-info">
+          <span class="numista-card-title">{{ item.title }}</span>
+          <span class="numista-card-meta">
+            <template v-if="item.issuer?.name">{{ item.issuer.name }}</template>
+            <template v-if="item.min_year"> · {{ item.min_year }}<template v-if="item.max_year && item.max_year !== item.min_year">–{{ item.max_year }}</template></template>
+          </span>
+        </div>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { searchNumista } from '@/api/client'
+import type { NumistaType } from '@/types'
+
+const props = defineProps<{
+  coinName: string
+  coinRuler: string
+  coinDenomination: string
+}>()
+
+const searching = ref(false)
+const results = ref<NumistaType[]>([])
+const error = ref('')
+
+async function handleSearch() {
+  searching.value = true
+  error.value = ''
+  results.value = []
+  try {
+    const q = [props.coinName, props.coinDenomination, props.coinRuler].filter(Boolean).join(' ')
+    const res = await searchNumista(q)
+    results.value = res.data.types || []
+    if (!results.value.length) {
+      error.value = 'No results found on Numista'
+    }
+  } catch (err: any) {
+    error.value = err.response?.data?.error || 'Numista search failed'
+  } finally {
+    searching.value = false
+  }
+}
+</script>
+
+<style scoped>
+.numista-section {
+  margin-bottom: 1.5rem;
+}
+
+.numista-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.numista-header h3 {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.numista-error {
+  font-size: 0.85rem;
+  color: #e67e22;
+  font-style: italic;
+}
+
+.numista-results {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+}
+
+.numista-card {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color var(--transition-fast);
+}
+
+.numista-card:hover {
+  border-color: var(--accent-gold);
+}
+
+.numista-thumb {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.numista-card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.numista-card-title {
+  font-size: 0.85rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.numista-card-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+</style>

--- a/src/web/src/components/settings/SavedConversationsSection.vue
+++ b/src/web/src/components/settings/SavedConversationsSection.vue
@@ -1,0 +1,118 @@
+<template>
+  <section class="settings-section card">
+    <h2>Saved Conversations</h2>
+    <p class="setting-desc" style="margin-bottom: 1rem">
+      Your saved AI coin search conversations. Open one to continue the search or review results.
+    </p>
+
+    <div v-if="loading" class="loading-inline">Loading...</div>
+
+    <div v-else-if="conversations.length" class="apikey-list">
+      <div v-for="conv in conversations" :key="conv.id" class="apikey-item">
+        <div class="apikey-item-info" style="cursor: pointer" @click="$emit('open', conv.id)">
+          <span class="apikey-item-name">{{ conv.title }}</span>
+          <span class="apikey-item-meta">{{ formatDate(conv.updatedAt) }}</span>
+        </div>
+        <div class="conv-actions">
+          <button class="btn btn-secondary btn-sm" @click="$emit('open', conv.id)">Open</button>
+          <button class="btn btn-danger btn-sm" @click="$emit('delete', conv.id)">Delete</button>
+        </div>
+      </div>
+    </div>
+    <p v-else class="setting-desc" style="margin-top: 0.5rem">No saved conversations yet. Use the Save button in the coin search chat to save a conversation.</p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { ConversationSummary } from '@/api/client'
+
+defineProps<{
+  conversations: ConversationSummary[]
+  loading: boolean
+}>()
+
+defineEmits<{
+  open: [id: number]
+  delete: [id: number]
+}>()
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+  })
+}
+</script>
+
+<style scoped>
+.settings-section h2 {
+  font-size: 1.1rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.setting-desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.loading-inline {
+  color: var(--text-muted);
+  font-style: italic;
+  padding: 0.5rem 0;
+}
+
+.apikey-list {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.apikey-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--border-subtle);
+  gap: 0.75rem;
+}
+
+.apikey-item:last-child {
+  border-bottom: none;
+}
+
+.apikey-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.apikey-item-name {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.apikey-item-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.conv-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.btn-danger {
+  background: #e74c3c;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+.btn-danger:hover {
+  background: #c0392b;
+}
+</style>

--- a/src/web/src/components/settings/SettingsAppearanceSection.vue
+++ b/src/web/src/components/settings/SettingsAppearanceSection.vue
@@ -1,0 +1,168 @@
+<template>
+  <section class="settings-section card">
+    <h2>Appearance</h2>
+    <div class="setting-item">
+      <div class="setting-info">
+        <span class="setting-label">Theme</span>
+        <span class="setting-desc">Choose your preferred color scheme</span>
+      </div>
+      <div class="theme-toggle">
+        <button
+          class="theme-btn"
+          :class="{ active: theme === 'dark' }"
+          @click="$emit('set-theme', 'dark')"
+        >Dark</button>
+        <button
+          class="theme-btn"
+          :class="{ active: theme === 'light' }"
+          @click="$emit('set-theme', 'light')"
+        >Light</button>
+      </div>
+    </div>
+
+    <div class="setting-item">
+      <div class="setting-info">
+        <span class="setting-label">Timezone</span>
+        <span class="setting-desc">Used for date display</span>
+      </div>
+      <select
+        :value="timezone"
+        class="form-select tz-select"
+        @change="$emit('save-timezone', ($event.target as HTMLSelectElement).value)"
+      >
+        <option v-for="tz in timezones" :key="tz" :value="tz">{{ tz }}</option>
+      </select>
+    </div>
+
+    <div class="setting-item">
+      <div class="setting-info">
+        <span class="setting-label">Default View</span>
+        <span class="setting-desc">Preferred collection view on mobile / PWA</span>
+      </div>
+      <div class="theme-toggle">
+        <button
+          class="theme-btn"
+          :class="{ active: defaultView === 'swipe' }"
+          @click="$emit('set-default-view', 'swipe')"
+        >Swipe</button>
+        <button
+          class="theme-btn"
+          :class="{ active: defaultView === 'grid' }"
+          @click="$emit('set-default-view', 'grid')"
+        >Grid</button>
+      </div>
+    </div>
+
+    <div class="setting-item">
+      <div class="setting-info">
+        <span class="setting-label">Default Sort</span>
+        <span class="setting-desc">How coins are sorted by default</span>
+      </div>
+      <select
+        :value="defaultSort"
+        class="form-select sort-select"
+        @change="$emit('save-default-sort', ($event.target as HTMLSelectElement).value)"
+      >
+        <option value="updated_at_desc">Last Updated</option>
+        <option value="created_at_desc">Newest First</option>
+        <option value="created_at_asc">Oldest First</option>
+        <option value="current_value_desc">Price: High → Low</option>
+        <option value="current_value_asc">Price: Low → High</option>
+      </select>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  theme: string
+  timezone: string
+  timezones: string[]
+  defaultView: string
+  defaultSort: string
+}>()
+
+defineEmits<{
+  'set-theme': [theme: string]
+  'save-timezone': [tz: string]
+  'set-default-view': [view: string]
+  'save-default-sort': [sort: string]
+}>()
+</script>
+
+<style scoped>
+.theme-toggle {
+  display: flex;
+  gap: 0.25rem;
+  background: var(--bg-primary);
+  border-radius: var(--radius-full);
+  padding: 0.2rem;
+}
+
+.theme-btn {
+  padding: 0.35rem 0.75rem;
+  border: none;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.theme-btn.active {
+  background: var(--accent-gold-dim);
+  color: var(--accent-gold);
+}
+
+.tz-select {
+  max-width: 250px;
+}
+
+.sort-select {
+  max-width: 250px;
+}
+
+.settings-section h2 {
+  font-size: 1.1rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.setting-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border-subtle);
+  gap: 1rem;
+}
+
+.setting-item:last-child {
+  border-bottom: none;
+}
+
+.setting-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.setting-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.setting-desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+  .setting-item {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+</style>

--- a/src/web/src/components/settings/SettingsToolsSection.vue
+++ b/src/web/src/components/settings/SettingsToolsSection.vue
@@ -1,0 +1,95 @@
+<template>
+  <section class="settings-section card">
+    <h2>Image Processor</h2>
+    <p class="setting-desc" style="margin-bottom: 1rem">
+      Remove backgrounds and crop coin images for your collection.
+    </p>
+    <ImageProcessor @saved="(coinId: number) => $emit('saved', coinId)" />
+
+    <h3 style="margin-top: 2rem">Blocked Users</h3>
+    <p class="setting-desc" style="margin-bottom: 0.75rem">
+      Blocked users cannot send you follow requests or view your collection.
+    </p>
+    <div v-if="blockedUsers.length" class="apikey-list">
+      <div v-for="user in blockedUsers" :key="user.id" class="apikey-item">
+        <div class="apikey-item-info" style="display: flex; align-items: center; gap: 0.5rem;">
+          <img
+            :src="user.avatarPath ? `/uploads/${user.avatarPath}` : '/coin-logo.jpg'"
+            :alt="user.username"
+            style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid var(--border-subtle);"
+          />
+          <span class="apikey-item-name">{{ user.username }}</span>
+        </div>
+        <button class="btn btn-secondary btn-sm" :disabled="blockedLoading" @click="$emit('unblock', user)">Unblock</button>
+      </div>
+    </div>
+    <p v-else class="setting-desc" style="margin-top: 0.5rem">No blocked users.</p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import ImageProcessor from '@/components/ImageProcessor.vue'
+
+defineProps<{
+  blockedUsers: { id: number; username: string; avatarPath: string }[]
+  blockedLoading: boolean
+}>()
+
+defineEmits<{
+  saved: [coinId: number]
+  unblock: [user: { id: number; username: string; avatarPath: string }]
+}>()
+</script>
+
+<style scoped>
+.settings-section h2 {
+  font-size: 1.1rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.settings-section h3 {
+  font-size: 0.95rem;
+  margin-top: 1.25rem;
+  margin-bottom: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.setting-desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.apikey-list {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.apikey-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--border-subtle);
+  gap: 0.75rem;
+}
+
+.apikey-item:last-child {
+  border-bottom: none;
+}
+
+.apikey-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.apikey-item-name {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+</style>

--- a/src/web/src/pages/AdminPage.vue
+++ b/src/web/src/pages/AdminPage.vue
@@ -22,45 +22,14 @@
       </div>
 
       <!-- Users Tab -->
-      <section v-if="activeTab === 'users'" class="admin-section card">
-        <h2>User Management</h2>
-        <div v-if="usersLoading" class="loading-overlay"><div class="spinner"></div></div>
-        <table v-else class="users-table">
-          <thead>
-            <tr>
-              <th>Username</th>
-              <th>Role</th>
-              <th>Created</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="user in users" :key="user.id">
-              <td>
-                <span class="username">{{ user.username }}</span>
-                <span v-if="user.id === auth.user?.id" class="you-badge">(you)</span>
-              </td>
-              <td>
-                <span class="badge" :class="`badge-${user.role === 'admin' ? 'roman' : 'modern'}`">
-                  {{ user.role }}
-                </span>
-              </td>
-              <td class="date-cell">{{ formatDate(user.createdAt) }}</td>
-              <td>
-                <div v-if="user.id !== auth.user?.id" class="action-btns">
-                  <button class="btn btn-secondary btn-sm" @click="openResetModal(user)">
-                    Reset
-                  </button>
-                  <button class="btn btn-danger btn-sm" @click="handleDeleteUser(user)">
-                    Delete
-                  </button>
-                </div>
-                <span v-else class="text-muted">—</span>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
+      <AdminUsersSection
+        v-if="activeTab === 'users'"
+        :users="users"
+        :loading="usersLoading"
+        :current-user-id="auth.user?.id ?? 0"
+        @reset="openResetModal"
+        @delete="handleDeleteUser"
+      />
 
       <!-- AI Tab -->
       <section v-if="activeTab === 'ai'" class="admin-section card">
@@ -271,75 +240,31 @@
       </section>
 
       <!-- System Tab -->
-      <section v-if="activeTab === 'system'" class="admin-section card">
-        <h2>System Settings</h2>
-        <form @submit.prevent="saveSettings">
-          <div class="form-group">
-            <label class="form-label">Numista API Key</label>
-            <input v-model="settings.NumistaAPIKey" class="form-input" type="password" placeholder="Enter your Numista API key" />
-            <span class="form-hint">Get a free key at <a href="https://en.numista.com/api/" target="_blank" rel="noopener">numista.com/api</a> (2,000 requests/month free)</span>
-          </div>
-          <div class="form-group">
-            <label class="form-label">Log Level</label>
-            <select v-model="settings.LogLevel" class="form-select">
-              <option v-for="level in LOG_LEVELS" :key="level" :value="level">{{ level }}</option>
-            </select>
-          </div>
-          <p v-if="settingsMsg" class="msg" :class="{ error: settingsError }">{{ settingsMsg }}</p>
-          <button type="submit" class="btn btn-primary btn-sm" :disabled="settingsSaving">
-            {{ settingsSaving ? 'Saving...' : 'Save System Settings' }}
-          </button>
-        </form>
-        <div class="version-info">
-          <span class="version-label">Version</span>
-          <span class="version-value">{{ appVersion }}</span>
-          <span v-if="buildDate" class="version-date">Built {{ buildDate }}</span>
-        </div>
-      </section>
+      <AdminSystemSection
+        v-if="activeTab === 'system'"
+        :numista-api-key="settings.NumistaAPIKey ?? ''"
+        :log-level="settings.LogLevel ?? ''"
+        :log-levels="LOG_LEVELS"
+        :saving="settingsSaving"
+        :msg="settingsMsg"
+        :error="settingsError"
+        :app-version="appVersion"
+        :build-date="buildDate"
+        @save="onSystemSave"
+      />
 
       <!-- Logs Tab -->
-      <section v-if="activeTab === 'logs'" class="admin-section card">
-        <h2>Application Logs</h2>
-        <div class="logs-toolbar">
-          <select v-model="logsFilter" class="form-select logs-filter" @change="loadLogs">
-            <option value="">All Levels</option>
-            <option v-for="level in ['TRACE','DEBUG','INFO','WARN','ERROR']" :key="level" :value="level">{{ level }}</option>
-          </select>
-          <button class="btn btn-secondary btn-sm" @click="loadLogs" :disabled="logsLoading">
-            {{ logsLoading ? 'Loading...' : 'Refresh' }}
-          </button>
-          <button
-            class="btn btn-sm"
-            :class="logsAutoRefresh ? 'btn-primary' : 'btn-secondary'"
-            @click="toggleAutoRefresh"
-          >
-            {{ logsAutoRefresh ? 'Auto ●' : 'Auto ○' }}
-          </button>
-          <button
-            class="btn btn-secondary btn-sm"
-            @click="exportLogs"
-            :disabled="logs.length === 0"
-            title="Export logs as text file"
-          >
-            <Download :size="14" /> Export
-          </button>
-        </div>
-        <div class="logs-container">
-          <div v-if="logs.length === 0 && !logsLoading" class="logs-empty">
-            No log entries. Click Refresh to load.
-          </div>
-          <div
-            v-for="(entry, i) in logs"
-            :key="i"
-            class="log-entry"
-            :class="logLevelClass(entry.level)"
-          >
-            <span class="log-time">{{ entry.timestamp.substring(11, 19) }}</span>
-            <span class="log-level-badge">{{ entry.level }}</span>
-            <span class="log-msg">{{ entry.message }}</span>
-          </div>
-        </div>
-      </section>
+      <AdminLogsSection
+        v-if="activeTab === 'logs'"
+        :logs="logs"
+        :loading="logsLoading"
+        :filter="logsFilter"
+        :auto-refresh="logsAutoRefresh"
+        @load="loadLogs"
+        @toggle-auto-refresh="toggleAutoRefresh"
+        @export="exportLogs"
+        @update:filter="logsFilter = $event"
+      />
 
       <!-- Schedules Tab -->
       <section v-if="activeTab === 'schedules'" class="admin-section card">
@@ -621,6 +546,9 @@ import { LOG_LEVELS } from '@/types'
 import type { UserInfo, AppSettings, LogEntry, AvailabilityRun, ValuationRun } from '@/types'
 import { useDialog } from '@/composables/useDialog'
 import ResetPasswordModal from '@/components/admin/ResetPasswordModal.vue'
+import AdminUsersSection from '@/components/admin/AdminUsersSection.vue'
+import AdminSystemSection from '@/components/admin/AdminSystemSection.vue'
+import AdminLogsSection from '@/components/admin/AdminLogsSection.vue'
 import { Users, Cpu, Wrench, ScrollText, Download, ShieldCheck, CalendarClock } from 'lucide-vue-next'
 
 const tabIcons: Record<string, Component> = { users: Users, ai: Cpu, system: Wrench, logs: ScrollText, schedules: CalendarClock }
@@ -885,18 +813,14 @@ function exportLogs() {
   URL.revokeObjectURL(url)
 }
 
-function logLevelClass(level: string) {
-  switch (level) {
-    case 'ERROR': return 'log-error'
-    case 'WARN': return 'log-warn'
-    case 'DEBUG': return 'log-debug'
-    case 'TRACE': return 'log-trace'
-    default: return 'log-info'
-  }
-}
-
 function formatDate(dateStr: string) {
   return new Date(dateStr).toLocaleDateString()
+}
+
+function onSystemSave(payload: { numistaApiKey: string; logLevel: string }) {
+  settings.value.NumistaAPIKey = payload.numistaApiKey
+  settings.value.LogLevel = payload.logLevel
+  saveSettings()
 }
 
 // Availability
@@ -1119,24 +1043,9 @@ onUnmounted(() => {
   font-weight: 600;
 }
 
-.username {
-  font-weight: 500;
-}
-
-.you-badge {
-  font-size: 0.7rem;
-  color: var(--text-muted);
-  margin-left: 0.3rem;
-}
-
 .date-cell {
   font-size: 0.85rem;
   color: var(--text-secondary);
-}
-
-.action-btns {
-  display: flex;
-  gap: 0.4rem;
 }
 
 .text-muted {
@@ -1307,103 +1216,14 @@ onUnmounted(() => {
   .users-table {
     font-size: 0.85rem;
   }
-  .action-btns {
-    flex-direction: column;
-  }
 }
 
 /* Logs */
-.logs-toolbar {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-
-.logs-filter {
-  width: auto;
-  min-width: 120px;
-}
-
-.logs-container {
-  max-height: 500px;
-  overflow-y: auto;
-  background: var(--bg-body);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  padding: 0.5rem;
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 0.78rem;
-  line-height: 1.5;
-}
-
 .logs-empty {
   text-align: center;
   padding: 2rem;
   color: var(--text-muted);
   font-family: 'Inter', sans-serif;
-}
-
-.log-entry {
-  display: flex;
-  gap: 0.5rem;
-  padding: 0.15rem 0.25rem;
-  border-radius: 2px;
-}
-
-.log-entry:hover {
-  background: var(--bg-card);
-}
-
-.log-time {
-  color: var(--text-muted);
-  flex-shrink: 0;
-}
-
-.log-level-badge {
-  flex-shrink: 0;
-  min-width: 48px;
-  text-align: center;
-  font-weight: 600;
-  border-radius: 2px;
-  padding: 0 4px;
-}
-
-.log-msg {
-  word-break: break-word;
-}
-
-.log-error .log-level-badge { color: #e74c3c; }
-.log-error .log-msg { color: #e74c3c; }
-.log-warn .log-level-badge { color: #f39c12; }
-.log-debug .log-level-badge { color: #3498db; }
-.log-trace .log-level-badge { color: #7f8c8d; }
-.log-info .log-level-badge { color: #2ecc71; }
-
-.version-info {
-  margin-top: 1.5rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border-subtle);
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.78rem;
-  color: var(--text-muted);
-}
-
-.version-label {
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.version-value {
-  font-family: 'Courier New', Courier, monospace;
-  color: var(--text-secondary);
-}
-
-.version-date {
-  margin-left: 0.25rem;
 }
 
 /* Availability */

--- a/src/web/src/pages/CoinDetailPage.vue
+++ b/src/web/src/pages/CoinDetailPage.vue
@@ -5,15 +5,14 @@
     </div>
 
     <div v-else-if="coin" class="coin-detail">
-      <div class="detail-header">
-        <button class="btn btn-secondary btn-sm" @click="$router.back()">← Back</button>
-        <div class="detail-actions">
-          <button v-if="coin.isWishlist" class="btn btn-primary btn-sm" @click="showPurchaseModal = true">Mark as Purchased</button>
-          <button v-if="!coin.isWishlist && !coin.isSold" class="btn btn-secondary btn-sm" @click="showSellModal = true">Sell</button>
-          <router-link :to="`/edit/${coin.id}`" class="btn btn-secondary btn-sm">Edit</router-link>
-          <button class="btn btn-danger btn-sm" @click="handleDelete">Delete</button>
-        </div>
-      </div>
+      <CoinDetailHeaderActions
+        :is-wishlist="coin.isWishlist"
+        :is-sold="coin.isSold"
+        :coin-id="coin.id"
+        @purchase="showPurchaseModal = true"
+        @sell="showSellModal = true"
+        @delete="handleDelete"
+      />
 
       <div class="detail-layout">
         <!-- Images -->
@@ -208,68 +207,23 @@
             </div>
           </div>
 
-          <div class="numista-section">
-            <div class="numista-header">
-              <h3>Numista Lookup</h3>
-              <button
-                class="btn btn-secondary btn-sm"
-                :disabled="numistaSearching"
-                @click="handleNumistaSearch"
-              >
-                {{ numistaSearching ? 'Searching...' : 'Search' }}
-              </button>
-            </div>
-            <p v-if="numistaError" class="numista-error">{{ numistaError }}</p>
-            <div v-if="numistaResults.length" class="numista-results">
-              <a
-                v-for="item in numistaResults"
-                :key="item.id"
-                :href="`https://en.numista.com/catalogue/pieces${item.id}.html`"
-                target="_blank"
-                rel="noopener"
-                class="numista-card"
-              >
-                <img v-if="item.obverse_thumbnail" :src="item.obverse_thumbnail" class="numista-thumb" />
-                <div class="numista-card-info">
-                  <span class="numista-card-title">{{ item.title }}</span>
-                  <span class="numista-card-meta">
-                    <template v-if="item.issuer?.name">{{ item.issuer.name }}</template>
-                    <template v-if="item.min_year"> · {{ item.min_year }}<template v-if="item.max_year && item.max_year !== item.min_year">–{{ item.max_year }}</template></template>
-                  </span>
-                </div>
-              </a>
-            </div>
-          </div>
+          <CoinNumistaPanel
+            :coin-name="coin.name"
+            :coin-ruler="coin.ruler"
+            :coin-denomination="coin.denomination"
+          />
 
           <div v-if="coin.notes" class="notes-section">
             <h3>Notes</h3>
             <p>{{ coin.notes }}</p>
           </div>
 
-          <!-- Activity Journal -->
-          <div class="journal-section">
-            <h3>Activity Journal</h3>
-            <div class="journal-add">
-              <input
-                v-model="journalInput"
-                type="text"
-                class="form-input journal-input"
-                placeholder="e.g. Cleaned, sent to grading, displayed at show..."
-                @keyup.enter="handleAddJournalEntry"
-              />
-              <button class="btn btn-primary btn-sm" :disabled="!journalInput.trim()" @click="handleAddJournalEntry">Add</button>
-            </div>
-            <div v-if="journalEntries.length" class="journal-list">
-              <div v-for="entry in journalEntries" :key="entry.id" class="journal-entry">
-                <div class="journal-entry-content">
-                  <span class="journal-entry-text">{{ entry.entry }}</span>
-                  <span class="journal-entry-date">{{ formatJournalDate(entry.createdAt) }}</span>
-                </div>
-                <button class="btn btn-ghost btn-xs" @click="handleDeleteJournalEntry(entry.id)">✕</button>
-              </div>
-            </div>
-            <p v-else class="journal-empty">No activity recorded yet.</p>
-          </div>
+          <CoinActivityJournal
+            :entries="journalEntries"
+            :coin-id="coin.id"
+            @add="handleAddJournalEntry"
+            @delete="handleDeleteJournalEntry"
+          />
 
           <div v-if="coin.referenceUrl" class="reference-section">
             <a :href="coin.referenceUrl" target="_blank" rel="noopener" class="btn btn-secondary btn-sm">
@@ -360,9 +314,12 @@ import { useCoinsStore } from '@/stores/coins'
 import ImageGallery from '@/components/ImageGallery.vue'
 import SellModal from '@/components/SellModal.vue'
 import PurchaseModal from '@/components/PurchaseModal.vue'
-import { uploadImage, proxyImage, analyzeCoin, deleteAnalysis, deleteCoin, deleteImage, purchaseCoin, sellCoin, getOllamaStatus, getJournalEntries, addJournalEntry, deleteJournalEntry, searchNumista, estimateCoinValue, updateCoin, getCoinValueHistory, updateListingStatus, getTags, addTagToCoin, removeTagFromCoin } from '@/api/client'
+import CoinDetailHeaderActions from '@/components/coin/CoinDetailHeaderActions.vue'
+import CoinNumistaPanel from '@/components/coin/CoinNumistaPanel.vue'
+import CoinActivityJournal from '@/components/coin/CoinActivityJournal.vue'
+import { uploadImage, proxyImage, analyzeCoin, deleteAnalysis, deleteCoin, deleteImage, purchaseCoin, sellCoin, getOllamaStatus, getJournalEntries, addJournalEntry, deleteJournalEntry, estimateCoinValue, updateCoin, getCoinValueHistory, updateListingStatus, getTags, addTagToCoin, removeTagFromCoin } from '@/api/client'
 import { removeBackground as removeBg } from '@imgly/background-removal'
-import type { CoinImage, CoinJournal, NumistaType, ValueEstimate, CoinValueHistory as CoinValueHistoryType, Tag } from '@/types'
+import type { CoinImage, CoinJournal, ValueEstimate, CoinValueHistory as CoinValueHistoryType, Tag } from '@/types'
 import MarkdownIt from 'markdown-it'
 import DOMPurify from 'dompurify'
 import { Camera } from 'lucide-vue-next'
@@ -390,12 +347,6 @@ const showPurchaseModal = ref(false)
 
 // Journal
 const journalEntries = ref<CoinJournal[]>([])
-const journalInput = ref('')
-
-// Numista
-const numistaResults = ref<NumistaType[]>([])
-const numistaSearching = ref(false)
-const numistaError = ref('')
 
 // Value Estimation
 const estimating = ref(false)
@@ -480,11 +431,10 @@ async function loadJournal(coinId: number) {
   }
 }
 
-async function handleAddJournalEntry() {
-  if (!coin.value || !journalInput.value.trim()) return
+async function handleAddJournalEntry(entry: string) {
+  if (!coin.value || !entry) return
   try {
-    await addJournalEntry(coin.value.id, journalInput.value.trim())
-    journalInput.value = ''
+    await addJournalEntry(coin.value.id, entry)
     loadJournal(coin.value.id)
   } catch {
     await showAlert('Failed to add journal entry', { title: 'Error' })
@@ -501,12 +451,6 @@ async function handleDeleteJournalEntry(entryId: number) {
   }
 }
 
-function formatJournalDate(dateStr: string) {
-  return new Date(dateStr).toLocaleDateString(undefined, {
-    month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit',
-  })
-}
-
 function formatListingDate(dateStr: string) {
   return new Date(dateStr).toLocaleDateString(undefined, {
     month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit',
@@ -520,25 +464,6 @@ async function dismissListingStatus() {
     store.fetchCoin(Number(route.params.id))
   } catch {
     // silently fail
-  }
-}
-
-async function handleNumistaSearch() {
-  if (!coin.value) return
-  numistaSearching.value = true
-  numistaError.value = ''
-  numistaResults.value = []
-  try {
-    const q = [coin.value.name, coin.value.denomination, coin.value.ruler].filter(Boolean).join(' ')
-    const res = await searchNumista(q)
-    numistaResults.value = res.data.types || []
-    if (!numistaResults.value.length) {
-      numistaError.value = 'No results found on Numista'
-    }
-  } catch (err: any) {
-    numistaError.value = err.response?.data?.error || 'Numista search failed'
-  } finally {
-    numistaSearching.value = false
   }
 }
 
@@ -726,18 +651,6 @@ function formatCurrency(value: number) {
 </script>
 
 <style scoped>
-.detail-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1.5rem;
-}
-
-.detail-actions {
-  display: flex;
-  gap: 0.5rem;
-}
-
 .detail-layout {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -876,16 +789,14 @@ function formatCurrency(value: number) {
 .inscriptions-section,
 .descriptions-section,
 .value-section,
-.notes-section,
-.journal-section {
+.notes-section {
   margin-bottom: 1.5rem;
 }
 
 .inscriptions-section h3,
 .descriptions-section h3,
 .value-section h3,
-.notes-section h3,
-.journal-section h3 {
+.notes-section h3 {
   margin-bottom: 0.75rem;
   font-size: 1rem;
 }
@@ -1001,56 +912,6 @@ function formatCurrency(value: number) {
   font-size: 0.75rem;
   color: var(--text-muted);
   margin: 0;
-}
-
-/* Journal */
-.journal-add {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
-}
-
-.journal-input {
-  flex: 1;
-}
-
-.journal-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.journal-entry {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  background: var(--bg-card);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-}
-
-.journal-entry-content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  min-width: 0;
-}
-
-.journal-entry-text {
-  font-size: 0.85rem;
-}
-
-.journal-entry-date {
-  font-size: 0.7rem;
-  color: var(--text-muted);
-}
-
-.journal-empty {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  font-style: italic;
 }
 
 /* AI Value Estimate */
@@ -1194,81 +1055,6 @@ function formatCurrency(value: number) {
   display: flex;
   gap: 0.5rem;
   margin-top: 0.75rem;
-}
-
-/* Numista */
-.numista-section {
-  margin-bottom: 1.5rem;
-}
-
-.numista-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.75rem;
-}
-
-.numista-header h3 {
-  font-size: 1rem;
-  margin: 0;
-}
-
-.numista-error {
-  font-size: 0.85rem;
-  color: #e67e22;
-  font-style: italic;
-}
-
-.numista-results {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 0.75rem;
-}
-
-.numista-card {
-  display: flex;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  text-decoration: none;
-  color: inherit;
-  transition: border-color var(--transition-fast);
-}
-
-.numista-card:hover {
-  border-color: var(--accent-gold);
-}
-
-.numista-thumb {
-  width: 48px;
-  height: 48px;
-  object-fit: contain;
-  border-radius: var(--radius-sm);
-  flex-shrink: 0;
-}
-
-.numista-card-info {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  min-width: 0;
-}
-
-.numista-card-title {
-  font-size: 0.85rem;
-  font-weight: 500;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-.numista-card-meta {
-  font-size: 0.75rem;
-  color: var(--text-muted);
 }
 
 /* Image upload */

--- a/src/web/src/pages/SettingsPage.vue
+++ b/src/web/src/pages/SettingsPage.vue
@@ -198,72 +198,19 @@
         </template>
       </section>
 
-      <!-- Blocked Users Tab -->
       <!-- Appearance Tab -->
-      <section v-if="activeTab === 'appearance'" class="settings-section card">
-        <h2>Appearance</h2>
-        <div class="setting-item">
-          <div class="setting-info">
-            <span class="setting-label">Theme</span>
-            <span class="setting-desc">Choose your preferred color scheme</span>
-          </div>
-          <div class="theme-toggle">
-            <button
-              class="theme-btn"
-              :class="{ active: theme === 'dark' }"
-              @click="setTheme('dark')"
-            >Dark</button>
-            <button
-              class="theme-btn"
-              :class="{ active: theme === 'light' }"
-              @click="setTheme('light')"
-            >Light</button>
-          </div>
-        </div>
-
-        <div class="setting-item">
-          <div class="setting-info">
-            <span class="setting-label">Timezone</span>
-            <span class="setting-desc">Used for date display</span>
-          </div>
-          <select v-model="timezone" class="form-select tz-select" @change="saveTimezone">
-            <option v-for="tz in timezones" :key="tz" :value="tz">{{ tz }}</option>
-          </select>
-        </div>
-
-        <div class="setting-item">
-          <div class="setting-info">
-            <span class="setting-label">Default View</span>
-            <span class="setting-desc">Preferred collection view on mobile / PWA</span>
-          </div>
-          <div class="theme-toggle">
-            <button
-              class="theme-btn"
-              :class="{ active: defaultView === 'swipe' }"
-              @click="setDefaultView('swipe')"
-            >Swipe</button>
-            <button
-              class="theme-btn"
-              :class="{ active: defaultView === 'grid' }"
-              @click="setDefaultView('grid')"
-            >Grid</button>
-          </div>
-        </div>
-
-        <div class="setting-item">
-          <div class="setting-info">
-            <span class="setting-label">Default Sort</span>
-            <span class="setting-desc">How coins are sorted by default</span>
-          </div>
-          <select v-model="defaultSort" class="form-select sort-select" @change="saveDefaultSort">
-            <option value="updated_at_desc">Last Updated</option>
-            <option value="created_at_desc">Newest First</option>
-            <option value="created_at_asc">Oldest First</option>
-            <option value="current_value_desc">Price: High → Low</option>
-            <option value="current_value_asc">Price: Low → High</option>
-          </select>
-        </div>
-      </section>
+      <SettingsAppearanceSection
+        v-if="activeTab === 'appearance'"
+        :theme="theme"
+        :timezone="timezone"
+        :timezones="timezones"
+        :default-view="defaultView"
+        :default-sort="defaultSort"
+        @set-theme="setTheme"
+        @save-timezone="(tz: string) => { timezone = tz; saveTimezone() }"
+        @set-default-view="setDefaultView"
+        @save-default-sort="(sort: string) => { defaultSort = sort; saveDefaultSort() }"
+      />
 
       <!-- Data Tab -->
       <section v-if="activeTab === 'data'" class="settings-section card">
@@ -417,56 +364,22 @@
       </section>
 
       <!-- Tools Tab -->
-      <section v-if="activeTab === 'tools'" class="settings-section card">
-        <h2>Image Processor</h2>
-        <p class="setting-desc" style="margin-bottom: 1rem">
-          Remove backgrounds and crop coin images for your collection.
-        </p>
-        <ImageProcessor @saved="handleProcessSaved" />
-
-        <h3 style="margin-top: 2rem">Blocked Users</h3>
-        <p class="setting-desc" style="margin-bottom: 0.75rem">
-          Blocked users cannot send you follow requests or view your collection.
-        </p>
-        <div v-if="blockedUsers.length" class="apikey-list">
-          <div v-for="user in blockedUsers" :key="user.id" class="apikey-item">
-            <div class="apikey-item-info" style="display: flex; align-items: center; gap: 0.5rem;">
-              <img
-                :src="user.avatarPath ? `/uploads/${user.avatarPath}` : '/coin-logo.jpg'"
-                :alt="user.username"
-                style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid var(--border-subtle);"
-              />
-              <span class="apikey-item-name">{{ user.username }}</span>
-            </div>
-            <button class="btn btn-secondary btn-sm" :disabled="blockedLoading" @click="handleUnblock(user)">Unblock</button>
-          </div>
-        </div>
-        <p v-else class="setting-desc" style="margin-top: 0.5rem">No blocked users.</p>
-      </section>
+      <SettingsToolsSection
+        v-if="activeTab === 'tools'"
+        :blocked-users="blockedUsers"
+        :blocked-loading="blockedLoading"
+        @saved="handleProcessSaved"
+        @unblock="handleUnblock"
+      />
 
       <!-- Conversations Tab -->
-      <section v-if="activeTab === 'conversations'" class="settings-section card">
-        <h2>Saved Conversations</h2>
-        <p class="setting-desc" style="margin-bottom: 1rem">
-          Your saved AI coin search conversations. Open one to continue the search or review results.
-        </p>
-
-        <div v-if="conversationsLoading" class="loading-inline">Loading...</div>
-
-        <div v-else-if="conversations.length" class="apikey-list">
-          <div v-for="conv in conversations" :key="conv.id" class="apikey-item">
-            <div class="apikey-item-info" style="cursor: pointer" @click="openConversation(conv.id)">
-              <span class="apikey-item-name">{{ conv.title }}</span>
-              <span class="apikey-item-meta">{{ formatDate(conv.updatedAt) }}</span>
-            </div>
-            <div class="conv-actions">
-              <button class="btn btn-secondary btn-sm" @click="openConversation(conv.id)">Open</button>
-              <button class="btn btn-danger btn-sm" @click="handleDeleteConversation(conv.id)">Delete</button>
-            </div>
-          </div>
-        </div>
-        <p v-else class="setting-desc" style="margin-top: 0.5rem">No saved conversations yet. Use the Save button in the coin search chat to save a conversation.</p>
-      </section>
+      <SavedConversationsSection
+        v-if="activeTab === 'conversations'"
+        :conversations="conversations"
+        :loading="conversationsLoading"
+        @open="openConversation"
+        @delete="handleDeleteConversation"
+      />
 
       <!-- Help Tab -->
       <HelpSection v-if="activeTab === 'help'" />
@@ -503,6 +416,9 @@ import type { Coin, Theme, ApiKey, WebAuthnCredentialInfo, Tag } from '@/types'
 import CoinSearchChat from '@/components/CoinSearchChat.vue'
 import ImageProcessor from '@/components/ImageProcessor.vue'
 import HelpSection from '@/components/HelpSection.vue'
+import SettingsAppearanceSection from '@/components/settings/SettingsAppearanceSection.vue'
+import SavedConversationsSection from '@/components/settings/SavedConversationsSection.vue'
+import SettingsToolsSection from '@/components/settings/SettingsToolsSection.vue'
 import { User, Palette, Database, MessageSquare, HelpCircle, Wrench, Menu, ShieldCheck, Tags } from 'lucide-vue-next'
 
 const tabIcons: Record<string, Component> = {
@@ -1271,38 +1187,6 @@ onMounted(() => {
   max-width: 350px;
 }
 
-.theme-toggle {
-  display: flex;
-  gap: 0.25rem;
-  background: var(--bg-primary);
-  border-radius: var(--radius-full);
-  padding: 0.2rem;
-}
-
-.theme-btn {
-  padding: 0.35rem 0.75rem;
-  border: none;
-  border-radius: var(--radius-full);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 0.8rem;
-  cursor: pointer;
-  transition: all var(--transition-fast);
-}
-
-.theme-btn.active {
-  background: var(--accent-gold-dim);
-  color: var(--accent-gold);
-}
-
-.tz-select {
-  max-width: 250px;
-}
-
-.sort-select {
-  max-width: 250px;
-}
-
 .import-btn {
   cursor: pointer;
 }
@@ -1507,18 +1391,6 @@ onMounted(() => {
     font-size: 0.78rem;
     padding: 0.5rem 0.6rem;
   }
-}
-
-.conv-actions {
-  display: flex;
-  gap: 0.5rem;
-  flex-shrink: 0;
-}
-
-.loading-inline {
-  color: var(--text-muted);
-  font-style: italic;
-  padding: 0.5rem 0;
 }
 
 .modal-overlay {


### PR DESCRIPTION
Extract section-level components from 5 large parent files:

SettingsPage (1634→1341 lines):
- SettingsAppearanceSection: theme, timezone, view/sort settings
- SavedConversationsSection: conversation list with open/delete
- SettingsToolsSection: ImageProcessor embed + blocked users

AdminPage (1712→1386 lines):
- AdminUsersSection: user management table
- AdminSystemSection: API key, log level, version info
- AdminLogsSection: log viewer with filter/auto-refresh/export

CoinSearchChat (954→579 lines):
- CoinShowResultsGrid: show cards with calendar save
- CoinSuggestionGrid: suggestion cards with wishlist add

CoinDetailPage (1452→1082 lines):
- CoinDetailHeaderActions: back/purchase/sell/edit/delete
- CoinNumistaPanel: self-contained Numista search
- CoinActivityJournal: journal entries with add/delete

ImageProcessor (961→781 lines):
- ImageInputPanel: file drop zone + URL input

All components use typed props/emits. vue-tsc passes clean.