### PR TITLE
fix: omit coin relationships on all update helpers

### DIFF
--- a/src/api/handlers/coin_handler_test.go
+++ b/src/api/handlers/coin_handler_test.go
@@ -27,7 +27,7 @@ func setupCoinHandlerTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to open test db: %v", err)
 	}
 	err = db.AutoMigrate(
-		&models.User{}, &models.Coin{}, &models.CoinImage{}, &models.CoinReference{}, &models.CatalogRegistry{},
+		&models.User{}, &models.StorageLocation{}, &models.Coin{}, &models.CoinImage{}, &models.CoinReference{}, &models.CatalogRegistry{},
 		&models.ValueSnapshot{}, &models.CoinJournal{},
 		&models.CoinValueHistory{}, &models.CoinComment{},
 		&models.AvailabilityResult{}, &models.AuctionLot{},
@@ -359,6 +359,73 @@ func TestCoinHandler_Update_WithSetsPayloadPreservesMemberships(t *testing.T) {
 	}
 	if memberships[0].AddedAt.IsZero() {
 		t.Fatal("membership AddedAt should remain populated after coin update")
+	}
+	if !memberships[0].AddedAt.Equal(originalMembership.AddedAt) {
+		t.Fatalf("membership AddedAt changed from %v to %v", originalMembership.AddedAt, memberships[0].AddedAt)
+	}
+}
+
+func TestCoinHandler_Update_StorageLocationWithSetsPreservesMemberships(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+
+	setRepo := repository.NewSetRepository(db)
+	coin := models.Coin{Name: "Stored Coin", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+	set := models.CoinSet{UserID: 1, Name: "Storage Test Set", SetType: models.CoinSetTypeOpen}
+	if err := setRepo.Create(&set); err != nil {
+		t.Fatalf("failed to seed set: %v", err)
+	}
+	if err := setRepo.AddCoinToSet(coin.ID, set.ID, 1, ""); err != nil {
+		t.Fatalf("failed to seed membership: %v", err)
+	}
+
+	var originalMembership models.CoinSetMembership
+	if err := db.Where("coin_id = ? AND set_id = ?", coin.ID, set.ID).First(&originalMembership).Error; err != nil {
+		t.Fatalf("failed to find seeded membership: %v", err)
+	}
+
+	updates := map[string]interface{}{
+		"name":              "Stored Coin",
+		"category":          "Roman",
+		"material":          "Silver",
+		"storageLocationId": 5,
+	}
+	body, _ := json.Marshal(updates)
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var updatedCoin models.Coin
+	if err := db.First(&updatedCoin, coin.ID).Error; err != nil {
+		t.Fatalf("updated coin not found: %v", err)
+	}
+	if updatedCoin.StorageLocationID == nil || *updatedCoin.StorageLocationID != 5 {
+		t.Fatalf("expected storage location 5, got %v", updatedCoin.StorageLocationID)
+	}
+
+	var memberships []models.CoinSetMembership
+	if err := db.Where("coin_id = ?", coin.ID).Find(&memberships).Error; err != nil {
+		t.Fatalf("failed to query memberships: %v", err)
+	}
+	if len(memberships) != 1 {
+		t.Fatalf("expected update to preserve exactly 1 membership, got %d", len(memberships))
+	}
+	if memberships[0].SetID != set.ID {
+		t.Fatalf("expected original set membership to remain, got set ID %d", memberships[0].SetID)
+	}
+	if memberships[0].AddedAt.IsZero() {
+		t.Fatal("membership AddedAt should remain populated after storage location update")
 	}
 	if !memberships[0].AddedAt.Equal(originalMembership.AddedAt) {
 		t.Fatalf("membership AddedAt changed from %v to %v", originalMembership.AddedAt, memberships[0].AddedAt)

--- a/src/api/repository/coin_repository.go
+++ b/src/api/repository/coin_repository.go
@@ -129,6 +129,10 @@ func (r *CoinRepository) DB() *gorm.DB {
 	return r.db
 }
 
+func omitCoinRelationships(db *gorm.DB) *gorm.DB {
+	return db.Omit("Tags", "Sets")
+}
+
 func applyOwnedFilterConditions(query *gorm.DB, filters OwnedCoinFilters) *gorm.DB {
 	if filters.Category != "" {
 		query = query.Where("category = ?", filters.Category)
@@ -337,7 +341,7 @@ func (r *CoinRepository) Create(coin *models.Coin) error {
 func (r *CoinRepository) Update(existing *models.Coin, updates *models.Coin) error {
 	// Relationship changes are managed through dedicated tag/set methods.
 	// Coin sets require explicit membership writes because AddedAt is NOT NULL.
-	if err := r.db.Model(existing).Omit("Tags", "Sets").Updates(updates).Error; err != nil {
+	if err := omitCoinRelationships(r.db.Model(existing)).Updates(updates).Error; err != nil {
 		return err
 	}
 	return r.db.Preload("Images").Preload("References").Preload("StorageLocation").First(existing, existing.ID).Error
@@ -345,7 +349,7 @@ func (r *CoinRepository) Update(existing *models.Coin, updates *models.Coin) err
 
 // UpdateField updates a single field on a coin.
 func (r *CoinRepository) UpdateField(coin *models.Coin, field string, value interface{}) error {
-	if err := r.db.Model(coin).Update(field, value).Error; err != nil {
+	if err := omitCoinRelationships(r.db.Model(coin)).Update(field, value).Error; err != nil {
 		return err
 	}
 	return r.db.Preload("Images").Preload("References").Preload("StorageLocation").First(coin, coin.ID).Error
@@ -353,7 +357,7 @@ func (r *CoinRepository) UpdateField(coin *models.Coin, field string, value inte
 
 // UpdateFields updates multiple fields on a coin using a map.
 func (r *CoinRepository) UpdateFields(coin *models.Coin, updates map[string]interface{}) error {
-	if err := r.db.Model(coin).Updates(updates).Error; err != nil {
+	if err := omitCoinRelationships(r.db.Model(coin)).Updates(updates).Error; err != nil {
 		return err
 	}
 	return r.db.Preload("Images").Preload("References").Preload("StorageLocation").First(coin, coin.ID).Error
@@ -361,7 +365,7 @@ func (r *CoinRepository) UpdateFields(coin *models.Coin, updates map[string]inte
 
 // UpdateStorageLocationID updates a coin storage-location foreign key, including clearing it.
 func (r *CoinRepository) UpdateStorageLocationID(coin *models.Coin, storageLocationID *uint) error {
-	if err := r.db.Model(coin).Update("storage_location_id", storageLocationID).Error; err != nil {
+	if err := omitCoinRelationships(r.db.Model(coin)).Update("storage_location_id", storageLocationID).Error; err != nil {
 		return err
 	}
 	return r.db.Preload("Images").Preload("References").Preload("StorageLocation").First(coin, coin.ID).Error

--- a/src/api/repository/coin_repository_test.go
+++ b/src/api/repository/coin_repository_test.go
@@ -15,7 +15,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to open test db: %v", err)
 	}
 	err = db.AutoMigrate(
-		&models.User{}, &models.Coin{}, &models.CoinImage{}, &models.CoinReference{},
+		&models.User{}, &models.StorageLocation{}, &models.Coin{}, &models.CoinImage{}, &models.CoinReference{},
 		&models.ValueSnapshot{}, &models.CoinJournal{},
 		&models.CoinValueHistory{}, &models.CoinComment{},
 		&models.AvailabilityResult{}, &models.AuctionLot{},
@@ -469,5 +469,123 @@ func TestCoinRepository_Update_WithSetsField(t *testing.T) {
 	db.Model(&models.CoinSetMembership{}).Where("coin_id = ? AND set_id = ?", coin.ID, set2.ID).Count(&set2Count)
 	if set2Count != 0 {
 		t.Error("set2 was added despite Omit('Sets'); update should not touch Sets")
+	}
+}
+
+func TestCoinRepository_UpdateHelpers_WithLoadedSetsDoNotSyncMemberships(t *testing.T) {
+	tests := []struct {
+		name   string
+		update func(repo *CoinRepository, coin *models.Coin) error
+		assert func(t *testing.T, db *gorm.DB, coinID uint)
+	}{
+		{
+			name: "UpdateField",
+			update: func(repo *CoinRepository, coin *models.Coin) error {
+				return repo.UpdateField(coin, "name", "Updated Field Coin")
+			},
+			assert: func(t *testing.T, db *gorm.DB, coinID uint) {
+				t.Helper()
+				var found models.Coin
+				if err := db.First(&found, coinID).Error; err != nil {
+					t.Fatalf("coin not found: %v", err)
+				}
+				if found.Name != "Updated Field Coin" {
+					t.Fatalf("expected updated name, got %q", found.Name)
+				}
+			},
+		},
+		{
+			name: "UpdateFields",
+			update: func(repo *CoinRepository, coin *models.Coin) error {
+				return repo.UpdateFields(coin, map[string]interface{}{"name": "Updated Fields Coin"})
+			},
+			assert: func(t *testing.T, db *gorm.DB, coinID uint) {
+				t.Helper()
+				var found models.Coin
+				if err := db.First(&found, coinID).Error; err != nil {
+					t.Fatalf("coin not found: %v", err)
+				}
+				if found.Name != "Updated Fields Coin" {
+					t.Fatalf("expected updated name, got %q", found.Name)
+				}
+			},
+		},
+		{
+			name: "UpdateStorageLocationID",
+			update: func(repo *CoinRepository, coin *models.Coin) error {
+				storageLocationID := uint(5)
+				return repo.UpdateStorageLocationID(coin, &storageLocationID)
+			},
+			assert: func(t *testing.T, db *gorm.DB, coinID uint) {
+				t.Helper()
+				var found models.Coin
+				if err := db.First(&found, coinID).Error; err != nil {
+					t.Fatalf("coin not found: %v", err)
+				}
+				if found.StorageLocationID == nil || *found.StorageLocationID != 5 {
+					t.Fatalf("expected storage location 5, got %v", found.StorageLocationID)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupTestDB(t)
+			coinRepo := NewCoinRepository(db)
+			setRepo := NewSetRepository(db)
+
+			coin := &models.Coin{
+				Name:     "Loaded Set Coin",
+				Category: models.CategoryRoman,
+				UserID:   1,
+			}
+			if err := coinRepo.Create(coin); err != nil {
+				t.Fatalf("Create coin failed: %v", err)
+			}
+
+			set := &models.CoinSet{UserID: 1, Name: "Loaded Set", SetType: models.CoinSetTypeOpen}
+			if err := setRepo.Create(set); err != nil {
+				t.Fatalf("Create set failed: %v", err)
+			}
+			if err := setRepo.AddCoinToSet(coin.ID, set.ID, 1, ""); err != nil {
+				t.Fatalf("AddCoinToSet failed: %v", err)
+			}
+
+			loaded, err := coinRepo.FindByID(coin.ID, 1)
+			if err != nil {
+				t.Fatalf("FindByID failed: %v", err)
+			}
+			if len(loaded.Sets) != 1 {
+				t.Fatalf("expected preloaded set, got %d", len(loaded.Sets))
+			}
+
+			var originalMembership models.CoinSetMembership
+			if err := db.Where("coin_id = ? AND set_id = ?", coin.ID, set.ID).First(&originalMembership).Error; err != nil {
+				t.Fatalf("membership not found: %v", err)
+			}
+
+			if err := tt.update(coinRepo, loaded); err != nil {
+				t.Fatalf("%s failed: %v", tt.name, err)
+			}
+			tt.assert(t, db, coin.ID)
+
+			var memberships []models.CoinSetMembership
+			if err := db.Where("coin_id = ?", coin.ID).Find(&memberships).Error; err != nil {
+				t.Fatalf("failed to query memberships: %v", err)
+			}
+			if len(memberships) != 1 {
+				t.Fatalf("expected exactly 1 membership after %s, got %d", tt.name, len(memberships))
+			}
+			if memberships[0].SetID != set.ID {
+				t.Fatalf("expected original membership to remain, got set ID %d", memberships[0].SetID)
+			}
+			if memberships[0].AddedAt.IsZero() {
+				t.Fatal("membership AddedAt should remain populated")
+			}
+			if !memberships[0].AddedAt.Equal(originalMembership.AddedAt) {
+				t.Fatalf("membership AddedAt changed from %v to %v", originalMembership.AddedAt, memberships[0].AddedAt)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Omit coin tag/set relationships from every coin update helper, not just the main Update path
- Fix storageLocationId updates on coins with preloaded set memberships
- Add repository regressions for UpdateField, UpdateFields, and UpdateStorageLocationID with loaded sets
- Add handler regression for PUT /api/coins/:id changing storageLocationId on a set member

## Constitution
- Principle I + §17

## Tests
- go test -v ./repository -run TestCoinRepository_UpdateHelpers_WithLoadedSetsDoNotSyncMemberships
- go test -v ./handlers -run "TestCoinHandler_Update_(StorageLocationWithSetsPreservesMemberships|WithSetsPayloadPreservesMemberships)"
- go test -v ./...
- go build ./...
- go vet ./...