### PR TITLE
feat: add coin lookup and configurable coin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Organize coins with rich metadata: denomination, ruler, material, weight, inscri
 ### 🎯 Discovery & Acquisition
 **AI Coin Search** — Chat with an agent to find real dealer listings matching your description. Imports structured results with images, metadata, prices, and candidate catalog references.
 
+**Coin Lookup** — Take or upload photos at a show to identify a coin or NGC Ancients slab. The app extracts NGC certification numbers, links to official NGC verification, enriches non-NGC lookups with Numista matches, and can save results to your wish list or collection. **[Learn more →](docs/features/coin-lookup.md)**
+
 **Wish List** — Track coins you want with automatic availability checking, AI search, price tracking, and one-click purchase-to-collection conversion.
 
 **Auction Tracking** — Monitor NumisBids lots through bidding lifecycle with status workflow, price alerts, bid reminders, auto-conversion to collection when won. **[Learn more →](docs/features/wish-list.md)**
@@ -82,6 +84,7 @@ Organize coins with rich metadata: denomination, ruler, material, weight, inscri
 **Daily Featured Coins** — Automated scheduler to rediscover forgotten coins.
 **Image Operations** — Background removal, circle clipping, automatic extraction.
 **Bulk Operations** — Multi-select for batch tagging, status changes, exports.
+**Configurable Coin Properties** — Admin-defined Era and Category option lists for tailoring collection metadata.
 
 ---
 
@@ -90,6 +93,7 @@ Organize coins with rich metadata: denomination, ruler, material, weight, inscri
 | Feature | Collection | Wish List | Auctions | Social | Analytics | Admin | Mobile |
 |---------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | Create/Edit Coins | ✅ | ✅ | ✅ | — | — | ✅ | ✅ |
+| Coin Lookup | ✅ | ✅ | — | — | — | ✅ | ✅ |
 | AI Analysis | ✅ | ✅ | ✅ | — | — | — | ✅ |
 | Search & Filter | ✅ | ✅ | ✅ | — | — | — | ✅ |
 | Tags & Sets | ✅ | ✅ | ❌ | — | ✅ | — | ✅ |
@@ -105,6 +109,8 @@ Organize coins with rich metadata: denomination, ruler, material, weight, inscri
 ## 🆕 What's New
 
 **v2.0 (Latest)**
+- **Coin Lookup** — Photo-based show workflow for NGC Ancients cert extraction, official NGC verification links, Numista fallback matches, and saving lookups to wish list or collection.
+- **Configurable Coin Properties** — Admin-managed Era and Category options used by coin forms and lookup saves.
 - **Coin Sets** — Organize coins into themed collections with trend tracking and completion analysis. Open, defined, goal, and smart (rule-based) set types. Snapshot history and value milestones.
 - **Health Scorecard** — Track AI coverage, image coverage, and metadata completeness.
 - Enhanced AI agent teams (grading, price trends, gap analysis, photography guide, similar lots).
@@ -184,6 +190,7 @@ Run `task --list` to see all targets.
 |------|------|
 | **Features (per-area detail)** | [`docs/features/INDEX.md`](docs/features/INDEX.md) — Browse by feature area |
 | Feature: Collection Management | [`docs/features/collection-management.md`](docs/features/collection-management.md) |
+| Feature: Coin Lookup | [`docs/features/coin-lookup.md`](docs/features/coin-lookup.md) |
 | Feature: Coin Sets | [`docs/features/coin-sets.md`](docs/features/coin-sets.md) |
 | Feature: Wish List | [`docs/features/wish-list.md`](docs/features/wish-list.md) |
 | Feature: AI Analysis | [`docs/features/ai-analysis.md`](docs/features/ai-analysis.md) |

--- a/docs/features.md
+++ b/docs/features.md
@@ -14,6 +14,7 @@
 - [**Coin of the Day**](features/coin-of-the-day.md) — Daily featured coin scheduler
 
 ### 🎯 Discovery & Acquisition
+- [**Coin Lookup**](features/coin-lookup.md) — Photo-based lookup for NGC Ancients slabs and Numista matches
 - [**Wish List**](features/wish-list.md) — Track coins with AI search and availability checking
 - [**Auction Tracking**](features/auction-tracking.md) — Monitor NumisBids lots through bidding lifecycle
 - [**Sold Coins**](features/sold-coins.md) — Track sales with profit/loss analysis
@@ -38,7 +39,7 @@
 - [**User Profiles**](features/user-profiles.md) — Avatars, bio, privacy controls
 
 ### 🔐 Admin & Configuration
-- [**Admin Settings**](features/admin-settings.md) — User management, AI config, scheduling
+- [**Admin Settings**](features/admin-settings.md) — User management, AI config, scheduling, configurable coin properties
 - [**Authentication**](authentication.md) — JWT, WebAuthn, API keys
 - [**External Tool Server**](external-tool-server.md) — OpenAPI for external clients
 
@@ -79,6 +80,7 @@ Track coins you'd like to acquire with an AI-powered search agent:
 - **AI Coin Search Agent** — Click "Find Coins" to open a chat drawer powered by the AI agent service (Anthropic Claude or Ollama, configurable in Admin). Describe the coins you're looking for (e.g., "Roman silver denarii of Julius Caesar under $500") and the agent searches the web for real listings and references. Results appear as cards with images, metadata, estimated prices, and source links — each with an "Add to Wishlist" button for one-click import.
 - **Purchase** — Move a wishlist coin to your main collection when you acquire it. A styled purchase modal prompts for the purchase price and date, replacing the default browser confirm dialog.
 - **Wish List Gallery** — A separate page showing only wishlist items with sorting support.
+- **Coin Lookup Entry Point** — Launch Coin Lookup directly from the Wish List page to photograph a coin at a show and save the result as a wishlist item.
 - **Availability Check** — Click "Check Availability" on the Wish List page to verify whether listed coins are still for sale. The system visits each coin's reference URL and uses HTTP status codes plus keyword heuristics (sold indicators, buy-now buttons) to determine listing status. Ambiguous results are escalated to the AI agent (Team 6) for deeper analysis. Results show as a summary banner (available / unavailable / unknown counts) and per-card status indicators (green dot, red "Unavailable" overlay, amber dot). Unavailable coins can be dismissed to clear the status.
 - **Scheduled Checks** — Admins can enable automatic availability checks with a configurable start time and repeat interval (e.g., starting at 2:00 AM, repeating every 120 minutes). Run history with per-coin drill-down is available in the Admin Availability tab.
 
@@ -150,9 +152,17 @@ To enable the search agent:
 2. Configure it in **Admin → AI Configuration → Anthropic API Key**
 3. Optionally select a different model or customize the agent prompt in Admin settings
 
+## Coin Lookup
+
+Use **Lookup Coin** from the main menu or Wish List page when evaluating a coin at a show. Capture or upload one or more photos of the coin or slab label. The app sends the images through the configured vision provider, extracts visible label text and coin fields, and looks for NGC Ancients certification numbers.
+
+When an NGC cert is found, the result includes the normalized cert and an official NGC Ancients verification link in the form `https://www.ngccoin.com/certlookup/{compactCert}/NGCAncients/`. The lookup returns immediately after NGC extraction instead of waiting on catalog enrichment. When no NGC cert is found, the app uses configured Numista access to search for possible catalog matches and displays links to Numista entries.
+
+Lookup results can be saved directly to the Wish List or Collection. The save flow creates the coin first, uploads the captured photos, then adds generated NGC or Numista structured references.
+
 ## Numista Catalog Integration
 
-Look up coins in the [Numista](https://en.numista.com/) catalog directly from any coin's detail page. The search uses the coin's name, denomination, and ruler to find matching entries, displaying thumbnails and linking to full catalog pages.
+Look up coins in the [Numista](https://en.numista.com/) catalog directly from any coin's detail page or as a fallback from Coin Lookup when no NGC cert is detected. The search uses coin names, denominations, rulers, and extracted fields to find matching entries, displaying thumbnails and linking to full catalog pages.
 
 To enable Numista lookup:
 
@@ -213,6 +223,7 @@ The first registered user is the admin. Admins can access **Admin** to manage:
 - **Users** — View all registered users, delete accounts, and reset passwords.
 - **AI Configuration** — Select your AI Provider: Anthropic (recommended) or Ollama. Configure Ollama (URL, vision model, timeout, analysis prompts), Anthropic (API key, model dropdown, editable agent prompt for the search agent), and SearXNG URL for Ollama web search.
 - **System** — Set the application log level (trace, debug, info, warn, error) and configure the Numista API key for catalog lookups.
+- **Coin Properties** — Configure newline-delimited Category and Era option lists used by coin forms and lookup saves.
 - **Logs** — View real-time application logs with level filtering, auto-refresh, and log export.
 - **Availability Checks** — Enable/disable automatic wishlist availability checking, configure the daily start time and repeat interval, and view paginated run history with per-coin drill-down results (URL, status, reason, HTTP code, whether the AI agent was used).
 - **Valuation Runs** — Scheduled collection valuation using the AI agent. Configurable interval (default: 7 days), start time (default: 03:00), and max coins per run (default: 50). View run history with per-coin results. Trigger or cancel runs manually.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -14,6 +14,7 @@ The repository currently includes app icons in `src/web/public/` but does not in
 
 ## Discovery & Acquisition
 
+- **[Coin Lookup](coin-lookup.md)** — Photograph a coin or slab at a show, extract NGC Ancients certs, verify with NGC, and save to wish list or collection
 - **[Wish List](wish-list.md)** — Track coins you'd like to acquire with AI-powered search and availability checking
 - **[Auction Tracking](auction-tracking.md)** — Monitor NumisBids lots through bidding lifecycle with price alerts and reminders
 - **[Sold Coins](sold-coins.md)** — Track coins you've sold with profit/loss analysis
@@ -73,6 +74,7 @@ The repository currently includes app icons in `src/web/public/` but does not in
 | Collection CRUD | Shipped | v1.0 |
 | AI Analysis (Ollama/Anthropic) | Shipped | v1.0 |
 | Wish List with AI Search | Shipped | v1.0 |
+| Coin Lookup | Shipped | v2.0 |
 | Auction Tracking | Shipped | v1.0 |
 | Social Features | Shipped | v1.0 |
 | External Tool Server | Shipped | v1.0 |

--- a/docs/features/admin-settings.md
+++ b/docs/features/admin-settings.md
@@ -40,6 +40,14 @@ Admin Settings are accessed by the first registered user (admin) and provide con
 - **Log Level** — trace, debug, info, warn, error
 - **Numista API Key** — For coin catalog lookups
 
+## Coin Properties Tab
+
+**Configurable Coin Metadata:**
+- **Categories** — Newline-delimited list of category values shown in coin forms
+- **Eras** — Newline-delimited list of era values shown in coin forms
+- **Lookup Compatibility** — Coin Lookup normalizes extracted era values to backend-supported save values while user-facing forms use the configured lists
+- **Defaults** — Roman, Greek, Byzantine, Modern, Other categories and ancient, medieval, modern eras are available by default
+
 ## Logs Tab
 
 **Real-Time Logging:**
@@ -106,4 +114,4 @@ POST   /admin/valuation-runs/:id/cancel # Cancel run
 - No multi-admin support currently
 - All settings are per-instance (not per-user)
 
-See also: [AI Coin Analysis](ai-analysis.md), [Auction Tracking](auction-tracking.md), [Authentication](../authentication.md)
+See also: [AI Coin Analysis](ai-analysis.md), [Auction Tracking](auction-tracking.md), [Coin Lookup](coin-lookup.md), [Authentication](../authentication.md)

--- a/docs/features/coin-lookup.md
+++ b/docs/features/coin-lookup.md
@@ -1,0 +1,83 @@
+# Coin Lookup
+
+> Capture a coin or slab photo at a show, extract lookup details, verify NGC Ancients certs, and save the result to your wish list or collection.
+
+## Overview
+
+Coin Lookup is designed for in-person acquisition workflows. When you see a coin at a show, open **Lookup Coin**, take or upload photos, review the extracted details, and save the result without leaving the show-floor workflow.
+
+## Entry Points
+
+- **Main menu** — Open **Lookup Coin** from the primary app navigation
+- **Wish List** — Open lookup from the Wish List page when evaluating a potential purchase
+
+## Lookup Flow
+
+1. Capture one or more photos with the device camera, or upload existing images
+2. The Go API sends the images to the configured vision provider through the agent proxy
+3. The response extracts visible slab/label text, candidate coin fields, and NGC certification data when present
+4. The results page shows extracted details, verification links, and possible catalog matches
+5. Save the result to the Wish List or Collection
+
+## NGC Ancients Verification
+
+When the image contains an NGC Ancients certification number, Coin Lookup:
+
+- Normalizes compact and hyphenated cert formats
+- Displays the normalized cert on the results page
+- Generates an official NGC Ancients verification URL:
+
+```text
+https://www.ngccoin.com/certlookup/{compactCert}/NGCAncients/
+```
+
+For example, `2412821-034` becomes:
+
+```text
+https://www.ngccoin.com/certlookup/2412821034/NGCAncients/
+```
+
+NGC does not currently expose a public developer API for cert lookup, so the app links to the official NGC verification page rather than scraping NGC data.
+
+## Numista Fallback
+
+When no NGC cert is detected, Coin Lookup uses extracted fields such as ruler, denomination, and era to search Numista if a Numista API key is configured.
+
+Possible Numista matches show:
+
+- Title
+- Issuer
+- Year range
+- Thumbnail when available
+- Link to the Numista catalog entry
+
+NGC-slab lookups return as soon as the cert is extracted; they do not wait for Numista enrichment.
+
+## Saving Results
+
+Coin Lookup supports:
+
+- **Add to Wishlist** — Creates a wishlist coin from the lookup
+- **Add to Collection** — Creates a collection coin from the lookup
+- **Captured Images** — Uploads captured photos after the coin is created
+- **Structured References** — Adds generated NGC or Numista references after the coin is created
+
+The save flow creates the coin first, then attaches images and references. This keeps the normal coin-create payload valid and avoids coupling lookup-only data to the core coin API.
+
+## Configuration
+
+### Required
+
+- An AI vision provider configured in **Admin → AI Configuration**
+
+### Optional
+
+- **Numista API Key** in **Admin → System** for fallback catalog matches
+- Admin-configured Category and Era values in **Admin → Coin Properties**
+
+## Related Features
+
+- [Wish List](wish-list.md) — Save lookups as potential acquisitions
+- [Numista Catalog Lookup](numista-integration.md) — Catalog reference integration
+- [Admin Settings](admin-settings.md) — AI provider, Numista API key, and coin property configuration
+- [Camera Capture](camera-capture.md) — Device camera support in PWA mode

--- a/docs/features/numista-integration.md
+++ b/docs/features/numista-integration.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Numista Catalog Lookup integrates with the Numista coin database to help you find matching coins and add structured catalog references to your collection.
+Numista Catalog Lookup integrates with the Numista coin database to help you find matching coins and add structured catalog references to your collection. Coin Lookup also uses Numista as a fallback enrichment source when a photo does not contain an NGC Ancients certification number.
 
 ## Features
 
@@ -13,6 +13,7 @@ Numista Catalog Lookup integrates with the Numista coin database to help you fin
 - **Browse Results** — View thumbnails, title, issuer, year range
 - **Link to Catalog** — Direct link to full Numista entry
 - **Add References** — Import catalog ID as structured reference
+- **Lookup Fallback** — Coin Lookup can show Numista matches when no NGC cert is detected
 
 ## Setup
 
@@ -34,6 +35,14 @@ Numista Catalog Lookup integrates with the Numista coin database to help you fin
 5. Click result to view full entry on Numista
 6. Click **Add Reference** to import as a structured reference
 
+### From Coin Lookup
+
+1. Open **Lookup Coin** from the main menu or Wish List page
+2. Capture or upload coin photos
+3. If no NGC cert is detected, the backend searches Numista with extracted coin fields
+4. Possible matches appear with thumbnails and links to Numista entries
+5. Saving the lookup adds selected/generated Numista references after the coin is created
+
 ## API Endpoints
 
 ```
@@ -50,6 +59,7 @@ GET    /api/numista/search           # Search Numista by query
 ## Related Features
 
 - [Coin Details](coin-details.md) — Structured references
+- [Coin Lookup](coin-lookup.md) — Photo-based lookup with Numista fallback matches
 - [AI Coin Analysis](ai-analysis.md) — Candidate references from search
 - [Admin Settings](admin-settings.md) — Configure API key
 

--- a/docs/features/wish-list.md
+++ b/docs/features/wish-list.md
@@ -23,12 +23,19 @@ The Wish List helps collectors systematically track and acquire coins. It integr
 5. Each result shows: image, metadata, estimated price, source link
 6. Click **Add to Wishlist** to import with one click
 
+#### Coin Lookup
+1. Navigate to **Wish List → Lookup Coin**
+2. Take or upload photos of a coin or certification slab
+3. Review extracted details, NGC verification links, or Numista fallback matches
+4. Click **Add to Wishlist** to create a wishlist coin with captured photos and structured references
+
 ### Viewing Your Wish List
 
 - **Dedicated Gallery** — Separate view from main collection
 - **Same Filters/Sort** — Full-text search, category filtering, sorting by price/date
 - **Status Indicators** — Show if coin is actively listed, unavailable, or unknown
 - **Price Tracking** — Note current asking prices and compare over time
+- **Lookup Saves** — Coins saved from Coin Lookup include captured photos and generated NGC or Numista references
 
 ## Availability Checking
 

--- a/src/api/handlers/coins.go
+++ b/src/api/handlers/coins.go
@@ -151,7 +151,7 @@ func (h *CoinHandler) List(c *gin.Context) {
 		}
 	}
 	if s := c.Query("set"); s != "" {
-		if setID, err := strconv.ParseUint(s, 10, 64); err == nil {
+		if setID, err := strconv.ParseUint(s, 10, strconv.IntSize); err == nil {
 			v := uint(setID)
 			filters.SetID = &v
 		}

--- a/src/api/services/coin_lookup_service.go
+++ b/src/api/services/coin_lookup_service.go
@@ -111,9 +111,11 @@ func (s *CoinLookupService) Lookup(ctx context.Context, userID uint, req CoinLoo
 
 	logger.Info("coin-lookup", "Extracted data: NGC=%v, LabelText=%v", extractedData.NGC != nil, extractedData.LabelText != "")
 
-	// 2. Build Numista search query from extracted fields
+	// 2. Build Numista search query from extracted fields.
+	// NGC-slab lookups should return as soon as cert extraction succeeds; Numista
+	// enrichment is only needed when there is no cert to verify directly.
 	numistaCandidates := []NumistaCandidate{}
-	if extractedData.CoinFields != nil {
+	if extractedData.NGC == nil && extractedData.CoinFields != nil {
 		candidates, err := s.searchNumista(ctx, extractedData.CoinFields)
 		if err != nil {
 			logger.Warn("coin-lookup", "Numista search failed: %v", err)
@@ -245,7 +247,7 @@ func (s *CoinLookupService) extractNGCCert(analysis string) *NGCData {
 				ngcData := &NGCData{
 					CertNumber:     certStr,
 					NormalizedCert: normalized,
-					LookupURL:      fmt.Sprintf("https://www.ngccoin.com/certlookup/%s/", normalized),
+					LookupURL:      ngcLookupURL(normalized),
 				}
 				if grade, ok := parsed["ngcGrade"].(string); ok && grade != "" && grade != "null" {
 					ngcData.Grade = grade
@@ -267,7 +269,7 @@ func (s *CoinLookupService) extractNGCCert(analysis string) *NGCData {
 			return &NGCData{
 				CertNumber:     certNumber,
 				NormalizedCert: normalized,
-				LookupURL:      fmt.Sprintf("https://www.ngccoin.com/certlookup/%s/", normalized),
+				LookupURL:      ngcLookupURL(normalized),
 			}
 		}
 	}
@@ -285,6 +287,10 @@ func normalizeCertNumber(cert string) string {
 		return cert
 	}
 	return ""
+}
+
+func ngcLookupURL(cert string) string {
+	return "https://www.ngccoin.com/certlookup/?CertNumber=" + url.QueryEscape(cert)
 }
 
 // extractLabelText extracts visible label text from analysis.

--- a/src/api/services/coin_lookup_service.go
+++ b/src/api/services/coin_lookup_service.go
@@ -89,8 +89,10 @@ type CoinLookupResponse struct {
 }
 
 var (
-	// Matches NGC cert formats: 823160-093, 1234567-001, etc.
-	ngcCertRegex = regexp.MustCompile(`\b(\d{6,7}-\d{3})\b`)
+	// Matches NGC cert formats: 823160-093, 1234567-001, 2412821034, etc.
+	ngcCertRegex      = regexp.MustCompile(`\b(\d{6,7}-?\d{3})\b`)
+	ngcCertExactRegex = regexp.MustCompile(`^(\d{6,7})-?(\d{3})$`)
+	compactCertRegex  = regexp.MustCompile(`^\d{9,10}$`)
 )
 
 // Lookup performs coin lookup from images: extracts NGC cert, label text, and enriches with Numista.
@@ -277,20 +279,35 @@ func (s *CoinLookupService) extractNGCCert(analysis string) *NGCData {
 	return nil
 }
 
-// normalizeCertNumber normalizes NGC cert numbers (e.g., 823160-093 → 823160-093).
+// normalizeCertNumber normalizes NGC cert numbers (e.g., 823160093 -> 823160-093).
 func normalizeCertNumber(cert string) string {
 	cert = strings.TrimSpace(cert)
 	// Remove any extra spaces or formatting
 	cert = strings.ReplaceAll(cert, " ", "")
-	// Validate format: XXXXXXX-XXX or XXXXXX-XXX
-	if ngcCertRegex.MatchString(cert) {
+
+	matches := ngcCertExactRegex.FindStringSubmatch(cert)
+	if len(matches) == 3 {
+		return matches[1] + "-" + matches[2]
+	}
+	return ""
+}
+
+func compactCertNumber(cert string) string {
+	cert = strings.TrimSpace(cert)
+	cert = strings.ReplaceAll(cert, " ", "")
+	cert = strings.ReplaceAll(cert, "-", "")
+	if compactCertRegex.MatchString(cert) {
 		return cert
 	}
 	return ""
 }
 
 func ngcLookupURL(cert string) string {
-	return "https://www.ngccoin.com/certlookup/?CertNumber=" + url.QueryEscape(cert)
+	compact := compactCertNumber(cert)
+	if compact == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://www.ngccoin.com/certlookup/%s/NGCAncients/", url.PathEscape(compact))
 }
 
 // extractLabelText extracts visible label text from analysis.

--- a/src/api/services/coin_lookup_service_test.go
+++ b/src/api/services/coin_lookup_service_test.go
@@ -103,7 +103,7 @@ func TestExtractNGCCert(t *testing.T) {
 				if result.NormalizedCert != tt.wantNum {
 					t.Errorf("extractNGCCert().NormalizedCert = %q, want %q", result.NormalizedCert, tt.wantNum)
 				}
-				expectedURL := "https://www.ngccoin.com/certlookup/" + tt.wantNum + "/"
+				expectedURL := "https://www.ngccoin.com/certlookup/?CertNumber=" + tt.wantNum
 				if result.LookupURL != expectedURL {
 					t.Errorf("extractNGCCert().LookupURL = %q, want %q", result.LookupURL, expectedURL)
 				}
@@ -162,6 +162,14 @@ func TestExtractLabelText(t *testing.T) {
 				t.Errorf("extractLabelText() = %q, want %q", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestNGCLookupURLUsesCertNumberQuery(t *testing.T) {
+	got := ngcLookupURL("823160-093")
+	want := "https://www.ngccoin.com/certlookup/?CertNumber=823160-093"
+	if got != want {
+		t.Errorf("ngcLookupURL() = %q, want %q", got, want)
 	}
 }
 

--- a/src/api/services/coin_lookup_service_test.go
+++ b/src/api/services/coin_lookup_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -23,6 +24,16 @@ func TestNormalizeCertNumber(t *testing.T) {
 		{
 			name:     "cert with spaces (normalized)",
 			input:    "823160 - 093",
+			expected: "823160-093",
+		},
+		{
+			name:     "compact cert with 10 digits",
+			input:    "2412821034",
+			expected: "2412821-034",
+		},
+		{
+			name:     "compact cert with 9 digits",
+			input:    "823160093",
 			expected: "823160-093",
 		},
 		{
@@ -84,6 +95,12 @@ func TestExtractNGCCert(t *testing.T) {
 			wantNum:  "1234567-001",
 		},
 		{
+			name:     "raw text with compact cert number",
+			input:    "This is an NGC Ancients slab with cert number 2412821034 clearly visible.",
+			wantCert: true,
+			wantNum:  "2412821-034",
+		},
+		{
 			name:     "no cert number",
 			input:    "This coin has no NGC certification.",
 			wantCert: false,
@@ -103,7 +120,7 @@ func TestExtractNGCCert(t *testing.T) {
 				if result.NormalizedCert != tt.wantNum {
 					t.Errorf("extractNGCCert().NormalizedCert = %q, want %q", result.NormalizedCert, tt.wantNum)
 				}
-				expectedURL := "https://www.ngccoin.com/certlookup/?CertNumber=" + tt.wantNum
+				expectedURL := "https://www.ngccoin.com/certlookup/" + strings.ReplaceAll(tt.wantNum, "-", "") + "/NGCAncients/"
 				if result.LookupURL != expectedURL {
 					t.Errorf("extractNGCCert().LookupURL = %q, want %q", result.LookupURL, expectedURL)
 				}
@@ -165,9 +182,9 @@ func TestExtractLabelText(t *testing.T) {
 	}
 }
 
-func TestNGCLookupURLUsesCertNumberQuery(t *testing.T) {
+func TestNGCLookupURLUsesAncientsPath(t *testing.T) {
 	got := ngcLookupURL("823160-093")
-	want := "https://www.ngccoin.com/certlookup/?CertNumber=823160-093"
+	want := "https://www.ngccoin.com/certlookup/823160093/NGCAncients/"
 	if got != want {
 		t.Errorf("ngcLookupURL() = %q, want %q", got, want)
 	}

--- a/src/api/services/internal_token_service.go
+++ b/src/api/services/internal_token_service.go
@@ -62,7 +62,7 @@ func (s *InternalTokenService) Verify(token string) (uint, error) {
 	signatureB64 := parts[2]
 
 	// Parse userID
-	userIDInt, err := strconv.ParseUint(userIDStr, 10, 64)
+	userIDInt, err := strconv.ParseUint(userIDStr, 10, strconv.IntSize)
 	if err != nil {
 		return 0, ErrInvalidInternalToken
 	}

--- a/src/web/src/pages/CoinLookupPage.vue
+++ b/src/web/src/pages/CoinLookupPage.vue
@@ -110,7 +110,7 @@
               <span>NGC Certification: {{ ngcCertNumber }}</span>
             </div>
             <a
-              :href="results.extractedData.ngc?.lookupURL ?? `https://www.ngccoin.com/certlookup/${ngcCertNumber}/`"
+              :href="ngcLookupUrl"
               target="_blank"
               rel="noopener noreferrer"
               class="btn btn-secondary btn-sm"
@@ -246,6 +246,11 @@ const results = ref<CoinLookupResponse | null>(null)
 
 const ngcCertNumber = computed(() => {
   return results.value?.extractedData.ngc?.normalizedCert ?? null
+})
+
+const ngcLookupUrl = computed(() => {
+  if (!ngcCertNumber.value) return ''
+  return `https://www.ngccoin.com/certlookup/?CertNumber=${encodeURIComponent(ngcCertNumber.value)}`
 })
 
 const draft = computed<CoinMutationPayload>(() => results.value?.prefilledDraft ?? {})

--- a/src/web/src/pages/CoinLookupPage.vue
+++ b/src/web/src/pages/CoinLookupPage.vue
@@ -210,7 +210,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { lookupCoin, createCoin, uploadImage } from '@/api/client'
+import { lookupCoin, createCoin, createCoinReference, uploadImage } from '@/api/client'
 import type { CoinLookupResponse, CoinMutationPayload } from '@/types'
 import {
   Camera,
@@ -257,6 +257,13 @@ const ngcLookupUrl = computed(() => {
 
 const draft = computed<CoinMutationPayload>(() => results.value?.prefilledDraft ?? {})
 const numistaResults = computed(() => results.value?.numistaCandidates ?? [])
+
+function normalizedEra(value: unknown): 'ancient' | 'medieval' | 'modern' | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'ancient' || normalized === 'medieval' || normalized === 'modern') return normalized
+  return undefined
+}
 
 function handleBack() {
   if (state.value === 'results') {
@@ -345,16 +352,21 @@ async function createCoinFromLookup(isWishlist: boolean) {
     name: draft.value.name || 'Lookup Coin',
     category: draft.value.category || 'Other',
     material: draft.value.material || 'Other',
+    era: normalizedEra(draft.value.era),
     isWishlist,
-    references: results.value.candidateReferences ?? [],
   }
   const created = await createCoin(payload)
+  const coinId = created.data.id
 
   for (let index = 0; index < capturedImages.value.length; index += 1) {
     const image = capturedImages.value[index]?.file
     if (!image) continue
     const imageType = index === 0 ? 'obverse' : index === 1 ? 'reverse' : 'detail'
-    await uploadImage(created.data.id, image, imageType, index === 0, false)
+    await uploadImage(coinId, image, imageType, index === 0, false)
+  }
+
+  for (const reference of results.value.candidateReferences ?? []) {
+    await createCoinReference(coinId, reference)
   }
 }
 

--- a/src/web/src/pages/CoinLookupPage.vue
+++ b/src/web/src/pages/CoinLookupPage.vue
@@ -249,8 +249,10 @@ const ngcCertNumber = computed(() => {
 })
 
 const ngcLookupUrl = computed(() => {
+  if (results.value?.extractedData.ngc?.lookupURL) return results.value.extractedData.ngc.lookupURL
   if (!ngcCertNumber.value) return ''
-  return `https://www.ngccoin.com/certlookup/?CertNumber=${encodeURIComponent(ngcCertNumber.value)}`
+  const compactCert = ngcCertNumber.value.replace(/\D/g, '')
+  return `https://www.ngccoin.com/certlookup/${encodeURIComponent(compactCert)}/NGCAncients/`
 })
 
 const draft = computed<CoinMutationPayload>(() => results.value?.prefilledDraft ?? {})


### PR DESCRIPTION
## Summary
Adds Coin Lookup and configurable coin-property documentation, plus the beta branch fixes for NGC Ancients verification URLs, faster NGC lookup returns, lookup save flows, CodeQL uint parsing alerts, and CodeQL request-forgery alerts on image proxy/scrape requests.

## Constitution self-check
- Principle(s) touched: I (Layered Architecture), V (Design Tokens), VII (Schema-Driven Contracts), XI (Security Hardening)
- Operational section(s): §17 Quality Gate, §21 Definition of Done
- ADR added? no

## Linked work
- Issue: n/a
- Spec: n/a
- Tasks completed: Coin Lookup implementation and beta bug-fix follow-ups

## Definition of Done (§21)
- [x] 1. Code compiles (`go build ./...`, `npm run build`, as applicable)
- [x] 2. Architecture tests green (`go test ./...` includes architecture tests)
- [x] 3. Unit tests pass (`go test -v ./...`, `npm.cmd run test`)
- [x] 4. Type checks pass (`vue-tsc --build` via `npm.cmd run type-check` / `npm.cmd run build`)
- [x] 5. Linters clean (`go vet ./...`, `npm.cmd run lint`; frontend has existing warnings, no errors)
- [x] 6. New service methods have >=1 unit test
- [x] 7. Public handlers have Swagger annotations
- [x] 8. If API changed: `task openapi` run and `docs/openapi.json` updated
- [ ] 9. If material design choice: ADR added in `docs/adr/` *(not applicable)*
- [ ] 10. Active `specs/NNN-*/tasks.md` items checked off *(not applicable)*
- [x] 11. `.squad/decisions/inbox/` written if cross-cutting decision made
- [x] 12. Secrets scan clean (no credentials in diff)
- [x] 13. Conventional commit messages
- [x] 14. `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer present when AI-assisted

## Notes for reviewer
- Coin Lookup intentionally links to official NGC pages instead of scraping; NGC Ancients URLs use `/certlookup/{compactCert}/NGCAncients/`.
- NGC-cert lookups return without waiting for Numista enrichment; Numista remains the fallback when no NGC cert is detected.
- Lookup saves now create the coin first, then attach images and generated references.
- The two CodeQL request-forgery alerts are addressed by the existing restricted outbound HTTP client plus inline suppression justification; outbound image URLs now also reject embedded credentials.