### PR TITLE
fix: preserve legacy coin eras during edits

### DIFF
--- a/src/api/handlers/coin_handler_test.go
+++ b/src/api/handlers/coin_handler_test.go
@@ -407,6 +407,46 @@ func TestCoinHandler_Update_CustomRegistryEraAccepted(t *testing.T) {
 	}
 }
 
+func TestCoinHandler_Update_PreservesUnchangedLegacyEra(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+
+	coin := models.Coin{Name: "Legacy Era", Category: models.CategoryRoman, Material: models.MaterialBronze, UserID: 1, Era: models.Era("Imperial")}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+
+	updates := map[string]interface{}{
+		"name":     "Updated Legacy Era",
+		"category": "Roman",
+		"material": "Bronze",
+		"era":      "Imperial",
+	}
+	body, _ := json.Marshal(updates)
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unchanged legacy era, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found: %v", err)
+	}
+	if found.Name != "Updated Legacy Era" {
+		t.Fatalf("expected updated name, got %q", found.Name)
+	}
+	if found.Era != models.Era("Imperial") {
+		t.Fatalf("expected legacy era to be preserved, got %q", found.Era)
+	}
+}
+
 func TestCoinHandler_Update_OtherUserCoin_NotFound(t *testing.T) {
 	router, db := setupCoinHandlerRouter(t)
 	createTestUser(t, db, 1, "owner")

--- a/src/api/services/coin_service.go
+++ b/src/api/services/coin_service.go
@@ -117,8 +117,11 @@ func (s *CoinService) UpdateCoin(existing *models.Coin, updates *models.Coin, us
 		}
 	}
 	updates.Era = models.Era(strings.TrimSpace(string(updates.Era)))
-	if err := s.validateCoinEra(updates.Era); err != nil {
-		return err
+	existingEra := models.Era(strings.TrimSpace(string(existing.Era)))
+	if updates.Era != existingEra {
+		if err := s.validateCoinEra(updates.Era); err != nil {
+			return err
+		}
 	}
 
 	return s.repo.DB().Transaction(func(tx *gorm.DB) error {

--- a/src/api/services/coin_service_test.go
+++ b/src/api/services/coin_service_test.go
@@ -348,3 +348,29 @@ func TestUpdateCoin_RejectsUnsupportedEraWhenCatalogRegistryEnabled(t *testing.T
 		t.Fatalf("expected ErrCoinInvalidEra, got %v", err)
 	}
 }
+
+func TestUpdateCoin_PreservesUnchangedLegacyEra(t *testing.T) {
+	db := setupTestDB(t)
+	svc := newTestCoinServiceWithCatalogRegistry(db)
+
+	coin := &models.Coin{Name: "Legacy Era Coin", UserID: 1, Era: models.Era("Imperial")}
+	if err := db.Create(coin).Error; err != nil {
+		t.Fatalf("setup: create legacy era coin failed: %v", err)
+	}
+
+	updates := &models.Coin{Name: "Updated Legacy Era Coin", Era: models.Era("Imperial")}
+	if err := svc.UpdateCoin(coin, updates, 1, "manual"); err != nil {
+		t.Fatalf("UpdateCoin should allow unchanged legacy era: %v", err)
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found: %v", err)
+	}
+	if found.Name != "Updated Legacy Era Coin" {
+		t.Fatalf("expected updated name, got %q", found.Name)
+	}
+	if found.Era != models.Era("Imperial") {
+		t.Fatalf("expected legacy era to be preserved, got %q", found.Era)
+	}
+}

--- a/src/web/src/components/CoinForm.vue
+++ b/src/web/src/components/CoinForm.vue
@@ -41,7 +41,7 @@
             <label class="form-label">Era</label>
             <select v-model="form.era" class="form-select">
               <option value="">Unspecified</option>
-              <option v-for="era in eraOptions" :key="era" :value="era">{{ era }}</option>
+              <option v-for="era in displayedEraOptions" :key="era" :value="era">{{ era }}</option>
             </select>
           </div>
         </div>
@@ -247,6 +247,14 @@ const storageLocationIdModel = computed({
   set: (value: string) => {
     props.form.storageLocationId = value === '' ? null : Number(value)
   },
+})
+
+const displayedEraOptions = computed(() => {
+  const currentEra = typeof props.form.era === 'string' ? props.form.era.trim() : ''
+  if (currentEra && !eraOptions.value.includes(currentEra)) {
+    return [currentEra, ...eraOptions.value]
+  }
+  return eraOptions.value
 })
 
 onMounted(async () => {

--- a/src/web/src/components/__tests__/CoinForm.test.ts
+++ b/src/web/src/components/__tests__/CoinForm.test.ts
@@ -25,4 +25,12 @@ describe('CoinForm', () => {
     expect(source).toContain('.form-group {')
     expect(source).toContain('min-width: 0;')
   })
+
+  it('keeps a current custom era selectable in the edit form', () => {
+    const source = fs.readFileSync(coinFormPath, 'utf8')
+
+    expect(source).toContain('v-for="era in displayedEraOptions"')
+    expect(source).toContain('const displayedEraOptions = computed(() => {')
+    expect(source).toContain('return [currentEra, ...eraOptions.value]')
+  })
 })

--- a/src/web/src/pages/EditCoinPage.vue
+++ b/src/web/src/pages/EditCoinPage.vue
@@ -17,7 +17,6 @@ import { ref, reactive, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CoinForm from '@/components/CoinForm.vue'
 import { getCoin, updateCoin, uploadImage, deleteImage, extractText } from '@/api/client'
-import { COIN_ERAS } from '@/types'
 import type { Coin } from '@/types'
 import { useDialog } from '@/composables/useDialog'
 
@@ -37,9 +36,6 @@ onMounted(async () => {
     Object.assign(form, res.data)
     if (form.purchaseDate) {
       form.purchaseDate = form.purchaseDate.substring(0, 10)
-    }
-    if (form.era && !COIN_ERAS.includes(form.era as (typeof COIN_ERAS)[number])) {
-      form.era = ''
     }
   } catch {
     await showAlert('Failed to load coin', { title: 'Error' })

--- a/src/web/src/pages/__tests__/EditCoinPage.test.ts
+++ b/src/web/src/pages/__tests__/EditCoinPage.test.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const editCoinPagePath = path.resolve(__dirname, '../EditCoinPage.vue')
+
+describe('EditCoinPage', () => {
+  it('does not clear legacy or custom era values when loading an existing coin', () => {
+    const source = fs.readFileSync(editCoinPagePath, 'utf8')
+
+    expect(source).not.toContain('COIN_ERAS')
+    expect(source).not.toContain('form.era = \'\'')
+  })
+})


### PR DESCRIPTION
## Summary
- Allow coin saves to preserve an unchanged legacy/custom era already stored on the coin
- Keep the current custom era selectable in the edit form instead of clearing it on load
- Add handler, service, and frontend regressions for the edit-save path that returned `era is not supported`

## Constitution
- Principle I + §17

## Tests
- go test -v ./handlers -run "TestCoinHandler_Update_(PreservesUnchangedLegacyEra|WithSetsPayloadPreservesMemberships)"
- go test -v ./services -run "TestUpdateCoin_(PreservesUnchangedLegacyEra|RejectsUnsupportedEraWhenCatalogRegistryEnabled|AcceptsCustomEraFromCatalogRegistry)"
- go test -v ./...
- npm.cmd test -- --run
- npm.cmd run build