### PR TITLE
feat: harden critical coin workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ src/api/uploads/
 src/web/node_modules/
 src/web/dist/
 
+# Playwright
+src/web/test-results/
+src/web/playwright-report/
+
 # Environment
 .env
 *.local

--- a/.squad/agents/aurelia/history.md
+++ b/.squad/agents/aurelia/history.md
@@ -33,6 +33,9 @@
 
 ## Learnings
 
+- **2026-06-09:** F013 browser workflow smoke uses Playwright under `src/web/e2e/` with route-level API mocks and authenticated localStorage setup, so login, manual add, and edit-one-field coverage can run without a live backend or production data.
+- **2026-06-09:** F013 frontend fixture data now lives in `src/web/src/test/fixtures/`. Coin builders return cloned `Coin` objects so component/browser tests can safely override nested images, references, tags, sets, and storage-location data without mutating shared golden fixtures.
+- **2026-06-09:** F013 add/edit workflow inventory: manual add and intake commit use the safer allowlisted `buildCoinPayload()`, but `EditCoinPage` still sends the whole loaded `Partial<Coin>` through `updateCoin(form.id!, form)`. `sanitizeCoin()` normalizes nullable scalars, strips `storageLocation`, defaults `currentValue`, and formats date-only values, but does not strip read-side fields such as `images`, `tags`, `sets`, ids, owner/status fields, or timestamps. F013 browser coverage should assert both user-visible results and request payloads, with tags/sets treated as detail-page association workflows rather than edit-form fields.
 - **2026-06-01 (CORRECTED):** The `showChat` defensive-reset theory below was WRONG and the fix was reverted. `App.vue.onMounted` runs once at app boot when `showChat` is already `false`, so `showChat.value = false` there is a no-op and cannot fix an intermittent mid-session freeze. The reported tap-blocking bug ("can't tap searched coin, can't rotate image") was actually caused by the **pull-to-refresh touch handler** in `src/web/src/composables/usePullToRefresh.ts`: it set `pulling=true` on touchstart but only cleared it on `touchend`. When the OS/browser hijacks a gesture (notification, multitouch, system back-swipe — common in heavy PWA use) `touchcancel` fires instead of `touchend`, leaving `pulling=true`; every later tap at scroll-top then hit a non-passive `touchmove` that called `e.preventDefault()`, which suppresses the synthesized click on mobile — so taps did nothing while the screen looked completely normal. Real fix (commit `9f906bf`): add a `touchcancel` handler that resets state, plus an `ENGAGE_SLOP` so `preventDefault()` only fires on a real pull, never on taps. Lesson: a non-passive `touchmove` that calls `preventDefault()` MUST be paired with a `touchcancel` reset and must never `preventDefault()` on a stationary tap.
 - **2026-06-01:** Module-level refs in composables do NOT reset on component unmount. When a module-level ref (exported from a composable like `useBulkSelect.ts`) gates global UI state or interaction behavior, the owning component MUST explicitly reset the ref in `onUnmounted()` or the state will leak across navigation. In CollectionPage, `bulkSelectActive` (module-level) stayed true after unmount while `selectMode` (local) was destroyed, causing the agent FAB in App.vue to stay hidden indefinitely. Fix: add `onUnmounted()` hook to reset module-level state, and defensive `onMounted()` reset to ensure clean state on every mount. Alternative patterns: move state to Pinia store with proper lifecycle, or avoid module-level refs entirely for interaction-gating state—pass via props/emits instead.
 - **2026-06-01:** Admin table layout overflow fix pattern: when action buttons overflow on narrow viewports, stack related data vertically in earlier columns rather than letting the table stretch horizontally. In `AdminCatalogsSection.vue`, moved the era pill below the catalog code in the same cell (flex column with `gap: 0.35rem` and `align-items: flex-start`) to free up horizontal space. Action buttons use `display: flex` with `flex-shrink: 0` and `justify-content: flex-end` to ensure they stay right-aligned and never overflow the boundary. This pattern keeps tables responsive without sacrificing action button visibility.
@@ -42,6 +45,12 @@
 - **2026-06-01:** Bulk assign location UI completed. Created `BulkLocationPickerModal.vue` (mirroring `BulkTagPickerModal.vue`) with "No location" clear option that emits `null`. Extended `bulkAction()` client signature to accept `opts?: { tagId?: number; storageLocationId?: number | null }` instead of a single `tagId` parameter, maintaining backward compatibility with existing call sites. Updated `BulkActionBar.vue` to add "Assign Location" button with `MapPin` icon emitting `location` event. Wired up `CollectionPage.vue` to load storage locations on mount, handle `@location` event, render `BulkLocationPickerModal`, and call `bulkAssignLocation(locationId)` which posts `{ coinIds, action: 'assign-location', storageLocationId }` to `/coins/bulk`. Build, type-check, and lint all pass (no new warnings).
 
 - **2026-06-01:** Backend storage-location migration convention: nullable `Coin` lookup FKs may exist without physical SQLite constraints (`constraint:-`) to avoid destructive rebuilds; frontend should continue treating `storageLocationId` as nullable and rely on API validation/errors.
+
+- **2026-06-09:** F013 Frontend Fixture Batch Completed
+   - Implemented 10 golden coin fixtures covering all lifecycle states (Roman, Greek, Byzantine, wishlist, sold, private, tagged, set-member, storage-location, image-heavy, valued, references, custom era)
+   - Fixtures live in `src/web/src/test/fixtures/coins.ts` with public export index
+   - Task T015 marked complete
+   - Orchestration log: `.squad/orchestration-log/2026-06-09T12-51-39Z-aurelia.md`
 
 - **2026-06-01:** Legacy catalog reference migration UI added to Settings → Data. New bordered section with Database and RefreshCw icons from lucide-vue-next, explanatory text (non-destructive, keeps originals, records outcomes in journal), trigger button with loading state, and result counts grid showing Succeeded (gold accent), Skipped, Failed (amber). Client function `migrateLegacyReferences()` calls `POST /references/migrate-legacy` and returns `LegacyMigrationResult { succeeded, skipped, failed, message? }` type. Results display uses design tokens (`--accent-gold`, `--text-muted`, `--bg-input`, `--border-subtle`, `--radius-sm`) and mobile-responsive stacked layout. Build and lint pass (no new warnings).
 
@@ -88,6 +97,20 @@ Completed three UI refinements to `CoinDetailPage.vue`:
 **Final Section Order:** Title → Inscription → Details (metadata) → Catalog References → Tags → Listing Status → Additional Details
 
 **Verification:** npm run type-check ✅, npm run build ✅, npm run lint ✅ (no new warnings)
+
+- **2026-06-09:** F013 Phase 4 Storage Location & Tags/Sets Workflows APPROVED
+   - T022: Storage Location edit workflow (Playwright E2E test with route-level mocks, fixture-backed)
+     - Navigate to coin detail → update storage location → save → verify summary updated
+     - Uses golden fixture data; no live backend required
+   - T023: Tags & Sets edit workflow (Playwright E2E test with route-level mocks, fixture-backed)
+     - Navigate to coin detail → add/remove tags and set membership → save → verify detail page reflects changes
+     - Uses golden fixture data; deterministic test coverage
+   - Coordinator pre-validation: npm type-check (99 tests ✅), npm test (99 tests ✅), npm run test:browser (6 Playwright tests ✅), git diff --check (✅ no whitespace issues)
+   - Maximus review: ✅ APPROVED — workflows deterministic and fixture-backed, mock extensions proportional, isolated from live backend, scope boundaries strict (storage/tags/sets only; no creep into T024–T028), Principles IV & VI satisfied
+   - Completion mark justified: all builds, tests, lints pass; no architecture violations; ready for merge
+   - Orchestration log: `.squad/orchestration-log/2026-06-09T13-32-43Z-maximus-t022-t023-approved.md`
+   - F013 Phase 4 progress: T018–T021 (infrastructure) + T022–T023 (storage/tags workflows) = 6 of 11 tasks complete
+   - Remaining: T024–T028 (edit validation, image upload, search/filter, mobile viewport, Taskfile, docs)
 
 **Status:** Code change UNCOMMITTED, awaiting Brian's approval. Decision merged to `.squad/decisions.md`.
 
@@ -163,3 +186,27 @@ Added navigator.permissions.query pre-check to CameraCaptureModal.vue. Persisted
   - **Type-Safety Blocker (QA finding):** `AdminPage.vue` lines 93–95 use `v-model` binding that conflicts with explicit prop binding (lines 96–98); both patterns cannot coexist in Vue. Fix: Remove `v-model` lines, keep nullish-coalesced props per Principle IV. Validation gate: `npm run type-check` must pass before merge.
   - **Coin Lookup UX Design:** New `/lookup` route (nav item between "Add Coin" and "Wishlist"). Single-page flow: Capture State (full-screen PWA camera with circular focus overlay) → Analyzing State (loading overlay) → Results State (read-only draft display + auto-triggered Numista search + quick actions). Quick actions: "Retake Photo", "Add to Collection" (navigate to `/add?draft=<id>`), "Add to Wishlist" (same with `?wishlist=true`). MVP scope: camera capture + file upload, AI draft generation (obverse only), auto-triggered Numista search. Defer: NGC, reverse capture, edit draft inline, lookup history, sharing. Backend dependency: Cassius to confirm `IntakeDraft` response includes persistent `id` for query param flow.
 
+- **2026-06-09:** F013 nullable scalar update contract: Go DTO pointer fields cannot distinguish omitted vs JSON `null` without raw-body presence tracking. For update DTOs, pair typed binding with raw `json.RawMessage` presence detection so explicit `null` clears nullable scalar DB columns while omitted fields preserve values.
+
+- **2026-06-09:** F013 Phase 4 Browser Workflow Infrastructure (T018–T021, APPROVED)
+  - Implemented Playwright-based browser testing framework under `src/web/e2e/`
+  - **Deliverables:** `playwright.config.ts`, `src/web/e2e/fixtures/workflow.ts` (reusable fixtures + mocked API routes), `src/web/e2e/workflows/auth.spec.ts` (login/logout), `src/web/e2e/workflows/coin-form.spec.ts` (add/edit coin), `test:browser` npm script
+  - **Test Coverage:** Golden fixtures with consistent mock data, no live backend or production data, frontend validation verified, all 4 Playwright tests passing
+  - **Hygiene:** Playwright-generated outputs (`src/web/test-results/`, `src/web/playwright-report/`) now properly ignored in `.gitignore`
+  - **Review Status:** Maximus BLOCKED on hygiene (stale docs, missing `.gitignore` entries), Brutus independently remediated, Maximus approved revision
+  - **Coordinator Validation:** `npm run type-check` ✅, `npm run test -- --run` 99 tests ✅, `npm run test:browser` 4 tests ✅, `git diff --check` ✅
+  - **Next Tasks:** T022–T028 (edit workflows, image upload, search/filter, mobile viewport, Taskfile, docs)
+
+- **2026-06-09:** F013 storage/tag browser workflows now extend the Playwright route mock with deterministic `/storage-locations`, `/tags`, `/sets`, tag attach/detach, and set add/remove handlers. T022 changes storage location A→B→None through `CoinForm`; T023 treats tags/sets as detail-page association edits and asserts captured mutation payloads plus visible chips.
+
+- **2026-06-09:** F013 final browser workflows (T024-T026) completed upload/delete image, collection search/filter, and mobile viewport edit Playwright coverage using the shared `src/web/e2e/fixtures/workflow.ts` mocked API state. Workflow mocks now record image uploads/deletes and coin query params, filter fixture coins deterministically, and CoinForm image controls have accessible labels for stable production-safe hooks. Learning: form image edits save the scalar update first, then delete removed/replaced images, then upload replacements; tests should assert all three effects.
+
+- **2026-06-09 (13:45:22):** F013 T024–T026 Image Upload, Search/Filter, Mobile Viewport Workflows APPROVED
+   - **T024 (Image Upload):** Manual add upload obverse/reverse with preview → save → verify persisted; manual edit replace/delete images → save → verify detail page reflects changes. Route-level mocked API state for image upload/delete handlers; fixture-backed deterministic File objects.
+   - **T025 (Search/Filter):** Navigate collection list → filter by category/era/material/name → verify results deterministically updated; route-level mocked filter handlers; fixture coins filtered by query params.
+   - **T026 (Mobile Viewport):** Playwright mobile device profile (375px width) → edit one field on coin detail → submit → verify responsive form layout, no scroll/overflow issues. Fixture-backed, deterministic mobile browser context.
+   - **Coordinator Pre-Validation:** npm type-check ✅ (99 tests), npm test ✅ (99 tests), npm run test:browser ✅ (9 Playwright tests), git diff-check ✅
+   - **Maximus Review:** ✅ APPROVED — workflows deterministic and fixture-backed, mocks proportional, scope boundaries strict (no creep into T027–T028), Principle VI + Principle IX satisfied
+   - **F013 Phase 4 Completion:** T018–T023 + T024–T026 = 9 of 11 Phase 4 tasks complete. T027–T028 (Taskfile + docs) pending.
+   - **Key Learning:** Image form edits perform scalar update first, then image deletes, then uploads; tests must assert all three side effects separately.
+   - **Orchestration Log:** `.squad/orchestration-log/2026-06-09T13-45-22Z-aurelia.md`

--- a/.squad/agents/brutus/history.md
+++ b/.squad/agents/brutus/history.md
@@ -41,3 +41,41 @@
   - **Test Infrastructure:** Added `CoinSet` and `CoinSetMembership` to `setupTestDB` AutoMigrate (previously missing from test schema).
   - **Test Results:** Targeted handler and repository regressions pass. Full Go API suite passes.
   - **Verdict:** The update path now has exact regression coverage for the production failure, not just repository-only coverage.
+
+- **2026-06-09:** F013 Critical Workflow Regression Strategy
+  - **Inventory:** Existing backend coverage already protects auth/ownership, basic create/update/delete, set preservation, storage-location update, custom/legacy era, value snapshots/history, and API client sanitization. Frontend coverage remains source/unit-level only for edit-era and list/wishlist rendering; no browser workflow suite exists.
+  - **Coverage Added:** Added focused handler regressions for `storageLocationId: null` clearing and structured reference replacement, and aligned coin handler test wiring with production reference/storage-location services.
+  - **Bug Found:** Explicit storage-location clearing did not persist NULL through `CoinRepository.UpdateStorageLocationID`; fixed the helper to update by explicit owned coin query and verified with handler tests.
+  - **Strategy:** Promoted F013 plan now carries the Brutus QA matrix: backend handler/service/repository tests first, golden fixtures second, deterministic browser tests third, F011 AI exploration later/advisory.
+  - **Validation:** `go test -v ./handlers ./repository ./services` ✅, `go test -v ./...` ✅, `go vet ./...` ✅ from `src/api`.
+- **2026-06-09:** F013 BLOCK resolution: presence-aware coin updates now use explicit GORM Select fields so false booleans, empty strings, and numeric zeros persist while omitted fields remain unchanged. Added HTTP handler and repository regressions for zero-value persistence plus storage-location null clear coverage remains dedicated.
+- **2026-06-09:** F013 backend regression completion: added HTTP coverage for typed DTO unknown/read-only/broad relationship fields, non-owned storage rejection, and manual current-value history/snapshot side effects; service coverage now proves storage ownership, reference normalization, and value snapshots; repository coverage proves `UpdateStorageLocationID(nil)` persists NULL and clears stale preloaded storage pointers. `go test -v ./...`, `go vet ./...`, and `git diff --check` passed from the required scopes.
+- **2026-06-09:** F013 Backend Regression Batch Completed
+   - Tasks T011, T012, T013 marked complete
+   - Regression test pattern documented for custom join-table fields
+   - Orchestration log: `.squad/orchestration-log/2026-06-09T12-51-39Z-brutus.md`
+
+- **2026-06-09:** F013 fixture docs/coverage slice: backend fixtures already had formal trait/persistence checks; frontend fixtures now have a catalog regression. Keep fixture matrices documented in `docs/testing.md` and defer browser workflow commands until Phase 4.
+- **2026-06-09 (13:09:16):** F013 Phase 3 golden fixtures complete (T016/T017). Updated `docs/testing.md` with F013 fixture matrix and usage patterns. Added `src/web/src/test/fixtures/coins.test.ts` covering fixture catalog/clone/association coverage. Approved by Maximus Lead Review. Go and web build/test/lint all pass. Orchestration log: `.squad/orchestration-log/2026-06-09T13-09-16-brutus.md`
+- **2026-06-09:** Playwright hygiene matters: keep `src/web/test-results/` and `src/web/playwright-report/` ignored, and remove stale docs once browser smoke coverage exists.
+
+- **2026-06-09:** F013 Phase 4 Browser Workflow Infrastructure Hygiene (T018–T021, APPROVED)
+  - **Strict Lockout Remediation:** Aurelia's browser suite BLOCKED by Maximus on .gitignore gaps + generated outputs present + stale docs TODO
+  - **Independent QA Fix:** Added `.gitignore` entries for Playwright output paths (`src/web/test-results/`, `src/web/playwright-report/`), removed generated `src/web/test-results/` directory, removed stale browser E2E TODO from `docs/testing.md`
+  - **Validation:** `npm run test:browser` — 4 tests passing, `git diff --check` — no formatting violations, design token changes only to `.gitignore` and docs
+  - **Principle Compliance:** Principle VI (Testing Infrastructure), Principle VIII (CI/CD & Build Hygiene), §18.2 (Strict Lockout)
+  - **Review Outcome:** Maximus Lead Re-review APPROVED revised state with all issues resolved
+  - **Key Learning:** Playwright generates deterministic artifacts (test-results/, playwright-report/, test data); must be `.gitignore`-excluded before integration into CI baseline
+
+- **2026-06-09:** F013 T027/T028 command/docs slice: added root `task test-critical-workflows` as the stable ergonomic alias for the existing web `npm run test:browser` Playwright suite. Documented that the suite uses mocked `/api/*` routes, authenticated localStorage setup, and frontend golden fixtures; initial coverage was authenticated session setup, manual add, one-field edit, storage-location set/clear, and tags/sets; later superseded by the final T024-T026 workflow docs once those tests landed.
+- **2026-06-09:** F013 final workflow docs BLOCK fix: keep `docs/testing.md` coverage bullets in lockstep with Playwright workflow additions so QA docs reflect the actual suite state.
+- **2026-06-09:** F013 Browser split acceptance review: verified Playwright workflow coverage, root `task test-critical-workflows` docs, spec/plan F011 guardrails, and passed `git diff --check`; marked both remaining Browser split checklist items complete.
+
+- **2026-06-09 (13:45:07):** F013 Docs Coverage Alignment — Strict Lockout Remediation APPROVED
+   - **Initial Block:** Maximus blocked F013 Phase 4 signoff because `docs/testing.md` listed T024–T026 under "Remaining Workflows" instead of "Current Coverage"; stale browser E2E TODO also present
+   - **Strict Lockout §18.2 Delegation:** Per constitution Strict Lockout process, Brutus delegated independent docs refresh
+   - **Remediation Actions:** Moved T024–T026 from "Remaining" → "Current Coverage" section; removed stale browser E2E TODO; kept Firefox/Safari multi-browser note as explicit backlog item
+   - **Validation:** git diff --check ✅ (no whitespace/line-ending issues); docs-only changes, no code impact
+   - **Lockout Clearance:** ✅ COMPLETE — docs state now reflects actual Playwright suite (9 tests), no stale backlog items, §18.2 process honored
+   - **Maximus Re-Review:** ✅ APPROVED — T024–T026 workflows + docs alignment internally consistent, Principle VIII (CI/CD & Build Hygiene) satisfied, all Quality Gate §17 checks passed
+   - **Orchestration Log:** `.squad/orchestration-log/2026-06-09T13-45-07Z-brutus.md`

--- a/.squad/agents/cassius/history.md
+++ b/.squad/agents/cassius/history.md
@@ -28,6 +28,7 @@
 
 - **2026-06-01:** #217 shared collection tool layer (internal token service, six internal endpoints, keyword gate removed), #217 Python ReAct agent completed end-to-end, #218 external tool server stack
 - **2026-06-01:** v1→v2 migration audit, Frontend navigation convention, Storage Location API pattern (per-user lookup table, nullable Coin.StorageLocationID FK, 409 conflict guard), Legacy RIC→CoinReference migration design + implementation + startup→endpoint refactor
+- **2026-06-09:** F013 Phase 3 golden fixtures complete (T014). Implemented Go fixture builders covering all 9 F013 golden coin names/traits with defensive cloning and optional deterministic DB persistence. Approved by Maximus Lead Review. Go build/test/vet all pass. Orchestration log: `.squad/orchestration-log/2026-06-09T13-09-16-cassius.md`
 - **2026-06-02:** Valuation freshness fix (CurrentValueUpdatedAt), Metadata health AI coverage fix (combined→obverse+reverse), AI coverage health scoring correction (per-side model finalized), checklist labels for missing side
 - **2026-06-08:** CodeQL request-forgery suppression comments added to `ProxyImage` and `ScrapeImage` handlers; SSRF protection layer remains unchanged
 
@@ -529,3 +530,43 @@ Addressed two CodeQL `go/request-forgery` alerts on `client.Do(req)` calls in `P
 - Join tables with custom NOT NULL columns require explicit management — use Omit() to prevent automatic sync
 - The pattern: when a join table has custom fields beyond FK pairs, manage it through explicit repository methods, not GORM association helpers
 - This follows the existing pattern where AddCoinToSet() already handled the proper insertion with AddedAt
+
+### 2026-06-09 — F013 backend typed mutation inventory
+
+Inventory for F013/AE006-AE013 found the primary risky broad binds in `CoinHandler.Create` and `CoinHandler.Update`, both currently binding `models.Coin`. Related paths include purchase/sell, bulk assign-location/tag/set, tag/set/reference endpoints, intake commit, collection proposal commit, valuation updates, and availability listing-status updates. The safest next slice is tests-first: add a one-field edit regression that seeds storage, tags, sets, references, images, era, and value data, then introduce explicit create/update request DTOs with patch-style presence tracking so omitted fields do not zero existing values while read-side fields are ignored.
+
+## 2026-06-09 — F013 Typed Coin DTO Slice
+
+Added explicit `CoinCreateRequest`/`CoinUpdateRequest` handler DTOs and mapped them back to the existing `CoinService` path so storage-location, era, reference, value-snapshot, tag, and set behavior stays centralized. Important regression: one-field coin updates now ignore broad read-side payload fields (`id`, `userId`, images, tags, sets, storageLocation, timestamps, AI analysis) while preserving existing associations and recording the normal value snapshot.
+
+## 2026-06-09 — F013 Batch Completion: Typed DTOs, Zero-Value Persistence, Nullable Semantics
+
+**Session:** F013 critical workflow hardening, backend typed DTO/revision batch
+**Agents:** Cassius (initial DTO contract), Maximus (review + block), Brutus (zero-value revision), Aurelia (nullable semantics), Maximus (re-review + approval)
+
+**Outcome:** ✅ APPROVED, block cleared
+
+**Sequence:**
+1. Cassius: Implemented typed `CoinCreateRequest` and `CoinUpdateRequest` DTOs, switched handlers away from broad `models.Coin` binding
+2. Maximus: BLOCKED — Model-shaped Updates risked skipping explicit zero values (false, "", 0); required presence-aware Select path + regressions
+3. Brutus: REVISED — Added presence-aware selected fields, repository Select path, handler/repository regressions for false/empty/zero persistence
+4. Aurelia: REVISED — Added explicit JSON null clear semantics for allowlisted nullable scalar fields (purchasePrice, currentValue, dates, dimensions)
+5. Maximus: RE-APPROVED — Semantics explicit, simple, tested; omitted fields preserve, JSON null clears allowlisted scalars; block cleared
+
+**Architecture:**
+- Handlers map DTO field presence to GORM `Select()` field list
+- Omitted fields automatically preserved (standard PATCH semantics)
+- Allowlisted nullable scalars accept JSON null clear: purchasePrice, currentValue, purchaseDate, soldPrice, soldDate, weightGrams, diameterMm
+- storageLocationId clear and references replacement remain on dedicated service/repository paths
+
+**Validation:**
+- ✅ `go test -v ./...` (147 tests pass)
+- ✅ `go vet ./...`
+- ✅ `git diff --check`
+- ✅ Regressions cover zero-value persistence, nullable scalar clears, omitted field preservation, storage-location clear, references replacement
+
+**T006-T010, T013 marked complete.** T011/T012 intentionally unchecked (broader regression coverage remains incomplete despite new handler/repository regressions passing). T014-T017 (fixture builders) pending.
+
+## 2026-06-09 — F013 Go golden fixture builders
+
+T014 now has backend golden coin builders in `src/api/testutil` aligned with the F013 fixture names. Builders return cloned model graphs and the optional persistence helper is explicit about caller-managed migrated test DB setup, which keeps repository/service tests deterministic without introducing production seed data.

--- a/.squad/agents/maximus/history.md
+++ b/.squad/agents/maximus/history.md
@@ -30,3 +30,67 @@
   - **Implementation Sequence:** Increment 1 (Core Lookup: Python team + Go endpoint), Increment 2 (Frontend: `/lookup` route), Increment 3 (Quick Actions), Increment 4 (Polish).
   - **Hard Blocker:** Spec #216 (AI Intake Draft) must land before Coin Lookup begins.
   - **Decision Owner:** Maximus. Review required from Brian (product), Brutus (Python feasibility), Aurelia (UX/PWA). Next: Brian confirms NGC/offline decisions, Maximus creates spec scaffold.
+
+## 2026-06-09 — F013 promotion learning
+
+- Promoting Agentic Excellence work works best when F013 owns the deterministic baseline first: typed coin mutation contracts, golden fixtures, and scripted critical browser workflows. Keep LLM-driven exploratory browser testing in F011 until F013 provides stable fixtures and workflow names.
+
+- **F013 Regressions & Fixtures Batch Approved**
+   - Reviewed and approved backend regression batch (T011/T012/T013): typed mutation coverage matches F013 risks, stale storage preload fix narrowly scoped, architecture boundaries maintained
+   - Reviewed and approved frontend fixture batch (T015): fixtures typed and deterministic, suitable for phase 3/4 workflows
+   - All builds/tests/lints passed; batch ready for coordinate validation and commit
+   - Orchestration log: `.squad/orchestration-log/2026-06-09T12-51-39Z-maximus.md`
+
+- **2026-06-09 (13:09:16):** F013 Phase 3 golden fixtures complete — approved T014 (Cassius Go fixtures) and T016/T017 (Brutus docs + frontend fixtures). Verdict: testutil package decoupled, frontend coverage checked, browser tooling deferred to Phase 4 as specified. Principle IV respected. Orchestration logs: `.squad/orchestration-log/2026-06-09T13-09-16-maximus-lead-{t014,t016-t017}.md`. F013 T006–T017 now complete; Phase 4 browser workflows pending.
+
+- **2026-06-09:** F013 Phase 4 Browser Workflow Infrastructure (T018–T021, APPROVED)
+  - **Initial Review:** Aurelia delivered Playwright suite (playwright.config.ts, fixtures, auth/coin-form workflows, test:browser script)
+  - **BLOCKED on hygiene:** Identified `.gitignore` missing Playwright output paths, generated `src/web/test-results/` present, stale browser E2E TODO in docs
+  - **Escalation:** Per Strict Lockout (§18.2), delegated hygiene fix to Brutus (QA)
+  - **Re-review APPROVED:** Brutus remediated all issues — `.gitignore` entries added, generated outputs removed, docs cleaned, `npm run test:browser` passing, `git diff --check` clean
+  - **Coordinator Validation:** Full test suite + diff check verified before hygiene review
+  - **Principle Compliance:** Principle VI (Testing Infrastructure), Principle VIII (CI/CD & Build Hygiene)
+  - **Next Phase 4 Tasks:** T022–T028 (edit workflows, image upload, search/filter, mobile viewport, Taskfile, docs)
+
+- **2026-06-09 (13:32:43):** F013 Phase 4 Storage Location & Tags/Sets Workflows (T022–T023, APPROVED)
+  - **Deliverables:** Aurelia delivered two E2E workflows (storage location edit, tags/sets edit) as Playwright tests with route-level mocks and fixture-backed test data
+  - **Coordinator Pre-Validation:** npm type-check (99 Vitest ✅), npm test (99 ✅), npm run test:browser (6 Playwright ✅), git diff --check (✅)
+  - **Review Assessment:**
+    - ✅ Workflows deterministic and golden-fixture-backed (no random/flaky behavior)
+    - ✅ Mock API coverage proportional to test scope (route-level mocks only; no over-engineering)
+    - ✅ Isolated from live backend data (test fixtures self-contained)
+    - ✅ Scope boundaries respected (storage/tags/sets only; did not attempt T024–T028)
+    - ✅ Principle IV (Proportional Scope), Principle VI (Testing Infrastructure), Principle IX (Critical Workflows Deterministic)
+  - **Verdict:** ✅ **APPROVED** — Completion mark justified. All Quality Gate §17 checks pass (type-check, lint, diff-check, no architecture violations)
+  - **Phase 4 Progress:** T018–T021 + T022–T023 = 6 of 11 tasks complete. Remaining: T024–T028 (edit form validation, image upload, search/filter, mobile viewport, Taskfile, docs)
+  - **Orchestration Log:** `.squad/orchestration-log/2026-06-09T13-32-43Z-maximus-t022-t023-approved.md`
+  - **Session Log:** `.squad/log/2026-06-09T13-32-43Z-scribe-session-t022-t023.md`
+
+- **2026-06-09 (13:45:22–13:45:33):** F013 Phase 4 Final Review Batch — T024–T026 Workflows + Docs Remediation APPROVED
+  - **Initial Review (13:45:22):** Aurelia delivered T024–T026 (image upload, search/filter, mobile viewport) Playwright workflows
+    - T024: Manual add/edit image upload/delete → form save → verify persisted in detail page; deterministic File fixtures
+    - T025: Collection list filter by category/era/material/name → fixture-backed deterministic result filtering
+    - T026: Mobile viewport (375px) edit workflow → responsive form layout, no scroll issues
+    - Coordinator Pre-Validation: npm type-check ✅ (99 tests), npm test ✅ (99 tests), npm run test:browser ✅ (9 Playwright), git diff-check ✅
+    - **Initial Verdict:** ✅ **APPROVED** — Workflows deterministic, fixture-backed, mocks proportional, scope strict (no T027–T028 creep), Principle VI + Principle IX satisfied
+
+  - **Strict Lockout Block + Remediation (13:45:07):** Docs coverage misalignment discovered
+    - Block Reason: `docs/testing.md` listed T024–T026 under "Remaining" instead of reflecting actual Playwright suite coverage
+    - §18.2 Delegation: Maximus delegated docs fix to Brutus (QA)
+    - Brutus Remediation: Moved T024–T026 → "Current Coverage", removed stale TODO, git diff-check ✅
+    - Lockout Clearance: ✅ COMPLETE
+
+  - **Final Re-Review (13:45:33):** Maximus approved revised state with docs alignment
+    - ✅ T024–T026 workflows + docs now internally consistent
+    - ✅ All Quality Gate §17 checks passed (type-check, lint, diff-check, tests, architecture)
+    - ✅ Principle VIII (CI/CD & Build Hygiene) satisfied
+    - ✅ Constitution §18.2 Strict Lockout process honored
+
+  - **F013 Phase 4 Status:** T018–T023 + T024–T026 = 9 of 11 tasks complete. T027–T028 (Taskfile root command + legacy docs cleanup) are administrative completions, not feature risk
+  - **Orchestration Logs:**
+    - Coordinator: `.squad/orchestration-log/2026-06-09T13-44-58Z-coordinator.md`
+    - Aurelia T024–T026: `.squad/orchestration-log/2026-06-09T13-45-22Z-aurelia.md`
+    - Brutus Docs: `.squad/orchestration-log/2026-06-09T13-45-07Z-brutus.md`
+    - Maximus Final: `.squad/orchestration-log/2026-06-09T13-45-33Z-maximus.md`
+  - **Session Log:** `.squad/log/2026-06-09T13-45-44Z-scribe-f013-final-review.md`
+  - **Decision:** F013 Critical Workflow Hardening implementation and validation COMPLETE. Ready for merge after session handoff.

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -9,6 +9,9 @@ Agent Scribe initialized and ready for work.
 
 ## Recent Updates
 
+- **2026-06-09 (13:25:42):** Logged F013 Phase 4 browser workflow infrastructure batch (Aurelia T018–T021 + Maximus review/block + Brutus hygiene fix). Created 3 orchestration logs (Aurelia, Maximus, Brutus) and 1 session log. No inbox entries to merge. Appended cross-team browser E2E testing context to Aurelia/Maximus/Brutus history.md. All product changes staged, ready for coordinator merge. F013 T006–T021 now complete.
+- **2026-06-09 (13:09:16):** Logged F013 Phase 3 golden fixtures completion (Cassius T014 + Maximus T014 approval + Brutus T016/T017 + Maximus T016/T017 approval). Created 4 orchestration logs and 1 session log. No inbox entries to merge. F013 T006–T017 now complete; Phase 4 browser workflows (T018–T028) deferred.
+- **2026-06-09:** Logged F013 regressions & fixtures batch (Brutus backend T011/T012/T013 + Aurelia frontend T015). Merged 11 decision inbox entries (NGC strategies, lookup UX, GORM patterns, SSRF suppression, audit scheduler, user directives). Cleared inbox. Session F013 T006–T013 and T015 marked complete.
 - **2026-06-01:** Logged storage-location/settings batch, merged Cassius/Aurelia decision inbox entries, and committed feature plus squad handoff state.
 
 📌 Team initialized on 2026-04-24

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,6 +2,311 @@
 
 ## Active Decisions
 
+### Decision: F013 Defines Deterministic Critical Workflow Baseline
+
+**Date:** 2026-06-09
+**Agent:** Maximus
+**Status:** Proposed for ledger merge
+
+## Context
+
+The Agentic Excellence Roadmap promotes F013 before F011. F013 must harden ordinary coin create/edit workflows and provide the stable fixture/workflow baseline that later AI-driven browser testing can explore.
+
+## Decision
+
+F013 owns deterministic scripted workflow coverage and golden fixture shape. F011 remains the follow-up for LLM-driven exploratory browser testing after F013 establishes repeatable fixtures and critical workflows.
+
+## Constitution Alignment
+
+- Principle IV: keeps the first slice simple, complete, and proportional.
+- Principle IX: converts critical workflow memory into repeatable checks.
+- §0: active spec `specs/220-critical-workflow-hardening/` now outranks the F013 backlog card.
+
+---
+
+### Decision: Aurelia F013 Frontend Inventory — AE015, AE018-AE028
+
+**Date:** 2026-06-09
+
+## Constitution alignment
+
+- Principle III: frontend mutation tests need explicit, typed create/update contracts instead of broad `Partial<Coin>` assumptions.
+- Principle IV: first pass should inventory and fixture the real workflow boundaries before rewriting add/edit pages.
+- Principle VI: browser coverage must include desktop and PWA/mobile variants.
+- Principle IX: critical collection workflows should become deterministic tests, not reviewer memory.
+
+## Current add/edit workflow boundaries
+
+### Manual add
+
+- Entry point: `src/web/src/pages/AddCoinPage.vue` renders `CoinForm` when `entryMode === 'manual'`.
+- Initial payload source: `createEmptyForm()` includes identity, physical, inscription, purchase/value, reference, privacy, wishlist, and `storageLocationId`.
+- Submit path: `handleManualSubmit()` calls `store.addCoin(buildCoinPayload(form))`, uploads obverse/reverse via `uploadImage()`, optionally extracts store-card text via `extractText()`, then sends a second `updateCoin()` for appended notes.
+- Browser coverage should assert the first create payload and the follow-up image/card calls separately, because the user sees one save action but the frontend performs multiple mutations.
+
+### Agentic add
+
+- Entry point: desktop users can toggle AI Assist Mode; PWA defaults to agentic mode.
+- Draft path: image files go to `createIntakeDraft()`, `normalizeDraftCoin()` maps draft fields into `reviewForm`, and `confirmDraft()` calls `commitIntakeDraft({ draftId, confirm: true, overrides: buildCoinPayload(reviewForm) })`.
+- Image path: after commit, obverse/reverse are uploaded separately. PWA camera-captured obverse/reverse pass the optional `circleClip` flag; card images are draft input only in this path.
+- Browser coverage should separate: generate draft, edit one review field before confirmation, commit override payload, upload image calls, and PWA camera/upload fallback behavior.
+
+### Edit one field
+
+- Entry point: `src/web/src/pages/EditCoinPage.vue` loads `getCoin(id)`, assigns the whole response into a reactive `Partial<Coin>`, and trims `purchaseDate` to `YYYY-MM-DD`.
+- Submit path: `handleSubmit()` sends `updateCoin(form.id!, form)` with the whole form object, then performs image deletes/uploads and optional card-note `updateCoin()`.
+- Risk: a one-field edit still sends read-side fields like images/tags/sets unless stripped later. This is the most important browser regression target for F013 because payload shaping can hide backend mutation semantics.
+
+### Storage location
+
+- `CoinForm` loads `getStorageLocations()` on mount and exposes a nullable select through `storageLocationIdModel`.
+- Empty selection maps to `null`; a selected option maps to `Number(value)`.
+- `sanitizeCoin()` also converts empty/undefined `storageLocationId` to `null` and strips read-only `storageLocation`.
+- Browser coverage should include changing from location A to B and clearing to None.
+
+### Tags and sets
+
+- Tags/sets are not part of `AddCoinPage`, `EditCoinPage`, or `CoinForm`.
+- User-facing add/remove happens after creation on `CoinDetailPage.vue` through `CoinTagsSection.vue`, using `addTagToCoin()`, `removeTagFromCoin()`, `addCoinToSet()`, and `removeCoinFromSet()`.
+- Set detail also supports adding/removing coins through `SetDetailPage.vue`.
+- F013 browser coverage should treat tags/sets as a detail-page association workflow after a coin exists, not as an edit-form workflow.
+
+### Images
+
+- `CoinForm` owns selected files, preview URLs, and removed obverse/reverse ids; parents perform API mutations after coin save/update.
+- Manual add uploads selected obverse/reverse after create. Manual edit deletes removed images, deletes replaced existing side images, and uploads replacements after update.
+- Detail-page image actions also exist in `CoinActionsPanel.vue` and `ImageLightbox.vue`, so F013 image coverage should start with form upload/delete and later include detail-page replace/delete if scope allows.
+
+### Mobile/PWA variants
+
+- PWA add defaults to agentic camera-first mode, starts `getUserMedia()` on mount, captures obverse/reverse/card slots, and falls back to file upload.
+- `CoinForm` shows capture inputs for obverse/reverse when `isPwa` is true.
+- Deterministic browser coverage should mock or stub camera APIs for PWA tests and prefer file-upload fallback for the first stable suite.
+
+## Frontend payload-shaping risks
+
+- `CoinMutationPayload` is `Partial<Omit<Coin, 'references' | 'storageLocation'>> & { references?: CoinReferenceInput[] }`, which still permits many read-side fields such as `id`, `images`, `tags`, `sets`, `createdAt`, and `updatedAt`.
+- `sanitizeCoin()` only normalizes nullable scalar fields, strips `storageLocation`, defaults `currentValue` from `purchasePrice`, and converts date-only strings. It does not strip `images`, `tags`, `sets`, ids, owner fields, status fields, or timestamps.
+- `EditCoinPage` sends the whole loaded `form`; this can mask whether a backend update path is truly typed and allow accidental broad mutation semantics.
+- `buildCoinPayload()` is safer than `sanitizeCoin()` because it allowlists fields, trims strings, and maps missing scalar values intentionally. Manual add and intake commit already use it.
+- `normalizeDraftCoin()` accepts both camelCase and snake_case draft fields and normalizes categories/materials to configured options or `Other`; browser fixtures should include an unexpected draft category/material to prove fallback behavior is intentional.
+- The card OCR path mutates notes through a second `updateCoin()` after create/edit. Tests should not confuse that notes-only request with the primary create/update request.
+
+## Proposed frontend fixture structure for AE015
+
+Use frontend-owned fixtures under `src/web/src/test/fixtures/` once implementation starts:
+
+- `coins.ts`: typed `Coin` and `CoinMutationPayload` builders for Roman, Greek, Byzantine, wishlist, sold, private, storage-location, image-heavy, legacy/custom-era, tagged, and set-member examples.
+- `files.ts`: deterministic tiny in-memory `File` helpers for obverse, reverse, and store-card uploads.
+- `intake.ts`: deterministic `IntakeDraft` examples with high-confidence, low-confidence, unresolved fields, and snake_case/camelCase field variants.
+- `storageLocations.ts`, `tags.ts`, `sets.ts`: small lookup fixtures reused by component tests and browser route mocks.
+
+Keep builders typed with overrides, e.g. `buildCoin(overrides?: Partial<Coin>): Coin`, and avoid snapshots as the main assertion mechanism.
+
+## Proposed deterministic browser workflow structure for AE018-AE028
+
+Do not add a browser framework until F013 `plan.md` selects one. If the plan chooses Playwright, the simplest structure is:
+
+```text
+src/web/
+  e2e/
+    fixtures/
+      auth.ts
+      coins.ts
+      files.ts
+    workflows/
+      login.spec.ts
+      add-coin-manual.spec.ts
+      add-coin-agentic.spec.ts
+      edit-one-field.spec.ts
+      edit-storage-location.spec.ts
+      edit-tags-sets.spec.ts
+      images.spec.ts
+      collection-search-filter.spec.ts
+      mobile-edit.spec.ts
+```
+
+Recommended deterministic design:
+
+1. Authenticate by fixture/setup helper, not by repeating the full login form in every spec.
+2. Seed a known collection before each workflow through the selected test fixture mechanism.
+3. Prefer user-visible assertions plus intercepted request payload assertions for mutation semantics.
+4. Use stable accessible labels/roles where possible; add minimal `data-testid` only where labels are ambiguous.
+5. Run desktop critical workflows first; add a separate mobile/PWA project/viewport for PWA camera fallback and mobile edit.
+6. Keep AI-assisted intake deterministic by route-mocking draft responses unless the selected plan explicitly requires full backend/agent integration.
+
+## Next frontend implementation task
+
+After Maximus promotes F013 and selects the browser tool, implement AE015 first: add typed frontend fixture builders for coins, upload files, intake drafts, storage locations, tags, and sets. Then use those fixtures to implement the AE020-AE026 browser workflows without changing `AddCoinPage` or `EditCoinPage` behavior in the same slice.
+
+---
+
+### Decision: F013 Phase 4 Uses Playwright for Deterministic Browser Smoke
+
+**Date:** 2026-06-09
+**Agent:** Aurelia
+**Status:** Ledger
+
+## Context
+
+F013 Phase 4 needs deterministic browser-level smoke coverage under `src/web/`. The current frontend stack has Vitest/jsdom and no existing browser automation pattern.
+
+## Decision
+
+Use Playwright with one Chromium project, Vite's dev server, mocked `/api/*` routes, authenticated `localStorage` setup, and frontend golden fixtures from `src/web/src/test/fixtures`. The local command is `npm run test:browser` from `src/web`.
+
+## Constitution Alignment
+
+- Principle III: keeps frontend workflow contracts explicit and type-safe at the API boundary.
+- Principle IV: adds the smallest useful browser slice without backend or UI rewrites.
+- Principle IX: converts login/add/edit workflow memory into repeatable automation.
+
+---
+
+### Decision: F013 Critical Workflow Root Command
+
+**Date:** 2026-06-09
+**Agent:** Brutus
+**Status:** Ledger
+
+## Context
+
+F013 requires one documented local Taskfile command for deterministic critical browser workflow checks. Aurelia already added the web package script `npm run test:browser` for the Playwright suite under `src/web/e2e/`.
+
+## Decision
+
+Expose the suite from the repository root as `task test-critical-workflows`. The target delegates to `npm run test:browser` in `src/web` so the Taskfile command stays ergonomic while reusing the existing package script and Playwright configuration.
+
+## Constitution Alignment
+
+- Principle III: preserves typed frontend workflow checks through the existing package script.
+- Principle IV: adds a simple root alias without changing browser test implementation.
+- Principle IX: makes the critical workflow regression suite easy to run consistently.
+
+---
+
+### Decision: Cassius F013 backend inventory (AE006-AE013)
+
+**Date:** 2026-06-09
+**Spec coordination:** Active spec `specs/220-critical-workflow-hardening/` appeared during inventory. To avoid conflicting with Maximus' freshly promoted spec/plan/tasks, this backend inventory is recorded in the decisions ledger as a permanent record.
+
+## 1. Coin create/update entry points
+
+### Primary manual REST coin mutation path
+- `POST /api/coins` -> `CoinHandler.Create` in `src/api/handlers/coins.go`.
+  - Currently binds `var coin models.Coin` via `ShouldBindJSON(&coin)`.
+  - Handler overwrites `UserID`, zeroes `ID`, clears read-side `StorageLocation`, then calls `CoinService.CreateCoin`.
+  - Service validates storage location ownership, trims/validates era, creates the coin in a transaction, optionally normalizes/creates structured references, and records a portfolio value snapshot.
+- `PUT /api/coins/:id` -> `CoinHandler.Update` in `src/api/handlers/coins.go`.
+  - Loads existing coin by owner, reads raw body only to detect explicit `storageLocationId`, then binds `var updates models.Coin` via `ShouldBindJSON(&updates)`.
+  - Handler overwrites `ID`/`UserID`, clears read-side `StorageLocation`, then calls `CoinService.UpdateCoin`.
+  - Service validates storage location only when the field was present, validates changed eras, calls repository `Update`, optionally updates storage-location FK, replaces structured references when `updates.References != nil`, records manual current-value history/journal when needed, and always records a value snapshot.
+
+### Related first-class mutation endpoints
+- `POST /api/coins/:id/purchase` -> typed `PurchaseRequest`; updates wishlist/purchase fields through `CoinService.PurchaseCoin` and records value snapshot.
+- `POST /api/coins/:id/sell` -> local typed body; updates sold fields through `CoinService.SellCoin` and records value snapshot.
+- `POST /api/coins/bulk` -> `BulkActionRequest`; can delete, mark sold, tag, set, export, or assign/clear storage location. Bulk storage-location path uses `CoinRepository.BulkAssignLocation` and does not record value snapshots.
+- `POST/DELETE /api/coins/:id/tags` -> `TagHandler.AttachToCoin` / `DetachFromCoin`; association-only path through `TagRepository`.
+- `POST/DELETE /api/sets/:id/coins` -> `SetHandler.AddCoin` / `RemoveCoin`; association-only path through `SetService`/`SetRepository`.
+- `POST/PUT/DELETE /api/coins/:id/references` -> `CoinReferenceHandler`; currently binds broad `models.CoinReference` for reference create/update, then normalizes and updates allowlisted columns. This is adjacent to F013 reference behavior but separate from coin payload DTOs.
+- `POST /api/coins/intake/commit` -> `CoinIntakeService.CommitDraft`; merges allowlisted override map, then `mapToCoin` unmarshals to `models.Coin` and creates via repository directly inside the intake transaction. It records a value snapshot and journal, but bypasses `CoinService.CreateCoin` validation for storage-location/era/reference orchestration.
+- Collection chat proposal commit -> `CollectionToolsService.CommitProposal`; applies allowlisted scalar/tag changes with raw GORM in `applyAllowedFieldChanges`, then records journal and value snapshot. It does not use `CoinService.UpdateCoin`, so current-value history/timestamp behavior may differ from manual update.
+- Agent valuation path -> `ValuationService.updateCoinValuation`; updates `current_value` and `current_value_updated_at`, records coin value history. Separate automated valuation path.
+- Availability listing status -> `AvailabilityHandler.UpdateListingStatus` / availability service; updates listing check fields only.
+
+## 2. Broad model mutation binding locations
+
+- `src/api/handlers/coins.go`: `Create` binds `models.Coin` and Swagger documents request body as `models.Coin`.
+- `src/api/handlers/coins.go`: `Update` binds `models.Coin` and Swagger documents request body as `models.Coin`.
+- Adjacent but separate: `src/api/handlers/coin_references.go` binds `models.CoinReference` in reference create/update.
+- Adjacent but service-internal: `src/api/services/coin_intake_service.go` maps merged draft data to `models.Coin` by JSON marshal/unmarshal.
+
+## 3. Simplest typed DTO direction
+
+Use explicit handler DTOs in `src/api/handlers/coin_requests.go` and keep business rules in `CoinService`:
+
+```go
+type CoinCreateRequest struct {
+    Name string `json:"name" binding:"max=200"`
+    Category models.Category `json:"category"`
+    Denomination string `json:"denomination" binding:"max=200"`
+    Ruler string `json:"ruler" binding:"max=200"`
+    Era models.Era `json:"era" binding:"omitempty,max=64"`
+    Mint string `json:"mint" binding:"max=200"`
+    Material models.Material `json:"material"`
+    WeightGrams *float64 `json:"weightGrams"`
+    DiameterMm *float64 `json:"diameterMm"`
+    Grade string `json:"grade" binding:"max=100"`
+    ObverseInscription string `json:"obverseInscription" binding:"max=1000"`
+    ReverseInscription string `json:"reverseInscription" binding:"max=1000"`
+    ObverseDescription string `json:"obverseDescription" binding:"max=2000"`
+    ReverseDescription string `json:"reverseDescription" binding:"max=2000"`
+    RarityRating string `json:"rarityRating" binding:"max=100"`
+    PurchasePrice *float64 `json:"purchasePrice"`
+    CurrentValue *float64 `json:"currentValue"`
+    PurchaseDate *time.Time `json:"purchaseDate"`
+    PurchaseLocation string `json:"purchaseLocation" binding:"max=500"`
+    Notes string `json:"notes" binding:"max=5000"`
+    ReferenceURL string `json:"referenceUrl" binding:"max=2000"`
+    ReferenceText string `json:"referenceText" binding:"max=2000"`
+    IsWishlist bool `json:"isWishlist"`
+    IsSold bool `json:"isSold"`
+    SoldPrice *float64 `json:"soldPrice"`
+    SoldDate *time.Time `json:"soldDate"`
+    SoldTo string `json:"soldTo"`
+    StorageLocationID *uint `json:"storageLocationId"`
+    IsPrivate bool `json:"isPrivate"`
+    References []CoinReferenceRequest `json:"references"`
+}
+```
+
+For update, use presence-aware fields so one-field edits do not zero omitted values and explicit clears remain possible:
+
+```go
+type CoinUpdateRequest struct {
+    // Same scalar allowlist as create, but presence-aware.
+    Name optionalString `json:"name"`
+    Era optionalEra `json:"era"`
+    CurrentValue optionalNullableFloat64 `json:"currentValue"`
+    StorageLocationID optionalNullableUint `json:"storageLocationId"`
+    References optionalSlice[CoinReferenceRequest] `json:"references"`
+    // ...other mutable coin scalar fields only.
+}
+```
+
+If generic optional helpers feel too broad for the first slice, keep the existing raw-body presence map and add small field-specific wrappers only for nullable fields (`storageLocationId`, prices/values/dates, `references`). Map DTOs to a service input or to a `models.Coin` plus explicit field-presence metadata as an interim step. Do not include read-side fields (`id`, `userId`, `storageLocation`, `images`, `tags`, `sets`, timestamps, listing-check fields unless deliberately mutable) in create/update DTOs.
+
+Important semantic choice for T007/T008: current `PUT` behaves like patch for omitted fields because GORM ignores zero-valued struct fields. Typed update should preserve patch semantics, not require full replacement.
+
+## 4. Regression tests needed
+
+Handler tests (`src/api/handlers/coin_handler_test.go`):
+1. One-field edit: seed a coin with category/material/era/storage/current value/references/tags/sets/images, send payload with only `name`, assert only `name` changes and all siblings remain.
+2. Explicit empty/zero edit: where intended, assert explicit empty string/false/zero can be applied or is rejected consistently by service rules; this is the gap broad `models.Coin` + GORM struct updates currently obscures.
+3. Storage location: update to owned location; explicit `storageLocationId:null` clears; invalid/non-owned location returns 400/404 without changing existing location or associations.
+4. Sets: sending coin update payload with `sets` must not create/replace memberships; first-class set endpoints remain responsible for membership writes and preserve `AddedAt`.
+5. Tags: sending coin update payload with `tags` must not replace tag memberships unless the promoted spec explicitly chooses that behavior; first-class tag/bulk endpoints should be tested separately.
+6. References: update with `references` replaces structured refs through `CoinService.UpdateCoin`; omitted references leave existing refs untouched; empty `references: []` clears refs if that remains intended.
+7. Legacy/custom eras: custom registry era accepted; unsupported changed era rejected; unchanged legacy era preserved during unrelated edits.
+8. Value snapshots/history: create records one portfolio snapshot; update records a snapshot; manual current-value change records `CoinValueHistory`, journal, and `CurrentValueUpdatedAt`; `source=estimate` skips manual history/timestamp; unrelated one-field edits do not create coin value history.
+9. Broad-field rejection/ignore: payload fields such as `id`, `userId`, `images`, `storageLocation`, `createdAt`, and `updatedAt` cannot mutate persisted data.
+
+Repository tests (`src/api/repository/coin_repository_test.go`):
+1. Association-safe scalar update with loaded `Tags`, `Sets`, `References`, `Images`, and `StorageLocation` preserves join rows/child rows.
+2. `UpdateField`, `UpdateFields`, and `UpdateStorageLocationID` have distinct documented purposes or are covered by a table test proving none syncs loaded many-to-many associations.
+3. `Update`/future typed update map can explicitly clear nullable scalar fields and storage location without touching associations.
+4. `RecordValueSnapshot` excludes wishlist/sold as currently intended and captures changed totals after create/update/delete/sell/purchase paths.
+
+Existing partial coverage already present: set membership preservation, storage-location with set preservation, custom registry era, unchanged legacy era, repository update helper association safety, and value snapshot basics. Recent local check: `go test ./handlers -run TestCoinHandler_Update_StorageLocationWithSetsPreservesMemberships -count=1` passed.
+
+## 5. Next coding task
+
+Start T007/T008 with tests first: add `TestCoinHandler_Update_OneFieldPreservesAssociationsAndReadOnlyFields`, then introduce typed `CoinUpdateRequest` mapping that keeps patch semantics and ignores read-side fields. After that, add create DTO and update Swagger/OpenAPI under T013.
+
+Validation note: Current targeted handler regressions for storage-location/set preservation, explicit storage clear, structured reference replacement, custom registry era, and unchanged legacy era passed with `go test ./handlers -run 'TestCoinHandler_Update_(StorageLocationWithSetsPreservesMemberships|ClearsStorageLocationWhenExplicitNull|ReplacesStructuredReferences|CustomRegistryEraAccepted|PreservesUnchangedLegacyEra)$' -count=1 -timeout 20s`.
+
+---
+
 ### Decision: Camera Capture Modal Extraction
 
 **Date:** 2026-06-02
@@ -5937,7 +6242,7 @@ Added two new backend settings to allow user-defined category and era option lis
 1. **`CoinCategories`** (key: `"CoinCategories"`)
    - Default: `"Roman\nGreek\nByzantine\nModern\nOther"`
    - Format: Newline-delimited list of category names
-   
+
 2. **`CoinEras`** (key: `"CoinEras"`)
    - Default: `"ancient\nmedieval\nmodern"`
    - Format: Newline-delimited list of era names
@@ -5987,8 +6292,8 @@ All tests pass. Settings follow the existing pattern of default fallback when no
 
 # Decision: Configurable Category, Era, and Material Options (Frontend)
 
-**Date:** 2026-06-07  
-**Agent:** Aurelia (Frontend Developer)  
+**Date:** 2026-06-07
+**Agent:** Aurelia (Frontend Developer)
 **Status:** Implemented
 
 ## Context
@@ -6105,10 +6410,10 @@ Remove lines 93–95 entirely. The explicit prop bindings with nullish coalescin
 
 # Decision: Coin Lookup Feature Architecture
 
-**Date**: 2026-06-07  
-**Author**: Maximus (Lead/Architect)  
-**Status**: Proposed  
-**Scope**: Feature design  
+**Date**: 2026-06-07
+**Author**: Maximus (Lead/Architect)
+**Status**: Proposed
+**Scope**: Feature design
 
 ## Context
 
@@ -6277,7 +6582,7 @@ Status: `CoinReference` exists but no Numista catalog type.
 
 **Architecture:**
 ```
-User uploads photo → AI Intake Draft (existing) 
+User uploads photo → AI Intake Draft (existing)
   → Extract keywords (ruler, denomination, era)
   → Query Numista search (existing handler logic)
   → Enrich draft response with Numista candidates
@@ -6460,9 +6765,9 @@ const draft = ref<IntakeDraft | null>(null)
 
 ### Decision: Custom Catalog Era Validation
 
-**Date:** 2026-06-09  
-**Agent:** Cassius (Backend Developer)  
-**Status:** Complete  
+**Date:** 2026-06-09
+**Agent:** Cassius (Backend Developer)
+**Status:** Complete
 
 ## Problem
 
@@ -6508,3 +6813,452 @@ Coin model enforced static era values (`ancient`, `medieval`, `modern`) via Gin 
 - Custom catalog feature can now proceed
 - Frontend coin forms can accept registry-defined eras
 - No breaking changes to existing coin creation/update APIs
+
+---
+
+### Decision: F013 Typed Coin DTO Contract
+
+**Date:** 2026-06-09
+**Agent:** Cassius (Backend Developer)
+**Status:** Implemented & Approved
+
+## Problem
+
+Coin create/update handlers were binding broad `models.Coin` payloads from JSON requests, allowing unknown/read-side fields to flow through to the database layer, risking data corruption and inconsistent editor workflows.
+
+## Solution
+
+Implemented explicit `CoinCreateRequest` and `CoinUpdateRequest` DTOs:
+
+- **CoinCreateRequest:** Allowlists identity, physical, inscription, purchase/value, reference, privacy, wishlist, storageLocationId fields
+- **CoinUpdateRequest:** Same allowlisted fields for PATCH semantics
+- Both DTOs **exclude** read-side associations (images, tags, sets, storageLocation), ownership/id/timestamps, listing-check fields, and AI analysis fields
+- Unknown/read-side fields are **ignored** by handler binding, preserving compatibility with current frontend edit form
+
+## Key Decisions
+
+1. **Update keeps existing patch-like semantics** by mapping only present DTO fields to model-shaped service input
+2. **storageLocationId retains explicit presence detection** so omitted leaves existing value unchanged, explicit null clears
+3. **Structured references remain allowlisted** mutation field continuing through `CoinService.UpdateCoin` normalization/replacement
+
+## Architecture Compliance
+
+- ✅ **Principle I (Layered Architecture):** Handlers remain thin; business rules stay in `CoinService`; persistence stays in repositories
+- ✅ **Principle III (Explicit DTO Contracts):** Public create/update inputs are explicit DTO schemas
+- ✅ **Principle IV (Simple Complete Changes):** Compatibility-preserving typed contract change without broad rewrite
+
+## Files Changed
+
+- `src/api/handlers/coin_requests.go` (new)
+- `src/api/handlers/coins.go` (handler layer)
+- `src/api/services/coin_service.go` (passthrough layer)
+- OpenAPI artifacts regenerated
+
+## Validation
+
+- ✅ `go test -v ./...` passed
+- ✅ `go vet ./...` passed
+- ✅ Architecture tests pass (layered imports enforced)
+
+---
+
+### Decision: F013 Coin Updates Use Presence-Aware Select Fields
+
+**Date:** 2026-06-09
+**Agent:** Brutus (QA)
+**Status:** Implemented & Approved
+
+## Problem
+
+The typed DTO slice was blocked because `Updates(models.Coin)` ignored explicit Go zero values. A collector can intentionally submit `false`, `""`, or `0`, and omitted fields must still preserve existing values.
+
+## Solution
+
+HTTP update path now maps present DTO fields to explicit GORM `Select` field list:
+
+1. **Handler detects request-field presence** via JSON struct tags or manual checks
+2. **Maps present fields to string array** for GORM `Select()`
+3. **CoinRepository.Update uses Select()** to persist only those fields, including zero values
+4. **Storage-location null clears** remain on dedicated service/repository path
+5. **Structured reference replacement** remains on dedicated service/repository path
+
+## Key Decisions
+
+1. **Presence-aware update map** ensures false booleans, empty strings, and numeric zeros persist while omitted fields remain unchanged
+2. **Omitted fields automatically preserved** via GORM default behavior when Select is used
+3. **Dedicated paths for complex updates:** storageLocationId clear and references replacement stay on service/repo paths
+
+## Architecture Compliance
+
+- ✅ **Principle I (Layered Architecture):** Handlers parse presence, services orchestrate rules, repositories own persistence
+- ✅ **Principle III (Explicit DTO Contracts):** Typed DTO contracts remain explicit
+- ✅ **Principle IV (Simple Complete Changes):** Fixes blocked workflow without broad rewrite
+- ✅ **Principle IX (Critical Workflow Memory):** Handler and repository regressions enforce zero-value persistence
+
+## Files Changed
+
+- `src/api/handlers/coin_requests.go` (DTO presence detection)
+- `src/api/repository/coin_repository.go` (Select path)
+- `src/api/handlers/coin_handler_test.go` (handler regressions)
+- `src/api/repository/coin_repository_test.go` (repository regressions)
+
+## Validation
+
+- ✅ Coordinator ran `go test -v ./...`, `go vet ./...`, `git diff --check`
+- ✅ All tests passed
+- ✅ No regressions
+
+---
+
+### Decision: F013 Coin Update Nullable Scalar Semantics
+
+**Date:** 2026-06-09
+**Agent:** Aurelia (Frontend acting as independent revision owner)
+**Status:** Implemented & Approved
+
+## Problem
+
+Nullable scalar JSON `null` semantics were not explicit and regression-tested. The frontend already normalizes empty nullable form values toward `null`, while omitted update fields must preserve existing database values.
+
+## Solution
+
+For `CoinUpdateRequest`, explicit JSON `null` clears **allowlisted nullable scalar fields**:
+- purchasePrice
+- currentValue
+- purchaseDate
+- soldPrice
+- soldDate
+- weightGrams
+- diameterMm
+
+**Omitted fields preserve existing values.** `storageLocationId: null` remains dedicated storage-location clear path. `references` replacement remains dedicated service/repository path.
+
+## Key Decisions
+
+1. **Allowlist approach** provides explicit control without ambiguity
+2. **Omitted field preservation** follows standard PATCH semantics (safe for edit workflows)
+3. **Dedicated paths remain** for storageLocationId clear and references replacement (avoid coupling)
+
+## Handler & Repository Regressions
+
+Added comprehensive coverage for:
+1. JSON null clears allowlisted nullable scalar field
+2. Omitted field preserves existing value
+3. storageLocationId null clear works through dedicated path
+4. References replacement works through dedicated path
+5. Null persistence for each allowlisted nullable scalar
+6. Omitted field preservation
+
+## Architecture Compliance
+
+- ✅ **Principle I (Layered Architecture):** Handlers detect presence, services orchestrate rules, repositories persist
+- ✅ **Principle III (Explicit DTO Contracts):** Update semantics are explicit for typed DTO fields
+- ✅ **Principle IV (Simple Complete Changes):** Direct presence tracking is smallest complete fix
+- ✅ **Principle IX (Critical Workflow Memory):** Handler + repository regressions cover the behavior
+
+## Files Changed
+
+- `src/api/handlers/coin_requests.go` (CoinUpdateRequest null handling)
+- `src/api/handlers/coin_handler_test.go` (handler regressions)
+- `src/api/repository/coin_repository_test.go` (repository regressions)
+- `specs/220-critical-workflow-hardening/spec.md` (documented semantics)
+- `specs/220-critical-workflow-hardening/plan.md` (documented semantics)
+- `specs/220-critical-workflow-hardening/tasks.md` (task status updated)
+
+## Validation
+
+- ✅ Coordinator ran `go test -v ./...`, `go vet ./...`, `git diff --check`
+- ✅ All tests passed
+- ✅ No regressions
+
+---
+
+### Decision: Simple Complete Changes governance amendment
+
+**By:** Brian DeNicola (via Copilot)
+**Date:** 2026-06-09
+**Status:** Affirmed
+
+**What:** Consolidate project governance into a Principles-based Constitution with Principle IV as the "Simple Complete Changes" guardrail: changes must be simple, direct, complete, and proportional.
+
+**Why:** Recent coin edit regressions and F013 batch demonstrated the need for an explicit guardrail against both hopeful narrow patches and clever oversized fixes. Changes should stay simple and easy for humans to understand.
+
+**References:** Constitution Principles I-XIII, §17 Quality Gate, §21 Definition of Done, §22 Amendment Process.
+
+---
+
+### Decision: Regression Test Pattern — Join Tables with Custom Timestamps
+
+**Date:** 2026-06-09
+**Author:** Brutus (Tester)
+**Status:** Approved
+**Context:** Backend regression coverage for T011/T012 (typed DTO mutations)
+
+When testing GORM models with many-to-many relationships that have custom timestamp fields beyond CreatedAt/UpdatedAt (like `CoinTag.added_at` or `CoinSetMembership.AddedAt`), **regression tests must verify that Update operations preserve those timestamps**.
+
+**Pattern:**
+```go
+// BAD: Naive GORM Update replaces associations without custom timestamps
+coin.Sets = []CoinSet{newSet}
+db.Model(&coin).Updates(coin)  // Deletes old memberships, inserts new ones with NULL AddedAt → constraint violation
+
+// GOOD: Omit associations from Update, manage via dedicated methods
+db.Model(&coin).Omit("Tags", "Sets").Updates(coin)  // Preserve existing memberships
+setRepo.AddCoinToSet(...)  // Properly sets AddedAt
+```
+
+**Test Requirements:**
+1. Join table models in `setupTestDB` (e.g., `db.AutoMigrate(&models.CoinSetMembership{})`)
+2. Verify timestamps survive updates
+3. Verify Update ignores association fields
+
+**Applied to:** `CoinTag` (many-to-many with `added_at`), `CoinSetMembership` (many-to-many with `AddedAt`)
+
+**Impact:** If future developer removes `Omit("Tags", "Sets")` from `CoinRepository.Update`, these tests will catch the regression immediately.
+
+---
+
+### Decision: Coin Lookup UX — Navigation & Wishlist Integration
+
+**Date:** 2026-06-07
+**Author:** Aurelia (Frontend Developer)
+**Status:** Proposed
+**Scope:** UX criteria for Coin Lookup feature navigation and save-to-wishlist flows
+
+**Main Decisions:**
+1. **Main Menu Entry:** Add "Lookup Coin" to sidebar nav (between "Add Coin" and "Wishlist"), route to `/lookup`
+2. **Wishlist Page Action:** Add "Lookup Coin" button in header (desktop + PWA variants)
+3. **Lookup Page Route:** `/lookup` with `LookupPage.vue` component
+4. **Mobile/PWA:** Camera access using Permissions API + `getUserMedia({ video: { facingMode: { ideal: 'environment' }}})`
+5. **Photo Capture:** 2-column layout (obverse/reverse), no circle-clip (lookup photos for identification only)
+6. **SSE Streaming:** Use `fetch` + manual SSE parsing (consistent with agent chat pattern)
+7. **Save-to-Wishlist Result:** Create coin with `isWishlist: true`, pre-filled from lookup result, show success toast, stay on page for next lookup
+8. **Design Tokens:** All colors, spacing, button classes from `variables.css` and `main.css`
+
+**Mobile-First Focus:** Coin show environment is primary use case
+
+**Architecture Compliance:** Principle IV (strict typing), Principle V (design tokens), Principle XIII (PWA mobile)
+
+---
+
+### Decision: NGC-Required Coin Lookup MVP Path
+
+**Date:** 2026-06-07
+**Agent:** Cassius (Backend Developer)
+**Status:** Proposed — awaiting Brian approval
+**Context:** Brian selected "NGC must be included in MVP" for Coin Lookup feature
+
+**Problem:** NGC provides no public API; scraping violates ToS and Constitution Principle XI
+
+**Solution: Tiered NGC Support (4 Safe Paths)**
+
+1. **Path 1: Certification Field + Deep-Link (MVP baseline)**
+   - Add optional `CertificationNumber` and `CertificationService` fields to Coin
+   - Display cert badge; click → opens NGC cert lookup in new tab
+   - User manually enters cert data or via OCR
+   - Effort: 0.5 days
+
+2. **Path 2: Slab OCR + Cert Suggestion (MVP enhancement)**
+   - Use vision model to extract cert info from slab photos
+   - Pre-populate form fields; user reviews before saving
+   - Effort: 1.5 days
+
+3. **Path 3: CSV Import (deferred)**
+   - Bulk import cert data from spreadsheet
+   - Effort: 2 days
+
+4. **Path 4: Structured References (F012 post-MVP)**
+   - Store certs as `CoinReference` entries; supports multi-cert per coin
+   - Effort: 2 days
+
+**Recommended MVP:** Paths 1 + 2 (total: 2 days)
+
+**Non-Negotiables:**
+- No scraping
+- No fabricated data
+- User confirmation required for OCR results
+- Deep-link format stability verified
+- No cert number validation (store whatever user enters)
+
+**Constitution Compliance:** Principle XI (no ToS violations), §22 (legal risk mitigation)
+
+---
+
+### Decision: Coin Lookup Feature Architecture
+
+**Date:** 2026-06-07
+**Author:** Maximus (Lead/Architect)
+**Status:** Proposed
+**Scope:** Feature design and MVP architecture
+
+**MVP Flow:**
+1. User opens PWA → "Lookup Coin" action (nav or quick-action)
+2. Camera opens → capture 1-2 photos
+3. Coin Lookup Agent processes → streams identification results
+4. Agent returns: Numista candidates (top 3) + AI-inferred attribution + confidence
+5. User reviews and selects action: Add to Wishlist, Add to Collection, or Done
+
+**Data Sources (MVP):** Numista only; NGC deferred to increment 2
+
+**Architecture Components:**
+- Python LangGraph team: `coin_lookup_pipeline` with search + fetch + format nodes
+- Go service layer: coin lookup orchestration + image validation
+- Frontend: camera capture modal (reuse `CameraCaptureModal.vue`), result cards, SSE streaming
+- PWA-first design (mobile coin show use case)
+
+**Confidence Levels:** Low (< 60%), Medium (60-80%), High (> 80%)
+
+---
+
+### Decision: NGC Certification Number Extraction from Slab Photos
+
+**Date:** 2026-06-07
+**Agent:** Cassius (Backend Developer)
+**Status:** Design Proposal
+**Context:** Coin Lookup MVP — NGC Support
+
+**Implementation Path:** Vision Model Text Extraction + Structured Parsing
+
+**Why not specialized OCR/barcode libraries:**
+1. Existing vision models already extract text
+2. NGC slabs have clear, machine-readable text
+3. No QR/barcode dependencies exist in current stack
+4. Consistent with coin-card OCR pattern
+5. Regex normalization post-extraction is safer
+
+**Architecture:**
+- Python agent team: `ngc_slab_extraction.py` with vision extraction + normalization nodes
+- Go service: `NGCSlabService` proxies to Python agent, generates cert lookup URL
+- Go handler: `NGCSlabHandler` with Swagger annotations, JWT auth
+- Database: optional grading service fields in Coin model (MVP), refactor to CoinReference (post-MVP)
+- Frontend: "Extract NGC Cert" button → modal with camera/upload → shows confidence indicator → user review → save
+
+**Cert Format:** 7-8 digits, optional `-XXX` suffix; regex: `^(\d{7,8})(\-\d{3})?$`
+
+**Test Strategy:** Unit tests (normalization logic), integration tests (handler/service), manual QA (slab accuracy)
+
+**Constitution Compliance:** Principle I (layered architecture), Principle IV (strict typing), Principle XI (security)
+
+---
+
+### Decision: NGC Support Required in Coin Lookup MVP
+
+**Date:** 2026-06-07
+**Agent:** Maximus (Lead/Architect)
+**Status:** Proposed (pending Brian approval)
+**Supersedes:** Prior Numista-only recommendation
+
+**Investigation Summary:**
+- NGC has no public API for certification lookup
+- PCGS has no public API for certification lookup
+- Both offer web-based manual lookup tools only
+- Both prohibit scraping in ToS
+
+**Proposed Solution: Tiered Support (4 Paths)**
+
+Same as Cassius decision above — all paths are API-free, scrape-free, and ToS-compliant.
+
+---
+
+### Decision: GORM Association Sync Prevention for Custom Join Tables
+
+**Date:** 2026-06-09
+**Author:** Cassius (Backend Dev)
+**Status:** Implemented
+
+**Problem:** Coin updates failed with NOT NULL constraint on `coin_set_memberships.added_at` when GORM's default association sync didn't populate custom fields.
+
+**Solution:** **All repository Update methods must use `Omit("Tags", "Sets")`** to prevent automatic association sync.
+
+Join tables with custom fields must be managed through dedicated methods:
+- Sets: Use `SetRepository.AddCoinToSet()` (sets `AddedAt: time.Now()`)
+- Tags: Use tag service methods
+
+**Implementation:** Modified `coin_repository.go` Update method to use `Omit("Tags", "Sets")`
+
+**Impact:** No negative consequences; Tags/Sets already managed through dedicated endpoints
+
+---
+
+### Decision: Coin Era Validation Uses Catalog Registry
+
+**Date:** 2026-06-09
+**Agent:** Cassius (Backend Dev)
+**Status:** Implemented
+
+**Context:** Coin create/update requests rejected custom eras during Gin binding due to static `oneof` tag
+
+**Solution:** Move era validation from static Gin binding into `CoinService`, backed by `CatalogRegistry`
+
+**Implementation:**
+- Built-in eras (`ancient`, `medieval`, `modern`) remain valid
+- Custom eras valid only when present on `CatalogRegistry` row
+- `Coin.Era` and `CatalogRegistry.Era` use `varchar(64)` with max-length binding
+- Validation happens in service layer (data-driven, not static)
+
+---
+
+### Decision: Auction Ending Scheduler — Time Window & Status Case Fix
+
+**Date:** 2026-05-22
+**Agent:** Cassius (Backend Developer)
+**Status:** Implemented
+
+**Problem:** Heritage lot #8325 not detected by auction ending scheduler despite matching criteria (Brian's UTC-5 timezone crossed midnight UTC)
+
+**Root Causes:**
+1. **UTC Calendar Day Boundary:** Original query used `[startOfDay, endOfDay)` window; lots with `sale_date` exactly on exclusive upper bound were excluded
+2. **Status Case Sensitivity:** Status comparison was case-sensitive; no defense against case drift
+
+**Solution:**
+1. **Time Window:** Changed to rolling `(now, now+24h]` semantic ("ends within next 24 hours") — timezone-independent
+2. **Status Case:** Added `LOWER(status)` comparison for case-insensitive matching
+
+**Files Changed:**
+- `auction_lot_repository.go` — renamed `GetEndingToday()` → `GetEndingSoon()`
+- `auction_ending_scheduler.go` — updated method calls and messages
+- `auction_ending_debug.go` — updated debug endpoint
+- Added 10 comprehensive test cases
+
+**Validation:** All tests pass; `go vet` clean
+
+---
+
+### Decision: CodeQL SSRF Protection Suppression Pattern
+
+**Date:** 2026-06-08
+**Author:** Cassius (Backend Dev)
+**Status:** Implemented
+
+**Context:** CodeQL `go/request-forgery` alerts flagged `client.Do(req)` calls where user-provided URLs flow through validation but static taint analysis doesn't recognize validation as sanitizer
+
+**SSRF Protection Stack (Tested):**
+1. **Layer 1: URL Validation** — scheme whitelist, credential blocking, IP blocklist
+2. **Layer 2: HTTP Client** — disabled proxy, per-connection DNS resolution, post-resolution IP blocking, redirect validation
+3. **Layer 3: Comprehensive IP Blocklist** — private/loopback/link-local/special ranges
+
+**Decision:** Use inline `lgtm [go/request-forgery]` suppression comments with justification
+
+**Rationale:**
+- Protection is comprehensive and tested
+- CodeQL limitation is known (doesn't recognize custom validators)
+- Inline suppression is standard practice for false positives
+- Comments document protection for future maintainers
+
+**Implementation:** `src/api/handlers/images.go` (2 suppression comments)
+
+**Validation:** All tests pass; architecture tests pass
+
+**Team Implications:** Pattern for future CodeQL alerts; security baseline unchanged (Principle XI satisfied)
+
+---
+
+### User Directive: Simplicity Over Cleverness
+
+**Timestamp:** 2026-06-09T15:47:14Z
+**By:** Brian DeNicola (via Copilot)
+**Status:** Captured for team memory
+
+**What:** Agents must make the simplest possible fix, but not the narrowest. The codebase should stay simple, direct, and easy for a human to understand. Avoid cute, fancy, or overly clever solutions, and avoid thousand-line changes for UI bugs or property additions.
+
+**Why:** User request for sustainable code quality

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -71,6 +71,12 @@ tasks:
     cmds:
       - go test -v ./...
 
+  test-critical-workflows:
+    desc: Run F013 critical browser workflow tests
+    dir: src/web
+    cmds:
+      - npm run test:browser
+
   build-agent:
     desc: Build the Python agent service
     dir: src/agent

--- a/docs/backlog/agentic-excellence-implementation-tasks-2026-06-09.md
+++ b/docs/backlog/agentic-excellence-implementation-tasks-2026-06-09.md
@@ -1,0 +1,129 @@
+# Agentic Excellence Implementation Tasks (2026-06-09)
+
+## Scope
+
+This task plan breaks the Agentic Excellence Roadmap into implementation-ready
+slices. It is roadmap-level, not a generated `specs/NNN-*/tasks.md`; promote
+each backlog card through SpecKit before implementation.
+
+## Task format
+
+- `[P]` means the task is parallelizable after its phase prerequisites are done.
+- `[F0NN]` maps the task to a backlog card.
+- Paths are the expected primary touch points; exact files may narrow during
+  the promoted spec/plan phase.
+
+## Phase 0 — Promote and baseline the roadmap
+
+- [ ] AE001 [F013] Promote `specs/_backlog/F013-critical-workflow-hardening.md` into an active SpecKit feature under `specs/NNN-critical-workflow-hardening/spec.md`.
+- [ ] AE002 [F013] Capture current critical workflow behavior and known regressions in `specs/NNN-critical-workflow-hardening/spec.md`.
+- [ ] AE003 [F013] Define the golden collection fixture shape in `specs/NNN-critical-workflow-hardening/spec.md`.
+- [ ] AE004 [F013] Decide deterministic browser test tool and run cadence in `specs/NNN-critical-workflow-hardening/plan.md`.
+- [ ] AE005 [F013] Add initial task breakdown in `specs/NNN-critical-workflow-hardening/tasks.md`.
+
+## Phase 1 — F013 critical workflow hardening
+
+### Backend typed mutation path
+
+- [ ] AE006 [F013] Inventory all coin create/update entry points in `src/api/handlers/coins.go`, `src/api/services/coin_service.go`, and `src/api/repository/coin_repository.go`.
+- [ ] AE007 [F013] Define typed coin create/update request DTOs in `src/api/handlers/coins.go` or a dedicated `src/api/handlers/coin_requests.go`.
+- [ ] AE008 [F013] Map typed request DTOs to service inputs without binding broad `models.Coin` mutation payloads in `src/api/handlers/coins.go`.
+- [ ] AE009 [F013] Preserve service-layer business rules for storage locations, eras, references, value history, tags, and sets in `src/api/services/coin_service.go`.
+- [ ] AE010 [F013] Reduce repository update helpers to one obvious mutation path or document why each remaining helper is distinct in `src/api/repository/coin_repository.go`.
+- [ ] AE011 [F013] Add backend regression tests for one-field edits, storage-location edits, tags, sets, references, legacy/custom era, and value snapshots in `src/api/handlers/coin_handler_test.go`.
+- [ ] AE012 [F013] Add repository-level tests for association-safe updates in `src/api/repository/coin_repository_test.go`.
+- [ ] AE013 [F013] Regenerate API docs with `task openapi` if public request/response contracts change.
+
+### Golden fixtures
+
+- [ ] AE014 [P] [F013] Create Go test fixture builders for representative coins in `src/api/testutil/` or existing API test helpers.
+- [ ] AE015 [P] [F013] Create frontend fixture data for representative coins in `src/web/src/test/` or existing test helper folders.
+- [ ] AE016 [P] [F013] Document fixture coverage in `docs/testing.md`.
+- [ ] AE017 [F013] Ensure fixture data covers Roman, Greek, Byzantine, wishlist, sold, private, tagged, set-member, storage-location, image-heavy, and legacy/custom-era coins.
+
+### Browser workflow coverage
+
+- [ ] AE018 [F013] Add deterministic browser smoke test infrastructure under `src/web/` using the selected tool.
+- [ ] AE019 [F013] Add login and authenticated session setup workflow tests under `src/web/`.
+- [ ] AE020 [F013] Add add-coin workflow test covering manual entry and save under `src/web/`.
+- [ ] AE021 [F013] Add edit-one-field workflow test under `src/web/`.
+- [ ] AE022 [F013] Add edit-storage-location workflow test under `src/web/`.
+- [ ] AE023 [F013] Add edit-tags-and-sets workflow test under `src/web/`.
+- [ ] AE024 [F013] Add upload/delete image workflow test under `src/web/`.
+- [ ] AE025 [F013] Add collection search/filter workflow test under `src/web/`.
+- [ ] AE026 [F013] Add mobile viewport edit workflow test under `src/web/`.
+- [ ] AE027 [F013] Add local task command for critical workflow tests in `Taskfile.yml`.
+- [ ] AE028 [F013] Document critical workflow test command and expected fixture setup in `docs/testing.md`.
+
+## Phase 2 — F011 AI-driven browser testing
+
+- [ ] AE029 [F011] Promote `specs/_backlog/F011-ai-driven-browser-testing.md` into an active SpecKit feature after F013 defines fixtures/workflows.
+- [ ] AE030 [F011] Choose Playwright MCP, deterministic Playwright, or hybrid execution in `specs/NNN-ai-driven-browser-testing/plan.md`.
+- [ ] AE031 [F011] Add `task test-ui-explore` in `Taskfile.yml` with hard step/time/token budgets.
+- [ ] AE032 [F011] Implement exploratory browser runner under `src/web/` or `tools/agentic-testing/`.
+- [ ] AE033 [F011] Emit structured reports with route coverage, screenshots, console errors, network failures, accessibility findings, and severity.
+- [ ] AE034 [F011] Add seeded-finding or fixture-based validation so the runner proves it can detect a known issue.
+- [ ] AE035 [F011] Document advisory versus blocking behavior in `docs/testing.md`.
+- [ ] AE036 [F011] Add optional GitHub Actions integration for manual or nightly exploratory runs in `.github/workflows/`.
+
+## Phase 3 — F012 existing collection intelligence spine
+
+- [ ] AE037 [F012] Inventory current collection chat behavior in `src/agent/app/teams/collection_chat.py`, `src/agent/app/tools/collection_tools.py`, `src/api/services/collection_tools_service.go`, and `src/web/src/composables/useCoinSearchChat.ts`.
+- [ ] AE038 [F012] Add behavior tests for collection read tools: search, get coin, summary, and top value in `src/api/services/`.
+- [ ] AE039 [F012] Add behavior tests for confirm-gated update proposals and commits in `src/api/services/`.
+- [ ] AE040 [F012] Replace untyped proposal change maps with typed allowlisted change structures where practical in `src/api/services/collection_tools_service.go`.
+- [ ] AE041 [F012] Improve collection chat routing examples and tests in `src/agent/app/supervisor.py` and `src/agent/tests/`.
+- [ ] AE042 [F012] Improve frontend proposal rendering, confirm, and cancel UX in `src/web/src/composables/useCoinSearchChat.ts` and related chat components.
+- [ ] AE043 [F012] Ensure external tool server parity reuses the same service logic in `src/api/handlers/external_tools.go`.
+- [ ] AE044 [F012] Update external tool docs in `docs/external-tool-server.md`.
+
+## Phase 4 — F014 attribution and reference assistant
+
+- [ ] AE045 [F014] Promote `specs/_backlog/F014-attribution-reference-assistant.md` into an active SpecKit feature.
+- [ ] AE046 [F014] Inventory current intake/analysis/reference behavior in `src/agent/app/teams/coin_intake.py`, `src/agent/app/teams/coin_analysis.py`, and `src/api/models/coin_reference.go`.
+- [ ] AE047 [F014] Define structured attribution draft schemas with field-level confidence and evidence in `src/agent/app/models/responses.py`.
+- [ ] AE048 [F014] Add source-backed catalog reference candidates to the intake/attribution pipeline in `src/agent/app/teams/coin_intake.py` or a new focused team.
+- [ ] AE049 [F014] Add trusted authority/source helpers for v1 source set in `src/agent/app/tools/`.
+- [ ] AE050 [F014] Add Go API review/apply endpoints or reuse existing intake draft commit flow in `src/api/handlers/`.
+- [ ] AE051 [F014] Add review-and-apply UI for individual fields in `src/web/src/pages/AddCoinPage.vue` or a dedicated attribution component.
+- [ ] AE052 [F014] Add tests for low confidence, conflicting sources, no-match results, and preserving user-entered data.
+- [ ] AE053 [F014] Document attribution confidence, evidence, and source limitations in `docs/features/`.
+
+## Phase 5 — F015 curator, watchlist, and provenance agents
+
+- [ ] AE054 [F015] Promote `specs/_backlog/F015-curator-watchlist-provenance-agents.md` into an active SpecKit feature.
+- [ ] AE055 [F015] Inventory existing portfolio, gap, availability, price trends, and similar-lot teams under `src/agent/app/teams/`.
+- [ ] AE056 [F015] Define collector preference model or settings keys for budget, favorite periods, disliked categories, preferred dealers, and collecting goals in `src/api/models/` or `src/api/services/settings_service.go`.
+- [ ] AE057 [F015] Add settings UI for collector preferences in `src/web/src/components/settings/`.
+- [ ] AE058 [F015] Add curator recommendation schema and team behavior in `src/agent/app/teams/`.
+- [ ] AE059 [F015] Add watchlist evaluation schema and workflow using existing wishlist/availability data in `src/agent/app/teams/`.
+- [ ] AE060 [F015] Add provenance/risk finding schema and read-only analysis workflow in `src/agent/app/teams/`.
+- [ ] AE061 [F015] Add frontend surfaces for recommendations, watchlist verdicts, and provenance/risk warnings in `src/web/src/components/`.
+- [ ] AE062 [F015] Add tests for user scoping, private coins, confidence thresholds, and no-write-without-confirmation.
+- [ ] AE063 [F015] Update feature documentation in `docs/features/`.
+
+## Phase 6 — F016 agentic engineering quality cockpit
+
+- [ ] AE064 [F016] Promote `specs/_backlog/F016-agentic-engineering-quality-cockpit.md` into an active SpecKit feature.
+- [ ] AE065 [F016] Define initial quality metrics: critical workflow coverage, flaky tests, large files, complexity hotspots, untyped maps/casts, stale specs/ADRs, and Principle IV self-check status.
+- [ ] AE066 [F016] Implement a deterministic local report command in `Taskfile.yml` using existing tools first.
+- [ ] AE067 [F016] Generate a Markdown or GitHub Actions summary report under `docs/audits/` or CI artifacts.
+- [ ] AE068 [F016] Add stale governance/spec checks for `specs/_backlog/`, `docs/adr/`, and `.specify/memory/constitution.md`.
+- [ ] AE069 [F016] Add complexity hotspot detection for large files and repeated broad maps/casts.
+- [ ] AE070 [F016] Map agent review roles to report sections in `.squad/agents/*/charter.md` or `.squad/decisions/inbox/`.
+- [ ] AE071 [F016] Document advisory versus blocking thresholds in `docs/testing.md` or `docs/ARCHITECTURE.md`.
+
+## Cross-cutting validation tasks
+
+- [ ] AE072 [P] Run Go validation from `src/api`: `go build ./...`, `go vet ./...`, `go test -v ./...`.
+- [ ] AE073 [P] Run frontend validation from `src/web`: `npm run build`, `npm test`, and lint if configured for the touched area.
+- [ ] AE074 [P] Run agent validation from `src/agent`: `ruff check app/ tests/` and `python -m pytest tests/ -v`.
+- [ ] AE075 [P] Update OpenAPI artifacts with `task openapi` whenever public API contracts change.
+- [ ] AE076 [P] Update docs for every shipped user-visible agentic workflow in `docs/features/`, `docs/testing.md`, or `docs/external-tool-server.md`.
+- [ ] AE077 [P] Add or update ADRs for material architecture/security/tooling decisions under `docs/adr/`.
+
+## Suggested first implementation slice
+
+Start with **F013 / AE001-AE013**. That gives the team a stable typed update
+contract and regression suite before expanding browser automation or agentic
+writes.

--- a/docs/backlog/agentic-excellence-roadmap-2026-06-09.md
+++ b/docs/backlog/agentic-excellence-roadmap-2026-06-09.md
@@ -1,0 +1,97 @@
+# Agentic Excellence Roadmap (2026-06-09)
+
+## Goal
+
+Make Ancient Coins the best-coded, best-tested, most useful agentically built
+coin-collecting application: harden the strong agentic foundation that already
+exists, then extend it into features that behave like a careful numismatic
+assistant.
+
+## Current baseline
+
+The roadmap is not a greenfield plan. The app already has important agentic
+building blocks:
+
+- In-app agent chat routed through the Python supervisor.
+- `collection_chat` with collection read tools and confirm-gated update
+  proposals.
+- A Go `CollectionToolsService` and internal/external tool endpoints.
+- Agentic coin intake drafts from images and coin cards.
+- Portfolio review, gap analysis, availability checking, price trends, similar
+  lots, coin search, coin shows, grading, and vision analysis teams.
+
+The work below is about **hardening, testing, and leveling up** those surfaces,
+not duplicating them.
+
+## Operating principles
+
+- **Reliability before novelty**: critical collection workflows must be boringly
+  dependable before new agentic surfaces expand.
+- **Agent proposes, user commits**: AI may draft, explain, and recommend; users
+  confirm changes before writes land.
+- **Structured over prose**: agent outputs that drive UI or writes use typed
+  schemas with confidence and evidence.
+- **One tool layer, many adapters**: in-app chat, external tools, and future
+  agents reuse the same server-side collection capabilities.
+- **Simple Complete Changes**: every implementation slice stays direct,
+  proportional, and covered by workflow tests.
+
+## Phased implementation plan
+
+Detailed implementation tasks live in
+`docs/backlog/agentic-excellence-implementation-tasks-2026-06-09.md`.
+
+| Phase | Focus | Backlog cards | Exit criteria |
+|---|---|---|---|
+| 0 | Core workflow hardening | F013 | Coin create/edit/update paths use typed contracts and regressions cover sibling update paths. |
+| 1 | Testing foundation | F011, F013 | Golden collection fixtures and browser workflow tests cover critical add/edit/search/mobile flows. |
+| 2 | Collection intelligence spine | F012, F014 | Existing collection tools/chat are hardened, expanded, and paired with attribution/reference drafts. |
+| 3 | Collector-facing agents | F015 | Existing portfolio/gap/availability capabilities evolve into curator, watchlist, and provenance workflows with citations and confidence. |
+| 4 | Agentic engineering loop | F016 | PRs and releases expose workflow coverage, complexity hotspots, flaky tests, and agent review status. |
+
+## Promotion order
+
+1. **F013 — Harden critical collection workflows.** This repairs trust and
+   creates the typed/tested foundation for all future agentic writes.
+2. **F011 — AI-driven browser testing.** Promote once F013 defines the golden
+   workflows and fixture set the browser agent should exercise.
+3. **F012 — Agentic collection access.** Harden and expand the existing shared
+   collection tool layer, collection chat routing, and confirm-gated writes.
+4. **F014 — Attribution and reference assistant.** Improve the existing coin
+   intake/analysis foundation with source-backed references, confidence, and
+   evidence without silent writes.
+5. **F015 — Curator, watchlist, and provenance agents.** Level up existing
+   portfolio/gap/availability features into dedicated collector workflows.
+6. **F016 — Agentic engineering quality cockpit.** Add durable visibility into
+   whether the repo is staying simple, tested, and healthy.
+
+## Dependency map
+
+```text
+F013 Core workflow hardening
+  ├─ enables F011 browser workflow testing
+  ├─ de-risks F012 confirm-gated collection writes
+  └─ provides golden fixture data for F014/F015
+
+F012 Existing collection tool layer
+  ├─ hardens in-app collection chat
+  ├─ extends external tool adapters
+  └─ provides safer read/write primitives for F015
+
+F014 Attribution/reference assistant
+  └─ improves data quality for F015 recommendations
+
+F016 Quality cockpit
+  └─ monitors all phases; can start after F013 defines core metrics
+```
+
+## Definition of success
+
+- Critical collection workflows have browser-level regression coverage.
+- Coin update/create contracts are typed, explicit, and hard to misuse.
+- AI-generated coin data is evidence-backed, confidence-scored, and reviewable.
+- Collector agents answer questions and recommend actions using owned collection
+  data, not generic chatbot guesses.
+- Agentic writes are confirm-gated, journaled, and scoped server-side.
+- Pull requests show whether the real workflow was tested and whether the change
+  stayed simple, complete, and proportional.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3069,7 +3069,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Coin"
+                            "$ref": "#/definitions/handlers.CoinCreateRequest"
                         }
                     }
                 ],
@@ -3420,7 +3420,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Coin"
+                            "$ref": "#/definitions/handlers.CoinUpdateRequest"
                         }
                     }
                 ],
@@ -7895,6 +7895,123 @@
                 }
             }
         },
+        "handlers.CoinCreateRequest": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "$ref": "#/definitions/models.Category"
+                },
+                "currentValue": {
+                    "type": "number"
+                },
+                "denomination": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "diameterMm": {
+                    "type": "number"
+                },
+                "era": {
+                    "maxLength": 64,
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.Era"
+                        }
+                    ]
+                },
+                "grade": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "isPrivate": {
+                    "type": "boolean"
+                },
+                "isSold": {
+                    "type": "boolean"
+                },
+                "isWishlist": {
+                    "type": "boolean"
+                },
+                "material": {
+                    "$ref": "#/definitions/models.Material"
+                },
+                "mint": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "notes": {
+                    "type": "string",
+                    "maxLength": 5000
+                },
+                "obverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "obverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "purchaseDate": {
+                    "type": "string"
+                },
+                "purchaseLocation": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "purchasePrice": {
+                    "type": "number"
+                },
+                "rarityRating": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "referenceText": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "referenceUrl": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.CoinReferenceRequest"
+                    }
+                },
+                "reverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "reverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "ruler": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "soldDate": {
+                    "type": "string"
+                },
+                "soldPrice": {
+                    "type": "number"
+                },
+                "soldTo": {
+                    "type": "string"
+                },
+                "storageLocationId": {
+                    "type": "integer"
+                },
+                "weightGrams": {
+                    "type": "number"
+                }
+            }
+        },
         "handlers.CoinDeletedResponse": {
             "type": "object",
             "properties": {
@@ -7992,6 +8109,31 @@
                 }
             }
         },
+        "handlers.CoinReferenceRequest": {
+            "type": "object",
+            "properties": {
+                "catalog": {
+                    "type": "string",
+                    "maxLength": 32
+                },
+                "invoiceNumber": {
+                    "type": "string",
+                    "maxLength": 64
+                },
+                "number": {
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "uri": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "volume": {
+                    "type": "string",
+                    "maxLength": 64
+                }
+            }
+        },
         "handlers.CoinReferenceUpsertRequest": {
             "type": "object",
             "properties": {
@@ -8058,6 +8200,123 @@
                 },
                 "sourceUrl": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.CoinUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "$ref": "#/definitions/models.Category"
+                },
+                "currentValue": {
+                    "type": "number"
+                },
+                "denomination": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "diameterMm": {
+                    "type": "number"
+                },
+                "era": {
+                    "maxLength": 64,
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.Era"
+                        }
+                    ]
+                },
+                "grade": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "isPrivate": {
+                    "type": "boolean"
+                },
+                "isSold": {
+                    "type": "boolean"
+                },
+                "isWishlist": {
+                    "type": "boolean"
+                },
+                "material": {
+                    "$ref": "#/definitions/models.Material"
+                },
+                "mint": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "notes": {
+                    "type": "string",
+                    "maxLength": 5000
+                },
+                "obverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "obverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "purchaseDate": {
+                    "type": "string"
+                },
+                "purchaseLocation": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "purchasePrice": {
+                    "type": "number"
+                },
+                "rarityRating": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "referenceText": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "referenceUrl": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.CoinReferenceRequest"
+                    }
+                },
+                "reverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "reverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "ruler": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "soldDate": {
+                    "type": "string"
+                },
+                "soldPrice": {
+                    "type": "number"
+                },
+                "soldTo": {
+                    "type": "string"
+                },
+                "storageLocationId": {
+                    "type": "integer"
+                },
+                "weightGrams": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,33 +20,33 @@ This document is the canonical testing strategy for Ancient Coins. It explains w
 |---|---|---|---|---|---|
 | Go API | Architecture | `go test` | `src/api/architecture_test.go` | `cd src/api && go test -v -run "TestNoDirectDatabaseImports|TestHandlersDoNotUseRawSQL|TestPackageImportMatrix" .` | 1 file / 3 tests enforcing DI-only database access, no raw SQL in handlers, and the package import matrix. |
 | Go API | Unit + package-level behavior | `go test` | `src/api/{handlers,middleware,repository,services}/*_test.go` | `cd src/api && go test -v ./...` | 14 files / 115 tests: handlers 30, middleware 10, repository 23, services 52. Uses `httptest`, Gin test routers, and in-memory SQLite. |
-| Go API | Dedicated integration / E2E | None today | None today | N/A | No cross-process integration suite or browser E2E suite exists. The closest coverage is handler HTTP tests and DB-backed repository/service tests. |
+| Go API | Dedicated integration / E2E | None today | None today | N/A | No cross-process backend integration suite exists. The closest API coverage is handler HTTP tests and DB-backed repository/service tests. |
 | Vue Web | Type checking | `vue-tsc` | `src/web/package.json`, `src/web/src/**` | `cd src/web && npx vue-tsc --noEmit` | CI gate for compile-time contract safety. Use it, but do not stop there. |
 | Vue Web | Lint | ESLint | `src/web/package.json`, `src/web/eslint.config.*` if present | `cd src/web && npm run lint` | Static linting gate; the script exists even though the current CI workflow does not run it yet. |
 | Vue Web | Unit / component / store / API tests | Vitest + Vue Test Utils | `src/web/src/**/__tests__/*` | `cd src/web && npm run test` | 8 files / 61 tests: API client 24, auth store 17, components 10, pages 3, design-token enforcement 7. Mocks browser APIs and the API client at the boundary. |
 | Vue Web | Build parity | `vite` + `vue-tsc --build` | `src/web/package.json` | `cd src/web && npm run build` | Production build gate. This is stricter than `vue-tsc --noEmit`; nullable props and indexed access that pass locally can still fail here. |
-| Vue Web | Browser E2E | None today | No `e2e/`, Playwright, or Cypress config found | N/A | No browser automation suite is configured today. |
+| Vue Web | Browser workflows | Playwright | `src/web/e2e/` | `task test-critical-workflows` | Deterministic F013 smoke coverage for login/session setup, manual add coin, edit-one-field, storage-location set/clear, tags/sets, upload/delete image, collection search/filter, and mobile viewport edit workflows with mocked API routes and golden fixtures. |
 | Python Agent | Lint | Ruff | `src/agent/app/`, `src/agent/tests/`, `src/agent/pyproject.toml` | `cd src/agent && ruff check app/ tests/` | Import order, correctness, and style rules for the deterministic Python surface. |
 | Python Agent | Unit / contract tests | pytest | `src/agent/tests/test_*.py` | `cd src/agent && pytest tests/ -v` | 6 files / 35 tests covering FastAPI request validation, Pydantic models, retry logic, streaming helpers, availability parsing, and supervisor location context. |
 | Python Agent | Static type checking | None configured today | `src/agent/pyproject.toml` | N/A | No `mypy` or `pyright` config is present; schema validation and pytest carry the current contract burden. |
 
 Notes:
 - `grep -rln "httptest\|testserver\|integration" src/api --include="*_test.go"` finds handler and middleware HTTP tests, but no dedicated integration package.
-- `find src/web -iname '*playwright*' -o -iname '*cypress*' -o -path '*/e2e/*'` returns nothing.
+- Browser workflow tests live in `src/web/e2e/` and run with Playwright.
 - `pytest tests/ --collect-only -q` currently collects 35 agent tests across 6 files.
 
 ## 3. What we DON'T test
 
 - We do **not** test SQLite, GORM, Gin, Vitest, FastAPI, or LangGraph themselves; we test our usage of them.
 - We do **not** hit third-party services in automated tests. Anthropic, Ollama, SearXNG, NumisBids, and Pushover should be mocked or stubbed at the service boundary.
-- We do **not** have a true browser E2E suite today. That is an honest gap, not hidden coverage.
+- Browser workflow tests are deterministic smoke checks with mocked APIs; they do **not** require a live backend or production data.
 - We do **not** attempt deterministic end-to-end assertions for LLM quality. For agent work we test input validation, parsing, retry behavior, routing helpers, and schema-shaped outputs.
 - We do **not** add tests for trivial getters or thin pass-through code just to raise coverage numbers.
 
 ## 4. Test Pyramid Shape
 
 ```text
-        E2E / browser-wide (none today; rare by design)
+        Deterministic browser smoke (F013 Playwright workflows)
       Integration / cross-package / DB-backed flows
    Unit + contract tests per package, component, store, route, helper
 Architecture tests and type/lint gates (cheapest, fastest, most structural)
@@ -89,6 +89,7 @@ For AI features, the top of the pyramid is intentionally shallow: we test determ
 ## 6. Running tests locally vs. CI
 
 - Start from the task runner when possible: `task test` (Go), `task build` (Go + web build), `task test-agent`, and `task lint-agent` from [`../Taskfile.yml`](../Taskfile.yml).
+- Run critical browser workflows from the repository root with `task test-critical-workflows`. The target delegates to the existing web package script, `npm run test:browser`.
 - Frontend tests and lint currently live in npm scripts documented in [`../src/web/README.md`](../src/web/README.md): `npm run test`, `npm run lint`, `npm run build`, `npm run type-check`.
 - The current Quality Gate workflow lives at [`../.github/workflows/ci.yml`](../.github/workflows/ci.yml). Today it runs Go build/vet/architecture tests, Vue `vue-tsc --noEmit`, and Python Ruff + pytest.
 - Local expectations are intentionally stricter than the current CI file in a few places: the Constitution still expects full `go test ./...` and `npm run build` before you call work done.
@@ -100,7 +101,77 @@ We do **not** gate PRs on a repo-wide coverage percentage. Coverage is a signal 
 
 Constitution §21.6 is the operative rule: **"every new service method has ≥ 1 unit test."** That pushes effort toward critical paths, invariants, and regressions instead of padding helpers with low-value tests. Use `go test ./... -cover` as a diagnostic when helpful, but do not treat a single percentage as proof of safety.
 
-## 8. Cross-references
+## 8. F013 golden collection fixtures
+
+F013 defines shared "golden" coin fixtures for deterministic backend and frontend workflow tests (Principle III, Principle IV, Principle IX). The fixture matrix covers:
+
+| Fixture | Required traits |
+|---|---|
+| `roman-denarius-core` | Roman |
+| `greek-tetradrachm-valued` | Greek, valued |
+| `byzantine-solidus-set-member` | Byzantine, set-member |
+| `wishlist-aureus-target` | Roman, wishlist, valued |
+| `sold-sestertius-archive` | Roman, sold |
+| `private-provincial-bronze` | Roman, private, legacy/custom-era |
+| `tagged-follis-storage` | Roman, tagged, storage-location |
+| `image-heavy-drachm` | Greek, image-heavy |
+| `reference-rich-denarius` | Roman, reference-rich, set-member |
+
+### Backend usage
+
+- Import `src/api/testutil`.
+- Use `BuildGoldenCoinFixture(name, userID)`, named helpers such as `BuildTaggedFollisStorage(userID)`, or `BuildGoldenCoinFixtures(userID)` for in-memory model tests.
+- Use `PersistGoldenCollection(db, userID)` when a migrated test database needs coins plus valid storage locations, tags, sets, set memberships, images, and references.
+- Formal coverage check: `src/api/testutil/coin_fixtures_test.go` verifies required traits, clone safety, and persisted associations.
+
+### Frontend usage
+
+- Import from `src/web/src/test/fixtures`.
+- Use `buildGoldenCoinFixture(name)`, named helpers such as `buildImageHeavyDrachm()`, or `buildGoldenCoinFixtures()` for Vitest/component data.
+- Use `buildTestStorageLocations()`, `buildTestTags()`, and `buildTestCoinSets()` when a test needs the related lookup catalogs.
+- Formal coverage check: `src/web/src/test/fixtures/coins.test.ts` verifies required traits, clone safety, and key associations.
+
+### Critical browser workflow command
+
+Run the F013 browser workflow suite from the repository root:
+
+```bash
+task test-critical-workflows
+```
+
+The Taskfile target runs `npm run test:browser` in `src/web`, which starts the Vite dev server through `playwright.config.ts`. No live API, database, or production data is required: `src/web/e2e/fixtures/workflow.ts` installs an authenticated test session, mocks `/api/*` routes, and seeds the test with golden fixtures from `src/web/src/test/fixtures`.
+
+Current workflow coverage:
+
+- login stores the authenticated session and opens the collection
+- authenticated setup helper opens protected workflows without a live backend
+- manual add-coin save payload
+- edit-one-field payload preservation
+- storage-location change and clear behavior
+- detail-page tag and set add/remove behavior
+- upload/delete image routes and detail rendering
+- collection search and category/tag filter queries
+- mobile viewport edit save flow without desktop-only controls
+
+Current F013 validation commands:
+
+```bash
+# From the repository root
+task test-critical-workflows
+
+# From src/api/
+go test -v ./...
+go vet ./...
+
+# From src/web/
+npm.cmd run type-check
+npm.cmd test -- --run
+npm.cmd run test:browser
+```
+
+The browser workflow suite uses Playwright with mocked API routes and golden fixtures from `src/web/src/test/fixtures`.
+
+## 9. Cross-references
 
 - Constitution: [`../.specify/memory/constitution.md`](../.specify/memory/constitution.md) (especially Principle X, §17, and §21)
 - System architecture: [`ARCHITECTURE.md`](ARCHITECTURE.md)
@@ -111,5 +182,4 @@ Constitution §21.6 is the operative rule: **"every new service method has ≥ 1
 - Task runner: [`../Taskfile.yml`](../Taskfile.yml)
 
 TODOs:
-- Browser E2E smoke coverage is still missing. If we promote it to backlog, file it as `specs/_backlog/F011-browser-e2e-smoke-tests.md`.
 - Python static type checking is still absent. If we promote it to backlog, file it as `specs/_backlog/F012-agent-static-type-checking.md`.

--- a/specs/220-critical-workflow-hardening/plan.md
+++ b/specs/220-critical-workflow-hardening/plan.md
@@ -1,0 +1,160 @@
+# Implementation Plan: Critical Workflow Hardening
+
+**Branch**: `220-critical-workflow-hardening` | **Date**: 2026-06-09 | **Spec**: `/specs/220-critical-workflow-hardening/spec.md`  
+**Input**: Feature specification from `/specs/220-critical-workflow-hardening/spec.md`
+
+## Summary
+
+Promote F013 by hardening coin create/update before adding broader agentic workflows: replace broad mutation binding with typed handler request contracts, preserve service-layer association/value business rules, add backend and repository regression coverage, define reusable golden collection fixtures, and add deterministic browser workflow tests for the core collection flows that F011 can later use as its exploration baseline.
+
+## Technical Context
+
+**Language/Version**: Go 1.26.x, TypeScript (Vue 3), Python 3.12  
+**Primary Dependencies**: Gin, GORM, SQLite, Vue 3 + Pinia, Vite, Taskfile  
+**Storage**: SQLite existing `coins` and related association tables; no new production table planned  
+**Testing**: `go build ./...`, `go vet ./...`, `go test -v ./...`, `npm run build`, deterministic browser workflow command added by this feature  
+**Target Platform**: Linux-hosted web app + PWA/mobile browser client  
+**Project Type**: Web application (Go API + Vue frontend; Python agent unaffected except future dependency)  
+**Performance Goals**: Coin create/update latency remains equivalent to current service paths; browser workflow suite stays small enough for local pre-PR use  
+**Constraints**: Keep handler → service → repository boundaries; no broad rewrite; no new agentic write surface; no production fixture data; explicit contracts and repeatable tests over manual memory  
+**Scale/Scope**: Existing coin mutation path, fixture helpers, docs, Taskfile, and critical web workflow tests
+
+## Constitution Check
+
+*GATE: Must pass before implementation. Re-check after design and before PR.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Principle I (Clear Layered Architecture) | PASS | Handlers bind typed DTOs, services keep business rules, repositories keep database access. |
+| Principle III (Strict Types and Explicit Contracts) | PASS | Create/update contracts become explicit request DTOs and documented Swagger contracts if public schemas change. |
+| Principle IV (Simple Complete Changes) | PASS | Scope is limited to critical sibling workflows around coin create/update and their tests. |
+| Principle VIII (Documented Decisions) | PASS | Browser-test scope decision is recorded in `.squad/decisions/inbox/`. |
+| Principle IX (Automated Enforcement Over Manual Memory) | PASS | Regression coverage and browser workflows become repeatable checks. |
+| §17 Quality Gate | PASS | Plan keeps existing Go/Web validations and adds the critical workflow command when available. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/220-critical-workflow-hardening/
+├── plan.md
+├── spec.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/api/
+├── handlers/
+│   ├── coins.go
+│   ├── coin_requests.go                 # possible new DTO home
+│   └── coin_handler_test.go
+├── services/
+│   └── coin_service.go
+├── repository/
+│   ├── coin_repository.go
+│   └── coin_repository_test.go
+└── testutil/                             # possible fixture builder home
+
+src/web/
+├── src/test/                             # possible frontend fixture data home
+└── <selected browser test location>       # chosen during implementation
+
+Taskfile.yml
+docs/testing.md
+```
+
+**Structure Decision**: Keep this feature inside existing API and web test surfaces. Add DTOs near handlers, keep mutation orchestration in `CoinService`, keep persistence in `CoinRepository`, and keep fixtures in test-only helper folders.
+
+## Architecture / Implementation Approach
+
+### Typed coin mutation contracts
+
+1. Inventory all create/update entry points before changing behavior.
+2. Introduce `CoinCreateRequest` and `CoinUpdateRequest` in `handlers/coins.go` or `handlers/coin_requests.go`.
+3. Bind only explicit fields in handlers and map to service inputs.
+4. Preserve existing service rules for storage locations, eras, references, value snapshots, tags, and sets. Explicit `null` on nullable scalar update fields (`purchasePrice`, `currentValue`, dates, sale price, weight, diameter) clears the field; omission preserves it.
+5. Simplify or document repository update helpers so there is one obvious association-safe path.
+6. Regenerate OpenAPI artifacts if public request/response contracts change.
+
+### Golden fixtures
+
+1. Create Go test fixture builders for backend service/repository/handler tests.
+2. Create frontend fixture data or seed helpers for deterministic browser workflows.
+3. Cover Roman, Greek, Byzantine, wishlist, sold, private, tagged, set-member, storage-location, image-heavy, and legacy/custom-era examples.
+4. Document fixture coverage and setup in `docs/testing.md`.
+
+### Deterministic browser workflow tests
+
+1. Use conventional deterministic browser automation for F013; defer LLM-driven exploration to F011.
+2. Select the smallest tool/cadence that can run login, add, edit, image, search/filter, and mobile viewport workflows repeatably.
+3. Add a Taskfile command for local execution.
+4. Keep the initial suite critical and proportional; do not broaden into speculative UI exploration.
+
+## Brutus QA Strategy for AE011-AE028
+
+### Existing coverage inventory
+
+- **Backend handler tests** (`src/api/handlers/coin_handler_test.go`): authenticated list/get/create/update/delete, owner isolation, invalid JSON, set-membership preservation on update, storage-location update with set preservation, custom registry era, unchanged legacy era, and new focused coverage for explicit `storageLocationId: null` clearing plus structured reference replacement.
+- **Backend service tests** (`src/api/services/coin_service_test.go`): create records value snapshots, manual current-value updates record value history/journal, estimate updates skip history, delete/purchase/sell paths, custom registry era acceptance/rejection, and unchanged legacy era preservation.
+- **Backend repository tests** (`src/api/repository/coin_repository_test.go`): create/get, wrong-user access, delete cascade, ownership/public/active scopes, value snapshot totals, deterministic random sort, and association-safe updates that preserve set memberships across `Update`, `UpdateField`, `UpdateFields`, and `UpdateStorageLocationID`.
+- **Frontend tests**: `src/web/src/api/__tests__/client.test.ts` covers create/update sanitization; `src/web/src/components/__tests__/CoinForm.test.ts` and `src/web/src/pages/__tests__/EditCoinPage.test.ts` are source-scanning regressions for custom/legacy era preservation; collection/wishlist page tests cover rendering/list fetch behavior but not add/edit workflows.
+- **Known gap**: no deterministic browser suite exists yet, and current frontend tests do not prove full form submit payloads for tags, sets, references, images, or storage-location edits.
+
+### Golden collection fixture matrix
+
+| Fixture | Purpose | Required traits covered |
+|---|---|---|
+| `roman-denarius-core` | Default owned active coin for scalar edit/search tests | Roman, active, public, reference-ready |
+| `greek-tetradrachm-valued` | Value-history and purchase/current-value side effects | Greek, silver, purchase price/date, current value |
+| `byzantine-solidus-set-member` | Set membership preservation and set filters | Byzantine, set-member, gold |
+| `wishlist-aureus-target` | Wishlist add/purchase/search workflows | wishlist, high value, no purchase date |
+| `sold-sestertius-archive` | Sold filtering and non-active collection behavior | sold, sale price/date/to |
+| `private-provincial-bronze` | Privacy and custom/legacy era preservation | private, legacy/custom era |
+| `tagged-follis-storage` | Tag and storage-location mutation workflows | tagged, storage-location |
+| `image-heavy-drachm` | Browser upload/delete and gallery stress path | image-heavy, multiple image types |
+| `reference-rich-denarius` | Structured reference replacement/dedup validation | references, catalog registry dependency |
+
+### Test placement
+
+- **Backend handler/service/repository**: AE011-AE013. Use real in-memory SQLite and Gin `httptest` for explicit request contracts, owner scoping, storage clear/set, references replace, value-history side effects, and association-safe updates.
+- **Frontend component/source tests**: AE014-AE017 early fixture data checks, API payload sanitization, `CoinForm`/`EditCoinPage` prop and submit payload safeguards. Keep these small until browser tooling is selected.
+- **Deterministic browser tests**: AE018-AE028. Script login, add coin, edit one field, edit storage location, edit tags/sets, upload/delete image, search/filter, and mobile edit against seeded golden fixtures. These should be conventional repeatable tests and become the critical workflow command.
+- **F011 AI-driven exploratory tests later**: use the F013 fixtures/workflows as prompts and guardrails for advisory exploration: console/network errors, visual/mobile oddities, accessibility/focus issues, and unexpected runtime paths. Do not let F011 perform writes outside throwaway seeded data.
+
+### Immediate QA tasks
+
+1. Finish T011 by adding missing backend tests for tags, images, full create payloads, and typed DTO unknown-field rejection once DTOs land.
+2. Finish T012 with repository tests for storage-location clearing and reference preloading/replacement if repository helper behavior changes further.
+3. Build T014/T015 fixture helpers from the matrix above before browser tests are authored.
+4. Select browser tooling before T018; no new frontend E2E dependency should be introduced in this first pass without the plan being updated.
+
+## Phase 0 Research (Completed for Promotion)
+
+Promotion resolves these roadmap-level decisions:
+
+1. F013 is active spec `220-critical-workflow-hardening` because 220 is the next numbered spec directory.
+2. F013 owns deterministic critical workflow tests and golden fixtures.
+3. F011 remains responsible for AI-driven exploratory browser testing after F013 defines stable fixtures/workflows.
+
+## Phase 1 Design Outputs (Completed for Promotion)
+
+1. `spec.md` defines user stories, functional requirements, edge cases, and success criteria.
+2. `tasks.md` maps AE001-AE028 into dependency-ordered implementation tasks.
+3. Backlog card F013 is marked promoted with a link to this active spec.
+4. Decision inbox records deterministic browser testing as F013's baseline and AI exploration as F011's follow-up.
+
+## Post-Design Constitution Check
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Principle I (Clear Layered Architecture) | PASS | Planned changes preserve handler/service/repository responsibility split. |
+| Principle III (Strict Types and Explicit Contracts) | PASS | Typed mutation DTOs are the central deliverable. |
+| Principle IV (Simple Complete Changes) | PASS | Scope excludes new agentic write behavior and broad UI exploration. |
+| Principle IX (Automated Enforcement Over Manual Memory) | PASS | Backend regressions and browser workflows are explicit tasks. |
+
+## Complexity Tracking
+
+No constitution violations or waivers identified at planning time.

--- a/specs/220-critical-workflow-hardening/spec.md
+++ b/specs/220-critical-workflow-hardening/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Critical Workflow Hardening
+
+**Feature Branch**: `220-critical-workflow-hardening`  
+**Created**: 2026-06-09  
+**Status**: Draft  
+**Input**: Backlog card F013 and Agentic Excellence Roadmap AE001-AE028
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Safely create and edit coins through explicit contracts (Priority: P1)
+
+As a collector, I want coin create and edit requests to use explicit fields so routine collection changes do not accidentally overwrite related data.
+
+**Why this priority**: Coin create/edit is the foundation for manual collection management and future agentic write paths.
+
+**Independent Test**: Submit create/update requests for one-field edits and association edits, then verify only intended fields and related records changed.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated collector editing one scalar coin field, **When** the update is saved, **Then** only that field changes and existing associations remain intact.
+2. **Given** a collector updates storage location, tags, sets, references, legacy/custom era fields, or current value, **When** the update is saved, **Then** the service applies the intended business rule and preserves unrelated sibling data.
+3. **Given** a request contains unknown or broad model payload fields, **When** the handler binds the request, **Then** only allowlisted typed request fields can affect the mutation.
+
+---
+
+### User Story 2 - Reuse golden fixture coins for workflow regressions (Priority: P1)
+
+As a developer, I want representative coin fixtures so backend and frontend workflow tests exercise realistic collection states.
+
+**Why this priority**: Critical workflow tests need shared, recognizable data rather than one-off ad hoc records.
+
+**Independent Test**: Build tests from the fixture set and verify it includes the required representative coin states.
+
+**Acceptance Scenarios**:
+
+1. **Given** tests need a representative collection, **When** fixture builders are used, **Then** they can create Roman, Greek, Byzantine, wishlist, sold, private, tagged, set-member, storage-location, image-heavy, and legacy/custom-era coins.
+2. **Given** backend tests use fixture builders, **When** a fixture is persisted, **Then** ownership and association data are valid for service/repository checks.
+3. **Given** frontend workflow tests use fixture data, **When** the test session starts, **Then** the expected coins and relationships are available deterministically.
+
+---
+
+### User Story 3 - Run deterministic browser tests for critical collection workflows (Priority: P1)
+
+As a developer, I want repeatable browser workflow tests so login, add, edit, image, search, and mobile regressions are caught before Brian finds them manually.
+
+**Why this priority**: Browser-level coverage is the safety net for the app's most valuable workflows and the handoff point to later AI-driven exploration in F011.
+
+**Independent Test**: Run the critical workflow command locally and verify the scripted browser flows pass against a seeded test collection.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is running with test fixtures, **When** the critical workflow test command runs, **Then** login, add coin, edit one field, edit storage location, edit tags/sets, upload/delete image, search/filter, and mobile edit workflows pass.
+2. **Given** a tested workflow fails, **When** the command exits, **Then** failure output identifies the broken workflow and enough context to reproduce it.
+3. **Given** F011 later adds AI-driven exploration, **When** it needs seed data and target workflows, **Then** it reuses this feature's fixture and workflow definitions instead of inventing new ones.
+
+### Edge Cases
+
+- Update request omits fields that already have values; omitted fields must not be zeroed.
+- Update request sends empty values intentionally; empty strings and explicit nullable scalar `null` values clear their corresponding allowlisted fields while omitted fields preserve existing values.
+- Storage location is changed to another owned location, cleared, or set to an invalid/non-owned location.
+- Tags, sets, and references are added, removed, or left unchanged in the same edit flow.
+- Legacy/custom era values coexist with structured era/category fields.
+- Current value changes create or preserve value-history side effects according to existing service rules.
+- Image-heavy coins remain usable in browser tests without relying on production files.
+- Mobile viewport tests must not depend on desktop-only controls.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Coin create/update handlers MUST bind explicit typed request DTOs rather than broad `models.Coin` mutation payloads.
+- **FR-002**: Typed request DTOs MUST map to service-layer inputs without bypassing existing business rules.
+- **FR-003**: Service logic MUST preserve storage location, era, reference, value history, tag, and set behavior while narrowing mutation contracts.
+- **FR-004**: Repository update helpers MUST have one obvious association-safe mutation path, or each remaining helper MUST have a distinct documented purpose.
+- **FR-005**: Backend regression tests MUST cover one-field edits, storage-location edits, tags, sets, references, legacy/custom era values, and value snapshots.
+- **FR-006**: Repository tests MUST cover association-safe updates for representative related data.
+- **FR-007**: Golden fixtures MUST cover Roman, Greek, Byzantine, wishlist, sold, private, tagged, set-member, storage-location, image-heavy, and legacy/custom-era coins.
+- **FR-008**: Deterministic browser workflow tests MUST cover login, add coin, edit one field, edit storage location, edit tags/sets, upload/delete image, search/filter, and mobile viewport edit.
+- **FR-009**: The repository MUST expose a local Taskfile command for the critical workflow suite.
+- **FR-010**: `docs/testing.md` MUST document fixture setup and the critical workflow command.
+- **FR-011**: Public API documentation MUST be regenerated if create/update request or response contracts change.
+
+### Key Entities *(include if feature involves data)*
+
+- **CoinCreateRequest**: Explicit handler input for creating a coin through the existing service path.
+- **CoinUpdateRequest**: Explicit handler input for updating allowlisted coin fields and related data.
+- **GoldenCollectionFixture**: Deterministic test data shape covering representative coin categories, states, and associations.
+- **CriticalWorkflowTest**: Browser-level deterministic test for a named user workflow.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of coin create/update handler mutation inputs use typed DTOs instead of binding broad model payloads.
+- **SC-002**: Regression tests prove scalar edits do not unintentionally clear storage location, tags, sets, references, images, or era/value data.
+- **SC-003**: Golden fixtures cover every required representative coin state listed in FR-007.
+- **SC-004**: One documented local command runs the deterministic critical workflow browser suite.
+- **SC-005**: Future F011 AI-driven browser testing can reference this feature's fixture and workflow definitions as its baseline.
+
+## Assumptions
+
+- F013 hardens existing manual and API workflows; it does not introduce new agentic write behavior.
+- Deterministic browser tests in this feature use conventional scripted automation; AI-driven exploratory browser testing remains F011 scope.
+- Existing auth, ownership, and layered API boundaries remain in force.
+- The first implementation slice should finish typed mutation contracts and backend regressions before browser automation expands.

--- a/specs/220-critical-workflow-hardening/tasks.md
+++ b/specs/220-critical-workflow-hardening/tasks.md
@@ -1,0 +1,131 @@
+---
+description: "Task breakdown for F013 critical workflow hardening"
+---
+
+# Tasks: Critical Workflow Hardening
+
+**Input**: Design documents from `/specs/220-critical-workflow-hardening/`  
+**Prerequisites**: `plan.md`, `spec.md`, Agentic Excellence Roadmap AE001-AE028
+
+**Tests**: This feature is test-first where practical. Backend regression coverage should land with typed mutation changes; browser workflow infrastructure lands after fixture shape is stable.
+
+## Phase 1: Promotion Foundation (Completed by Spec Promotion)
+
+**Purpose**: Promote F013 from backlog into an active SpecKit feature and baseline the scope.
+
+- [x] T001 [AE001] Promote `specs/_backlog/F013-critical-workflow-hardening.md` into active feature `specs/220-critical-workflow-hardening/spec.md`
+- [x] T002 [AE002] Capture current critical workflow behavior and known regression targets in `specs/220-critical-workflow-hardening/spec.md`
+- [x] T003 [AE003] Define the golden collection fixture shape in `specs/220-critical-workflow-hardening/spec.md`
+- [x] T004 [AE004] Decide deterministic browser test tool scope and run cadence in `specs/220-critical-workflow-hardening/plan.md`
+- [x] T005 [AE005] Add initial task breakdown in `specs/220-critical-workflow-hardening/tasks.md`
+
+---
+
+## Phase 2: Backend Typed Mutation Path
+
+**Purpose**: Make coin create/update explicit, association-safe, and regression-tested before browser tests expand.
+
+**⚠️ CRITICAL**: Complete this phase before browser workflow implementation.
+
+- [x] T006 [AE006] Inventory all coin create/update entry points in `src/api/handlers/coins.go`, `src/api/services/coin_service.go`, and `src/api/repository/coin_repository.go`
+- [x] T007 [AE007] Define typed coin create/update request DTOs in `src/api/handlers/coins.go` or dedicated `src/api/handlers/coin_requests.go`
+- [x] T008 [AE008] Map typed request DTOs to service inputs without binding broad `models.Coin` mutation payloads in `src/api/handlers/coins.go`
+- [x] T009 [AE009] Preserve service-layer business rules for storage locations, eras, references, value history, tags, and sets in `src/api/services/coin_service.go`
+- [x] T010 [AE010] Reduce repository update helpers to one obvious mutation path or document why each remaining helper is distinct in `src/api/repository/coin_repository.go`
+- [x] T011 [AE011] Add backend regression tests for one-field edits, storage-location edits, explicit false/empty-string updates, storage-location null clears, nullable scalar null clears, tags, sets, references, legacy/custom era, and value snapshots in `src/api/handlers/coin_handler_test.go`
+- [x] T012 [AE012] Add repository-level tests for association-safe, explicit zero-value, and nullable scalar NULL updates in `src/api/repository/coin_repository_test.go`
+- [x] T013 [AE013] Regenerate API docs with `task openapi` if public request/response contracts change
+
+**Brutus decomposition for T011-T012**:
+
+- [x] Add handler test for typed DTO unknown/broad relationship fields being ignored or rejected according to the final contract.
+- [x] Add handler tests for create/update structured references, storage-location set/clear/invalid, one scalar edit preserving sibling associations, and manual current-value history side effects.
+- [x] Add handler regression for explicit false booleans and empty-string clears through the HTTP update path.
+- [x] Add service tests only where business rules live: storage ownership validation, era validation, reference normalization, and value-history snapshots.
+- [x] Add repository tests only for persistence invariants: association-safe updates, storage-location NULL updates, preloads, and helper behavior.
+- [x] Add repository regression proving selected update fields persist explicit false, empty-string, and numeric zero values.
+- [x] Add handler and repository regressions proving explicit nullable scalar `null` clears persist for `purchasePrice`, `currentValue`, dates, sale price, weight, and diameter while omitted fields preserve existing values.
+
+**Checkpoint**: Coin mutation inputs are typed and backend regressions prove critical related data survives updates.
+
+---
+
+## Phase 3: Golden Fixtures
+
+**Purpose**: Provide deterministic, representative collection data for backend and browser workflow coverage.
+
+- [x] T014 [P] [AE014] Create Go test fixture builders for representative coins in `src/api/testutil/` or existing API test helpers
+- [x] T015 [P] [AE015] Create frontend fixture data for representative coins in `src/web/src/test/` or existing test helper folders
+- [x] T016 [P] [AE016] Document fixture coverage in `docs/testing.md`
+- [x] T017 [AE017] Ensure fixture data covers Roman, Greek, Byzantine, wishlist, sold, private, tagged, set-member, storage-location, image-heavy, and legacy/custom-era coins
+
+**Golden fixture names**: `roman-denarius-core`, `greek-tetradrachm-valued`, `byzantine-solidus-set-member`, `wishlist-aureus-target`, `sold-sestertius-archive`, `private-provincial-bronze`, `tagged-follis-storage`, `image-heavy-drachm`, and `reference-rich-denarius`.
+
+**Checkpoint**: Backend and frontend tests can create or load the same representative collection states deterministically.
+
+---
+
+## Phase 4: Browser Workflow Coverage
+
+**Purpose**: Add deterministic browser-level coverage for the highest-value collection workflows.
+
+- [x] T018 [AE018] Add deterministic browser smoke test infrastructure under `src/web/` using the selected tool
+- [x] T019 [AE019] Add login and authenticated session setup workflow tests under `src/web/`
+- [x] T020 [AE020] Add add-coin workflow test covering manual entry and save under `src/web/`
+- [x] T021 [AE021] Add edit-one-field workflow test under `src/web/`
+- [x] T022 [AE022] Add edit-storage-location workflow test under `src/web/`
+- [x] T023 [AE023] Add edit-tags-and-sets workflow test under `src/web/`
+- [x] T024 [AE024] Add upload/delete image workflow test under `src/web/`
+- [x] T025 [AE025] Add collection search/filter workflow test under `src/web/`
+- [x] T026 [AE026] Add mobile viewport edit workflow test under `src/web/`
+- [x] T027 [AE027] Add local task command for critical workflow tests in `Taskfile.yml`
+- [x] T028 [AE028] Document critical workflow test command and expected fixture setup in `docs/testing.md`
+
+**Browser split**:
+
+- [x] Deterministic F013 tests block critical regressions for login, add, edit, image, search/filter, and mobile viewport flows.
+- [x] Later F011 AI-driven exploration remains advisory and uses the F013 golden fixtures/workflow list; it should report console/network/visual/accessibility findings without expanding the mutation contract.
+
+**Checkpoint**: Critical workflows run through one documented local command and produce deterministic pass/fail output.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Promotion Foundation)**: No dependencies; complete before implementation.
+- **Phase 2 (Backend Typed Mutation Path)**: Depends on Phase 1 and blocks browser workflow implementation.
+- **Phase 3 (Golden Fixtures)**: Depends on Phase 1; backend and frontend fixture builders can proceed in parallel after fixture shape is agreed.
+- **Phase 4 (Browser Workflow Coverage)**: Depends on Phase 2 typed update stability and Phase 3 fixture availability.
+
+### Execution Graph
+
+```text
+Promotion -> Backend Typed Mutation Path -> Browser Workflow Coverage
+          \-> Golden Fixtures ----------/
+```
+
+### Parallel Execution Examples
+
+```bash
+Task T014: Create Go fixture builders in src/api/testutil/
+Task T015: Create frontend fixture data in src/web/src/test/
+Task T016: Document fixture coverage in docs/testing.md
+```
+
+## Implementation Strategy
+
+### First Slice
+
+1. Start with T006 to inventory the existing mutation paths.
+2. Complete T007-T010 as one backend contract slice.
+3. Land T011-T012 with the contract changes so regression coverage proves association safety.
+4. Run Go validation from `src/api`: `go build ./...`, `go vet ./...`, `go test -v ./...`.
+
+### Incremental Delivery
+
+1. Ship typed backend mutation contracts and regression tests.
+2. Add golden fixture builders/data and documentation.
+3. Add deterministic browser workflow infrastructure and critical flows.
+4. Add Taskfile command and final testing documentation.

--- a/specs/_backlog/F011-ai-driven-browser-testing.md
+++ b/specs/_backlog/F011-ai-driven-browser-testing.md
@@ -1,15 +1,14 @@
 ---
 id: F011
 title: "AI-driven exploratory browser testing for runtime UI bugs"
-status: deferred           # backlog | triaged | promoted | dropped | deferred
-priority: P2
+status: triaged            # backlog | triaged | promoted | dropped
+priority: P0
 effort: L
-value: 4
-risk: 2
+value: 5
+risk: 3
 owner: unassigned
 created: 2026-05-28
-updated: 2026-05-28
-blocked_by: "#163 (three-pillar audit) — defer spec drafting until audit findings inform which flows to cover first"
+updated: 2026-06-09
 ---
 
 # F011 — AI-driven exploratory browser testing for runtime UI bugs
@@ -30,8 +29,10 @@ We have unit tests (Go 118, Vue 61, Python 35) but **zero browser-level coverage
 
 - **§17 Quality Gate** — exploratory results are advisory (don't block merge initially); promote to gating once stable
 - **§19 Documentation Requirements** — `docs/testing.md` testing-pyramid section gains an "Exploratory" tier
-- **Principle XV (Supply Chain & CI Integrity)** — any new MCP server / browser driver pinned to a specific version
-- **Principle XI (Security Hardening)** — exploratory agent runs against a throwaway database; no production data
+- **Principle IV (Simple Complete Changes)** — browser tests exercise the real user workflow, not just implementation details
+- **Principle VII (CI, Supply Chain, and Release Integrity)** — any new MCP server / browser driver pinned to a specific version
+- **Principle IX (Automated Enforcement Over Manual Memory)** — high-value workflow checks become repeatable
+- **Principle V (Security, Auth, and Privacy by Default)** — exploratory agent runs against a throwaway database; no production data
 
 ## Approach Options (to be decided during spec phase)
 
@@ -50,11 +51,11 @@ Coordinator recommendation captured 2026-05-28: pursue (1) as primary, keep (2) 
 - [ ] Do we seed deterministic test accounts/data via fixtures, or let the agent create its own via the UI on each run?
 - [ ] Token-budget enforcement: hard cap per run, soft cap with continuation prompt, or both?
 
-## Why Deferred
+## Roadmap role
 
-The **#163 three-pillar audit** (Security / SWE best practices / DRY) will surface the highest-risk UI surfaces and likely identify components that should be refactored *before* we invest in exploratory coverage. Drafting the F011 spec before #163 lands risks targeting flows that are about to be restructured.
-
-**Trigger to promote:** when #163 closes, revisit this card. Brutus to draft `specs/NNN-ai-exploratory-testing/spec.md` at that point.
+This card is now part of the Agentic Excellence Roadmap. It should follow F013
+so the exploratory browser agent has a golden fixture collection and critical
+workflow list to exercise.
 
 ## Notes
 
@@ -65,15 +66,19 @@ The **#163 three-pillar audit** (Security / SWE best practices / DRY) will surfa
 
 ## Dependencies
 
-- **Blocked by:** Issue #163 (three-pillar audit) completion — see `blocked_by` front-matter.
+- **Depends on:** F013 defining the golden fixture collection and critical
+  workflows.
 - Coordinates with: `docs/testing.md` (Brutus owns; will gain new tier).
 
 ## References
 
 - Issue #163 (audit findings will scope which UI flows are highest-priority)
+- F013 — Harden critical collection workflows
 - `docs/testing.md` — current testing pyramid; F011 adds the exploratory tier
 - `.squad/decisions.md` entry #18 (this card's deferral and tracking decision)
+- `docs/backlog/agentic-excellence-roadmap-2026-06-09.md`
 
 ## History
 
 - 2026-05-28: Created. Status `deferred` pending #163 completion. Coordinator recommendation: AI-driven (Playwright MCP + vision model). Brutus to own spec drafting on promotion.
+- 2026-06-09: Moved to `triaged` / `P0` as part of the Agentic Excellence Roadmap. F013 should define the golden workflows before this is promoted.

--- a/specs/_backlog/F012-agentic-collection-updates.md
+++ b/specs/_backlog/F012-agentic-collection-updates.md
@@ -1,4 +1,4 @@
-# Epic — Agentic Collection: Structured Data → AI Entry → Conversational Access
+# Epic — Agentic Collection: Improve Structured Data, AI Entry, and Conversational Access
 
 > **Status:** Backlog (epic)
 > **Type:** Epic / theme
@@ -7,34 +7,32 @@
 
 ## Summary
 
-A four-card arc that moves the app from *manual data entry + web-search AI*
-toward *structured data, AI-assisted entry, and conversational access to the
-collection itself* — including from external clients. Each card is shippable on
-its own, but together they compound: better-structured data makes AI entry more
-useful, AI entry produces richer records to query, and a shared tool layer lets
-both the in-app agent and external clients (OpenWebUI/Ollama, Claude Desktop)
-query and update the collection.
+A four-card arc that improves the agentic collection features already present:
+structured references, AI-assisted entry, collection chat, and external tool
+access. Each card is shippable on its own, but together they compound:
+better-structured data makes AI entry more useful, AI entry produces richer
+records to query, and the shared tool layer lets both the in-app agent and
+external clients query and update the collection safely.
 
 ## Why these belong together
 
-The existing AI agent only looks *outward* (web search for wishlist, auctions,
-prices). This epic turns the intelligence *inward* — onto the collection the
-user already owns — and raises the quality of the underlying data so that
-inward-facing AI has something solid to work with.
+The app already has inward-facing collection chat, coin intake, portfolio
+review, and tool-server foundations. This epic turns those foundations into a
+more complete, tested, and coherent collection intelligence system.
 
-The connective tissue is a **transport-agnostic collection tool layer** (Go):
-query / filter / aggregate / propose-update / commit-update, scoped per user,
-with the Go API as the only writer. In-app chat and the external server are both
-adapters onto it. Designing this layer once is the central architectural bet of
-the epic.
+The connective tissue remains the existing **transport-agnostic collection tool
+layer** (Go): query / filter / aggregate / propose-update / commit-update,
+scoped per user, with the Go API as the only writer. In-app chat and the
+external server are both adapters onto it. The central architectural bet is to
+improve that layer once instead of duplicating query/update logic.
 
 ## Member cards
 
 |#|Card                                 |One-liner                                                                                                                    |Primary value                                                                |
 |-|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 |1|**Structured Catalog References**    |Normalize attribution (RIC/RPC/Sear/KM…) into a `CoinReference` model + `era`, with per-catalog validation and authority URIs|Clean, portable, machine-usable reference data across ancient/medieval/modern|
-|2|**Agentic Coin Entry**               |New `coin_intake` agent team drafts a fully-populated coin from photos / OCR / lookups; user reviews & confirms              |Cuts data entry to review-and-confirm; produces richer records               |
-|3|**Collection Chat**                  |New `collection_chat` team answers questions and makes guarded updates over the user’s own collection via tool-calling       |Conversational read + confirm-gated write, in-app                            |
+|2|**Agentic Coin Entry**               |Improve existing `coin_intake` draft flow from photos / OCR / lookups; user reviews & confirms                              |Cuts data entry to review-and-confirm; produces richer records               |
+|3|**Collection Chat**                  |Harden and expand existing `collection_chat` for questions and guarded updates over the user's own collection via tools      |Conversational read + confirm-gated write, in-app                            |
 |4|**Collection Tool Server (External)**|Re-exposes the same tool layer to external clients (OpenWebUI/Ollama, MCP) with full read + write parity                     |Use the collection from outside the app                                      |
 
 ## Dependency graph
@@ -71,7 +69,7 @@ the epic.
 
 1. **Structured Catalog References (1).** Foundational, independent, low-risk,
    and lifts the data quality everything else builds on. Do first.
-1. **Collection Chat (3) — read-only slice first.** Stand up the
+1. **Collection Chat (3) — harden read-only slice first.** Improve the existing
    transport-agnostic tool layer + `get_coin` / `query_coins` / `aggregate`,
    scoped per user, in the existing chat drawer. This is the spine; getting it
    right de-risks card 4.

--- a/specs/_backlog/F013-critical-workflow-hardening.md
+++ b/specs/_backlog/F013-critical-workflow-hardening.md
@@ -1,14 +1,15 @@
 ---
 id: F013
 title: "Harden critical collection workflows"
-status: triaged
+status: promoted
 priority: P0
 effort: L
 value: 5
 risk: 4
-owner: unassigned
+owner: Maximus
 created: 2026-06-09
 updated: 2026-06-09
+promoted_to: specs/220-critical-workflow-hardening/
 ---
 
 # F013 — Harden critical collection workflows
@@ -19,6 +20,9 @@ Make the core collection workflows boringly reliable before expanding agentic
 write surfaces. The first target is coin create/edit/update because those flows
 touch identity fields, storage locations, tags, sets, references, images,
 legacy/custom values, and value history.
+
+**Promotion:** Active SpecKit feature lives at
+`specs/220-critical-workflow-hardening/`.
 
 ## Acceptance criteria
 
@@ -65,3 +69,5 @@ tested, and stable.
 ## History
 
 - 2026-06-09: created (status: triaged).
+- 2026-06-09: promoted to active SpecKit feature
+  `specs/220-critical-workflow-hardening/` (owner: Maximus).

--- a/specs/_backlog/F013-critical-workflow-hardening.md
+++ b/specs/_backlog/F013-critical-workflow-hardening.md
@@ -1,0 +1,67 @@
+---
+id: F013
+title: "Harden critical collection workflows"
+status: triaged
+priority: P0
+effort: L
+value: 5
+risk: 4
+owner: unassigned
+created: 2026-06-09
+updated: 2026-06-09
+---
+
+# F013 — Harden critical collection workflows
+
+## Summary
+
+Make the core collection workflows boringly reliable before expanding agentic
+write surfaces. The first target is coin create/edit/update because those flows
+touch identity fields, storage locations, tags, sets, references, images,
+legacy/custom values, and value history.
+
+## Acceptance criteria
+
+- [ ] Coin create/update uses explicit typed request contracts instead of
+      binding broad model payloads for mutation.
+- [ ] Regression tests cover editing one property, storage location, sets, tags,
+      references, images, legacy/custom era values, and value-history side
+      effects.
+- [ ] A golden test collection fixture includes Roman, Greek, Byzantine,
+      wishlist, sold, private, tagged, set-member, storage-location, image-heavy,
+      and legacy/custom-era coins.
+- [ ] Browser workflow tests cover login, add coin, edit one field, edit storage
+      location, edit tags/sets, upload/delete images, search/filter, and mobile
+      viewport edit.
+- [ ] Documentation identifies the critical workflow suite and the command to
+      run it locally and in CI.
+
+## Constitution alignment
+
+- Principle I (Clear Layered Architecture) — typed request handling must preserve
+  handler/service/repository boundaries.
+- Principle III (Strict Types and Explicit Contracts) — update contracts and API
+  payloads are explicit.
+- Principle IV (Simple Complete Changes) — fixes cover real workflows and
+  directly related sibling paths.
+- Principle IX (Automated Enforcement Over Manual Memory) — workflow regressions
+  become repeatable tests.
+- §17 Quality Gate, §21 Definition of Done.
+
+## Open questions
+
+- [ ] Should browser workflow tests use Playwright as deterministic tests before
+      F011 adds AI-driven exploration?
+- [ ] Should the golden fixture live in Go test helpers, frontend test fixtures,
+      or a shared seed endpoint used only in tests?
+- [ ] Which workflows should block every PR versus run nightly?
+
+## Notes
+
+This is the foundation for agentic writes. Agents should not be allowed to
+commit collection changes until the ordinary human update paths are typed,
+tested, and stable.
+
+## History
+
+- 2026-06-09: created (status: triaged).

--- a/specs/_backlog/F014-attribution-reference-assistant.md
+++ b/specs/_backlog/F014-attribution-reference-assistant.md
@@ -1,0 +1,65 @@
+---
+id: F014
+title: "Build attribution and reference assistant"
+status: backlog
+priority: P1
+effort: XL
+value: 5
+risk: 4
+owner: unassigned
+created: 2026-06-09
+updated: 2026-06-09
+---
+
+# F014 — Build attribution and reference assistant
+
+## Summary
+
+Improve the existing coin intake and analysis foundation into an attribution and
+reference assistant that drafts coin attribution from images, OCR text, existing
+notes, and trusted sources. The assistant proposes ruler, mint, denomination,
+date range, legends, catalog references, authority links, confidence, and
+evidence. Users review before anything is saved.
+
+## Acceptance criteria
+
+- [ ] Assistant returns a structured attribution draft with field-level
+      confidence and evidence.
+- [ ] Suggested catalog references include source/citation and normalized
+      reference fields compatible with existing `CoinReference` behavior.
+- [ ] UI presents a review-and-apply flow where the user can accept individual
+      fields, reject fields, or save the draft to notes.
+- [ ] Agent never overwrites existing coin identity/reference fields without
+      explicit user confirmation.
+- [ ] Tests cover low-confidence results, conflicting sources, no-match results,
+      and preserving existing user-entered data.
+
+## Constitution alignment
+
+- Principle II (Service Boundary Separation) — Python agent remains stateless;
+  Go API owns persistence.
+- Principle III (Strict Types and Explicit Contracts) — drafts use structured
+  schemas.
+- Principle IV (Simple Complete Changes) — build as reviewable slices, not a
+  broad rewrite of coin editing.
+- Principle V (Security, Auth, and Privacy by Default) — no cross-user data
+  exposure; source URLs are validated.
+- §17 Quality Gate, §21 Definition of Done.
+
+## Open questions
+
+- [ ] Which external reference sources are in v1: NGC, Numista, Wildwinds, RPC,
+      OCRE/RIC, ACSearch, dealer pages, or a smaller starter set?
+- [ ] Should confidence be numeric, low/medium/high, or both?
+- [ ] Should attribution drafts be persisted as separate review records before
+      being applied to a coin?
+
+## Notes
+
+This complements F012 and the existing `coin_intake` team. F012 gives agents
+safe access to collection data; F014 adds deeper numismatic attribution skill
+and evidence-backed reference drafting.
+
+## History
+
+- 2026-06-09: created (status: backlog).

--- a/specs/_backlog/F015-curator-watchlist-provenance-agents.md
+++ b/specs/_backlog/F015-curator-watchlist-provenance-agents.md
@@ -1,0 +1,67 @@
+---
+id: F015
+title: "Add curator, watchlist, and provenance agents"
+status: backlog
+priority: P1
+effort: XL
+value: 5
+risk: 4
+owner: unassigned
+created: 2026-06-09
+updated: 2026-06-09
+---
+
+# F015 — Add curator, watchlist, and provenance agents
+
+## Summary
+
+Level up existing portfolio review, gap analysis, availability checking, and
+similar-lot capabilities into collector-facing workflows: a curator agent for
+gaps/themes/next buys, a watchlist agent for matching lots to goals, and a
+provenance/risk agent for missing provenance, suspicious listings, duplicate
+images, and documentation gaps.
+
+## Acceptance criteria
+
+- [ ] Curator agent can explain collection strengths, gaps, themes, and suggested
+      next acquisitions using owned collection data.
+- [ ] Watchlist agent can evaluate candidate lots against user goals, budget,
+      duplicates, and existing collection coverage.
+- [ ] Provenance/risk agent flags missing provenance, suspicious claims,
+      duplicate images, broken source links, and coins needing better
+      documentation.
+- [ ] Recommendations include citations/evidence, confidence, and a clear
+      "why this matters" explanation.
+- [ ] User preferences such as budget, favorite periods, disliked categories,
+      preferred dealers, and collecting goals are configurable and respected.
+- [ ] No agent writes changes without confirmation and journal/audit metadata.
+
+## Constitution alignment
+
+- Principle II (Service Boundary Separation) — agent service performs inference;
+  Go API owns data and writes.
+- Principle III (Strict Types and Explicit Contracts) — recommendations and risk
+  findings use schemas.
+- Principle IV (Simple Complete Changes) — ship one agent slice at a time.
+- Principle V (Security, Auth, and Privacy by Default) — personal collection
+  preferences and private coins remain user-scoped.
+- §17 Quality Gate, §21 Definition of Done.
+
+## Open questions
+
+- [ ] Should user collecting preferences live in admin settings, account
+      settings, or a dedicated collector profile model?
+- [ ] Should watchlist inputs come from wishlist coins, manual goals, auction
+      URLs, saved searches, or all of them?
+- [ ] What confidence/evidence threshold is required before surfacing a
+      provenance risk warning?
+
+## Notes
+
+This card should follow F012 read tools and benefit from F014 attribution
+evidence. It should improve and unify existing collection-analysis teams rather
+than duplicate them. The first slice should be read-only recommendations.
+
+## History
+
+- 2026-06-09: created (status: backlog).

--- a/specs/_backlog/F016-agentic-engineering-quality-cockpit.md
+++ b/specs/_backlog/F016-agentic-engineering-quality-cockpit.md
@@ -1,0 +1,63 @@
+---
+id: F016
+title: "Create agentic engineering quality cockpit"
+status: backlog
+priority: P2
+effort: L
+value: 4
+risk: 3
+owner: unassigned
+created: 2026-06-09
+updated: 2026-06-09
+---
+
+# F016 — Create agentic engineering quality cockpit
+
+## Summary
+
+Create a repository health surface that helps humans and agents keep the app
+simple, tested, and reliable. It should summarize workflow coverage, flaky
+tests, complexity hotspots, large files, untyped maps/casts, stale specs/ADRs,
+and whether each PR satisfied the Simple Complete Changes check.
+
+## Acceptance criteria
+
+- [ ] A repeatable command produces a repository health report with critical
+      workflow coverage, test failures/flakes, complexity hotspots, and stale
+      governance artifacts.
+- [ ] PR template or automation records whether the real workflow was tested,
+      sibling paths were checked, and the change stayed proportional.
+- [ ] Report highlights files/components that exceed agreed complexity or size
+      thresholds and links them to backlog/refactor candidates.
+- [ ] Agent review roles are mapped to checks: architecture, backend, frontend,
+      tests, security, and runtime/CI health.
+- [ ] Dashboard/report output is deterministic enough to compare over time.
+
+## Constitution alignment
+
+- Principle IV (Simple Complete Changes) — tracks proportionality and workflow
+  proof.
+- Principle VII (CI, Supply Chain, and Release Integrity) — integrates with CI
+  health without hiding failures.
+- Principle VIII (Documented Decisions) — reports stale or conflicting specs,
+  ADRs, and decisions.
+- Principle IX (Automated Enforcement Over Manual Memory) — automates repeatable
+  quality checks.
+- §17 Quality Gate, §21 Definition of Done.
+
+## Open questions
+
+- [ ] Should the first version be a Markdown report, GitHub Actions summary,
+      local web page, or admin-only app page?
+- [ ] Which complexity thresholds should be advisory versus blocking?
+- [ ] Should this use existing tools only at first, or add a dedicated analyzer?
+
+## Notes
+
+This is not a vanity dashboard. It should make regressions, drift, and
+over-complexity visible early enough that agents can act on them before users
+hit bugs.
+
+## History
+
+- 2026-06-09: created (status: backlog).

--- a/specs/_backlog/README.md
+++ b/specs/_backlog/README.md
@@ -55,7 +55,7 @@ A card may be promoted when **all** of the following are true:
 1. `status: triaged`
 2. Acceptance criteria are concrete (testable, not aspirational).
 3. Constitution alignment section names at least one Principle and one
-   operational section (e.g., "Principle XI + §17").
+   operational section (e.g., "Principle IV + §17").
 4. No `priority: P3` cards are promoted ahead of `P0`/`P1` without a written
    exception in `.squad/decisions/inbox/`.
 

--- a/specs/_backlog/_TEMPLATE.md
+++ b/specs/_backlog/_TEMPLATE.md
@@ -28,8 +28,8 @@ implementation detail — that lives in the eventual `plan.md`.
 
 Name the binding Principles and operational sections this work touches, e.g.:
 
-- Principle I (Layered Architecture) — new repo/service/handler trio
-- Principle XI (Security Hardening) — input validation on new endpoint
+- Principle I (Clear Layered Architecture) — new repo/service/handler trio
+- Principle V (Security, Auth, and Privacy by Default) — input validation on new endpoint
 - §17 Quality Gate, §21 Definition of Done
 
 ## Open questions

--- a/src/api/docs/docs.go
+++ b/src/api/docs/docs.go
@@ -3076,7 +3076,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Coin"
+                            "$ref": "#/definitions/handlers.CoinCreateRequest"
                         }
                     }
                 ],
@@ -3427,7 +3427,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Coin"
+                            "$ref": "#/definitions/handlers.CoinUpdateRequest"
                         }
                     }
                 ],
@@ -7902,6 +7902,123 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.CoinCreateRequest": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "$ref": "#/definitions/models.Category"
+                },
+                "currentValue": {
+                    "type": "number"
+                },
+                "denomination": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "diameterMm": {
+                    "type": "number"
+                },
+                "era": {
+                    "maxLength": 64,
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.Era"
+                        }
+                    ]
+                },
+                "grade": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "isPrivate": {
+                    "type": "boolean"
+                },
+                "isSold": {
+                    "type": "boolean"
+                },
+                "isWishlist": {
+                    "type": "boolean"
+                },
+                "material": {
+                    "$ref": "#/definitions/models.Material"
+                },
+                "mint": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "notes": {
+                    "type": "string",
+                    "maxLength": 5000
+                },
+                "obverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "obverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "purchaseDate": {
+                    "type": "string"
+                },
+                "purchaseLocation": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "purchasePrice": {
+                    "type": "number"
+                },
+                "rarityRating": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "referenceText": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "referenceUrl": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.CoinReferenceRequest"
+                    }
+                },
+                "reverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "reverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "ruler": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "soldDate": {
+                    "type": "string"
+                },
+                "soldPrice": {
+                    "type": "number"
+                },
+                "soldTo": {
+                    "type": "string"
+                },
+                "storageLocationId": {
+                    "type": "integer"
+                },
+                "weightGrams": {
+                    "type": "number"
+                }
+            }
+        },
         "handlers.CoinDeletedResponse": {
             "type": "object",
             "properties": {
@@ -7999,6 +8116,31 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.CoinReferenceRequest": {
+            "type": "object",
+            "properties": {
+                "catalog": {
+                    "type": "string",
+                    "maxLength": 32
+                },
+                "invoiceNumber": {
+                    "type": "string",
+                    "maxLength": 64
+                },
+                "number": {
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "uri": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "volume": {
+                    "type": "string",
+                    "maxLength": 64
+                }
+            }
+        },
         "handlers.CoinReferenceUpsertRequest": {
             "type": "object",
             "properties": {
@@ -8065,6 +8207,123 @@ const docTemplate = `{
                 },
                 "sourceUrl": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.CoinUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "$ref": "#/definitions/models.Category"
+                },
+                "currentValue": {
+                    "type": "number"
+                },
+                "denomination": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "diameterMm": {
+                    "type": "number"
+                },
+                "era": {
+                    "maxLength": 64,
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.Era"
+                        }
+                    ]
+                },
+                "grade": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "isPrivate": {
+                    "type": "boolean"
+                },
+                "isSold": {
+                    "type": "boolean"
+                },
+                "isWishlist": {
+                    "type": "boolean"
+                },
+                "material": {
+                    "$ref": "#/definitions/models.Material"
+                },
+                "mint": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "notes": {
+                    "type": "string",
+                    "maxLength": 5000
+                },
+                "obverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "obverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "purchaseDate": {
+                    "type": "string"
+                },
+                "purchaseLocation": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "purchasePrice": {
+                    "type": "number"
+                },
+                "rarityRating": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "referenceText": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "referenceUrl": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.CoinReferenceRequest"
+                    }
+                },
+                "reverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "reverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "ruler": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "soldDate": {
+                    "type": "string"
+                },
+                "soldPrice": {
+                    "type": "number"
+                },
+                "soldTo": {
+                    "type": "string"
+                },
+                "storageLocationId": {
+                    "type": "integer"
+                },
+                "weightGrams": {
+                    "type": "number"
                 }
             }
         },

--- a/src/api/docs/swagger.json
+++ b/src/api/docs/swagger.json
@@ -3069,7 +3069,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Coin"
+                            "$ref": "#/definitions/handlers.CoinCreateRequest"
                         }
                     }
                 ],
@@ -3420,7 +3420,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Coin"
+                            "$ref": "#/definitions/handlers.CoinUpdateRequest"
                         }
                     }
                 ],
@@ -7895,6 +7895,123 @@
                 }
             }
         },
+        "handlers.CoinCreateRequest": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "$ref": "#/definitions/models.Category"
+                },
+                "currentValue": {
+                    "type": "number"
+                },
+                "denomination": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "diameterMm": {
+                    "type": "number"
+                },
+                "era": {
+                    "maxLength": 64,
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.Era"
+                        }
+                    ]
+                },
+                "grade": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "isPrivate": {
+                    "type": "boolean"
+                },
+                "isSold": {
+                    "type": "boolean"
+                },
+                "isWishlist": {
+                    "type": "boolean"
+                },
+                "material": {
+                    "$ref": "#/definitions/models.Material"
+                },
+                "mint": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "notes": {
+                    "type": "string",
+                    "maxLength": 5000
+                },
+                "obverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "obverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "purchaseDate": {
+                    "type": "string"
+                },
+                "purchaseLocation": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "purchasePrice": {
+                    "type": "number"
+                },
+                "rarityRating": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "referenceText": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "referenceUrl": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.CoinReferenceRequest"
+                    }
+                },
+                "reverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "reverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "ruler": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "soldDate": {
+                    "type": "string"
+                },
+                "soldPrice": {
+                    "type": "number"
+                },
+                "soldTo": {
+                    "type": "string"
+                },
+                "storageLocationId": {
+                    "type": "integer"
+                },
+                "weightGrams": {
+                    "type": "number"
+                }
+            }
+        },
         "handlers.CoinDeletedResponse": {
             "type": "object",
             "properties": {
@@ -7992,6 +8109,31 @@
                 }
             }
         },
+        "handlers.CoinReferenceRequest": {
+            "type": "object",
+            "properties": {
+                "catalog": {
+                    "type": "string",
+                    "maxLength": 32
+                },
+                "invoiceNumber": {
+                    "type": "string",
+                    "maxLength": 64
+                },
+                "number": {
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "uri": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "volume": {
+                    "type": "string",
+                    "maxLength": 64
+                }
+            }
+        },
         "handlers.CoinReferenceUpsertRequest": {
             "type": "object",
             "properties": {
@@ -8058,6 +8200,123 @@
                 },
                 "sourceUrl": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.CoinUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "$ref": "#/definitions/models.Category"
+                },
+                "currentValue": {
+                    "type": "number"
+                },
+                "denomination": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "diameterMm": {
+                    "type": "number"
+                },
+                "era": {
+                    "maxLength": 64,
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.Era"
+                        }
+                    ]
+                },
+                "grade": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "isPrivate": {
+                    "type": "boolean"
+                },
+                "isSold": {
+                    "type": "boolean"
+                },
+                "isWishlist": {
+                    "type": "boolean"
+                },
+                "material": {
+                    "$ref": "#/definitions/models.Material"
+                },
+                "mint": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "notes": {
+                    "type": "string",
+                    "maxLength": 5000
+                },
+                "obverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "obverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "purchaseDate": {
+                    "type": "string"
+                },
+                "purchaseLocation": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "purchasePrice": {
+                    "type": "number"
+                },
+                "rarityRating": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "referenceText": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "referenceUrl": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.CoinReferenceRequest"
+                    }
+                },
+                "reverseDescription": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "reverseInscription": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "ruler": {
+                    "type": "string",
+                    "maxLength": 200
+                },
+                "soldDate": {
+                    "type": "string"
+                },
+                "soldPrice": {
+                    "type": "number"
+                },
+                "soldTo": {
+                    "type": "string"
+                },
+                "storageLocationId": {
+                    "type": "integer"
+                },
+                "weightGrams": {
+                    "type": "number"
                 }
             }
         },

--- a/src/api/docs/swagger.yaml
+++ b/src/api/docs/swagger.yaml
@@ -164,6 +164,87 @@ definitions:
     - currentPassword
     - newPassword
     type: object
+  handlers.CoinCreateRequest:
+    properties:
+      category:
+        $ref: '#/definitions/models.Category'
+      currentValue:
+        type: number
+      denomination:
+        maxLength: 200
+        type: string
+      diameterMm:
+        type: number
+      era:
+        allOf:
+        - $ref: '#/definitions/models.Era'
+        maxLength: 64
+      grade:
+        maxLength: 100
+        type: string
+      isPrivate:
+        type: boolean
+      isSold:
+        type: boolean
+      isWishlist:
+        type: boolean
+      material:
+        $ref: '#/definitions/models.Material'
+      mint:
+        maxLength: 200
+        type: string
+      name:
+        maxLength: 200
+        type: string
+      notes:
+        maxLength: 5000
+        type: string
+      obverseDescription:
+        maxLength: 2000
+        type: string
+      obverseInscription:
+        maxLength: 1000
+        type: string
+      purchaseDate:
+        type: string
+      purchaseLocation:
+        maxLength: 500
+        type: string
+      purchasePrice:
+        type: number
+      rarityRating:
+        maxLength: 100
+        type: string
+      referenceText:
+        maxLength: 2000
+        type: string
+      referenceUrl:
+        maxLength: 2000
+        type: string
+      references:
+        items:
+          $ref: '#/definitions/handlers.CoinReferenceRequest'
+        type: array
+      reverseDescription:
+        maxLength: 2000
+        type: string
+      reverseInscription:
+        maxLength: 1000
+        type: string
+      ruler:
+        maxLength: 200
+        type: string
+      soldDate:
+        type: string
+      soldPrice:
+        type: number
+      soldTo:
+        type: string
+      storageLocationId:
+        type: integer
+      weightGrams:
+        type: number
+    type: object
   handlers.CoinDeletedResponse:
     properties:
       message:
@@ -232,6 +313,24 @@ definitions:
         example: III
         type: string
     type: object
+  handlers.CoinReferenceRequest:
+    properties:
+      catalog:
+        maxLength: 32
+        type: string
+      invoiceNumber:
+        maxLength: 64
+        type: string
+      number:
+        maxLength: 128
+        type: string
+      uri:
+        maxLength: 2000
+        type: string
+      volume:
+        maxLength: 64
+        type: string
+    type: object
   handlers.CoinReferenceUpsertRequest:
     properties:
       catalog:
@@ -278,6 +377,87 @@ definitions:
         type: string
       sourceUrl:
         type: string
+    type: object
+  handlers.CoinUpdateRequest:
+    properties:
+      category:
+        $ref: '#/definitions/models.Category'
+      currentValue:
+        type: number
+      denomination:
+        maxLength: 200
+        type: string
+      diameterMm:
+        type: number
+      era:
+        allOf:
+        - $ref: '#/definitions/models.Era'
+        maxLength: 64
+      grade:
+        maxLength: 100
+        type: string
+      isPrivate:
+        type: boolean
+      isSold:
+        type: boolean
+      isWishlist:
+        type: boolean
+      material:
+        $ref: '#/definitions/models.Material'
+      mint:
+        maxLength: 200
+        type: string
+      name:
+        maxLength: 200
+        type: string
+      notes:
+        maxLength: 5000
+        type: string
+      obverseDescription:
+        maxLength: 2000
+        type: string
+      obverseInscription:
+        maxLength: 1000
+        type: string
+      purchaseDate:
+        type: string
+      purchaseLocation:
+        maxLength: 500
+        type: string
+      purchasePrice:
+        type: number
+      rarityRating:
+        maxLength: 100
+        type: string
+      referenceText:
+        maxLength: 2000
+        type: string
+      referenceUrl:
+        maxLength: 2000
+        type: string
+      references:
+        items:
+          $ref: '#/definitions/handlers.CoinReferenceRequest'
+        type: array
+      reverseDescription:
+        maxLength: 2000
+        type: string
+      reverseInscription:
+        maxLength: 1000
+        type: string
+      ruler:
+        maxLength: 200
+        type: string
+      soldDate:
+        type: string
+      soldPrice:
+        type: number
+      soldTo:
+        type: string
+      storageLocationId:
+        type: integer
+      weightGrams:
+        type: number
     type: object
   handlers.CommitUpdateRequest:
     properties:
@@ -3505,7 +3685,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/models.Coin'
+          $ref: '#/definitions/handlers.CoinCreateRequest'
       produces:
       - application/json
       responses:
@@ -3617,7 +3797,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/models.Coin'
+          $ref: '#/definitions/handlers.CoinUpdateRequest'
       produces:
       - application/json
       responses:

--- a/src/api/handlers/coin_handler_test.go
+++ b/src/api/handlers/coin_handler_test.go
@@ -22,7 +22,7 @@ const coinTestJWTSecret = "coin-handler-test-secret"
 
 func setupCoinHandlerTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:coin_handler_%d?mode=memory&cache=shared", time.Now().UnixNano())), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("failed to open test db: %v", err)
 	}
@@ -83,7 +83,13 @@ func setupCoinHandlerRouter(t *testing.T) (*gin.Engine, *gorm.DB) {
 	db := setupCoinHandlerTestDB(t)
 	coinRepo := repository.NewCoinRepository(db)
 	catalogRegistryRepo := repository.NewCatalogRegistryRepository(db)
-	coinSvc := services.NewCoinService(coinRepo, nil).WithCatalogRegistrySupport(catalogRegistryRepo)
+	coinReferenceRepo := repository.NewCoinReferenceRepository(db)
+	coinReferenceSvc := services.NewCoinReferenceService(coinReferenceRepo, catalogRegistryRepo)
+	storageLocationRepo := repository.NewStorageLocationRepository(db)
+	coinSvc := services.NewCoinService(coinRepo, nil).
+		WithReferenceSupport(coinReferenceRepo, coinReferenceSvc).
+		WithStorageLocationSupport(storageLocationRepo).
+		WithCatalogRegistrySupport(catalogRegistryRepo)
 	handler := NewCoinHandler(coinRepo, coinSvc, services.NewLogger(100))
 
 	r := gin.New()
@@ -283,6 +289,228 @@ func TestCoinHandler_Update_OwnCoin(t *testing.T) {
 	}
 }
 
+func TestCoinHandler_Update_OneFieldPreservesAssociationsAndReadOnlyFields(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+	createTestUser(t, db, 2, "other")
+
+	location := models.StorageLocation{UserID: 1, Name: "Tray A"}
+	if err := db.Create(&location).Error; err != nil {
+		t.Fatalf("failed to seed storage location: %v", err)
+	}
+	currentValue := 250.0
+	valuationTime := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	coin := models.Coin{
+		Name:                  "Original Denarius",
+		Category:              models.CategoryRoman,
+		Material:              models.MaterialSilver,
+		Era:                   models.EraAncient,
+		UserID:                1,
+		CurrentValue:          &currentValue,
+		CurrentValueUpdatedAt: &valuationTime,
+		AIAnalysis:            "existing analysis",
+		StorageLocationID:     &location.ID,
+	}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+	originalID := coin.ID
+	originalCreatedAt := coin.CreatedAt
+
+	if err := db.Create(&models.CoinImage{CoinID: coin.ID, FilePath: "coins/original.jpg", ImageType: models.ImageTypeObverse, IsPrimary: true}).Error; err != nil {
+		t.Fatalf("failed to seed image: %v", err)
+	}
+	if err := db.Create(&models.CoinReference{CoinID: coin.ID, Catalog: "RIC", Volume: "II", Number: "12"}).Error; err != nil {
+		t.Fatalf("failed to seed reference: %v", err)
+	}
+	tag := models.Tag{UserID: 1, Name: "Favorites", Color: "#c9a84c"}
+	if err := db.Create(&tag).Error; err != nil {
+		t.Fatalf("failed to seed tag: %v", err)
+	}
+	if err := repository.NewTagRepository(db).AttachToCoin(coin.ID, tag.ID, 1); err != nil {
+		t.Fatalf("failed to attach tag: %v", err)
+	}
+	set := models.CoinSet{UserID: 1, Name: "Roman Core", SetType: models.CoinSetTypeOpen}
+	if err := repository.NewSetRepository(db).Create(&set); err != nil {
+		t.Fatalf("failed to seed set: %v", err)
+	}
+	if err := repository.NewSetRepository(db).AddCoinToSet(coin.ID, set.ID, 1, "keeper"); err != nil {
+		t.Fatalf("failed to attach set: %v", err)
+	}
+
+	updates := map[string]interface{}{
+		"id":                    originalID + 100,
+		"userId":                2,
+		"name":                  "Renamed Denarius",
+		"createdAt":             time.Now().Add(-24 * time.Hour),
+		"aiAnalysis":            "incoming analysis",
+		"currentValueUpdatedAt": time.Now(),
+		"images": []map[string]interface{}{
+			{"id": 999, "coinId": coin.ID, "filePath": "coins/replacement.jpg", "imageType": "reverse"},
+		},
+		"tags": []map[string]interface{}{
+			{"id": tag.ID + 100, "name": "Incoming"},
+		},
+		"sets": []map[string]interface{}{
+			{"id": set.ID + 100, "name": "Incoming Set"},
+		},
+		"storageLocation": map[string]interface{}{"id": location.ID + 100, "name": "Incoming Location"},
+	}
+	body, _ := json.Marshal(updates)
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var found models.Coin
+	if err := db.Preload("Images").Preload("References").Preload("Tags").Preload("Sets").First(&found, originalID).Error; err != nil {
+		t.Fatalf("updated coin not found: %v", err)
+	}
+	if found.ID != originalID {
+		t.Fatalf("expected read-only id %d to be preserved, got %d", originalID, found.ID)
+	}
+	if found.UserID != 1 {
+		t.Fatalf("expected read-only userId 1 to be preserved, got %d", found.UserID)
+	}
+	if !found.CreatedAt.Equal(originalCreatedAt) {
+		t.Fatalf("expected read-only createdAt to be preserved, got %v want %v", found.CreatedAt, originalCreatedAt)
+	}
+	if found.Name != "Renamed Denarius" {
+		t.Fatalf("expected name update, got %q", found.Name)
+	}
+	if found.Category != models.CategoryRoman || found.Material != models.MaterialSilver || found.Era != models.EraAncient {
+		t.Fatalf("unexpected scalar sibling mutation: category=%q material=%q era=%q", found.Category, found.Material, found.Era)
+	}
+	if found.AIAnalysis != "existing analysis" {
+		t.Fatalf("expected read-only aiAnalysis to be preserved, got %q", found.AIAnalysis)
+	}
+	if found.CurrentValueUpdatedAt == nil || !found.CurrentValueUpdatedAt.Equal(valuationTime) {
+		t.Fatalf("expected currentValueUpdatedAt to be preserved, got %v want %v", found.CurrentValueUpdatedAt, valuationTime)
+	}
+	if found.StorageLocationID == nil || *found.StorageLocationID != location.ID {
+		t.Fatalf("expected storage location %d to remain, got %v", location.ID, found.StorageLocationID)
+	}
+	if len(found.Images) != 1 || found.Images[0].FilePath != "coins/original.jpg" {
+		t.Fatalf("expected original image association to remain, got %#v", found.Images)
+	}
+	if len(found.References) != 1 || found.References[0].Number != "12" {
+		t.Fatalf("expected original reference association to remain, got %#v", found.References)
+	}
+	if len(found.Tags) != 1 || found.Tags[0].ID != tag.ID {
+		t.Fatalf("expected original tag association to remain, got %#v", found.Tags)
+	}
+	if len(found.Sets) != 1 || found.Sets[0].ID != set.ID {
+		t.Fatalf("expected original set association to remain, got %#v", found.Sets)
+	}
+
+	var valueHistoryCount int64
+	if err := db.Model(&models.CoinValueHistory{}).Where("coin_id = ?", coin.ID).Count(&valueHistoryCount).Error; err != nil {
+		t.Fatalf("failed to count value history: %v", err)
+	}
+	if valueHistoryCount != 0 {
+		t.Fatalf("expected no manual value history for name-only edit, got %d", valueHistoryCount)
+	}
+	var snapshotCount int64
+	if err := db.Model(&models.ValueSnapshot{}).Where("user_id = ?", uint(1)).Count(&snapshotCount).Error; err != nil {
+		t.Fatalf("failed to count value snapshots: %v", err)
+	}
+	if snapshotCount != 1 {
+		t.Fatalf("expected one value snapshot for update, got %d", snapshotCount)
+	}
+}
+
+func TestCoinHandler_Update_IgnoresUnknownReadOnlyAndBroadRelationshipFields(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+	createTestUser(t, db, 2, "other")
+
+	coin := models.Coin{Name: "Typed Contract Coin", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+	if err := db.Create(&models.CoinImage{CoinID: coin.ID, FilePath: "coins/original.jpg", ImageType: models.ImageTypeObverse}).Error; err != nil {
+		t.Fatalf("failed to seed image: %v", err)
+	}
+	if err := db.Create(&models.CoinReference{CoinID: coin.ID, Catalog: "RIC", Number: "1"}).Error; err != nil {
+		t.Fatalf("failed to seed reference: %v", err)
+	}
+	tag := models.Tag{UserID: 1, Name: "Original Tag"}
+	if err := db.Create(&tag).Error; err != nil {
+		t.Fatalf("failed to seed tag: %v", err)
+	}
+	if err := repository.NewTagRepository(db).AttachToCoin(coin.ID, tag.ID, 1); err != nil {
+		t.Fatalf("failed to attach tag: %v", err)
+	}
+	set := models.CoinSet{UserID: 1, Name: "Original Set", SetType: models.CoinSetTypeOpen}
+	if err := repository.NewSetRepository(db).Create(&set); err != nil {
+		t.Fatalf("failed to seed set: %v", err)
+	}
+	if err := repository.NewSetRepository(db).AddCoinToSet(coin.ID, set.ID, 1, "original"); err != nil {
+		t.Fatalf("failed to attach set: %v", err)
+	}
+
+	updates := map[string]interface{}{
+		"name":       "Typed Contract Coin Updated",
+		"unknownKey": "ignored",
+		"userId":     2,
+		"storageLocation": map[string]interface{}{
+			"id":   99,
+			"name": "Injected Location",
+		},
+		"images": []map[string]interface{}{
+			{"filePath": "coins/injected.jpg", "imageType": "reverse"},
+		},
+		"tags": []map[string]interface{}{
+			{"id": tag.ID + 100, "name": "Injected Tag"},
+		},
+		"sets": []map[string]interface{}{
+			{"id": set.ID + 100, "name": "Injected Set"},
+		},
+	}
+	body, _ := json.Marshal(updates)
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with ignored unknown/broad fields, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var found models.Coin
+	if err := db.Preload("Images").Preload("References").Preload("Tags").Preload("Sets").First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("updated coin not found: %v", err)
+	}
+	if found.Name != "Typed Contract Coin Updated" {
+		t.Fatalf("expected allowlisted name update, got %q", found.Name)
+	}
+	if found.UserID != 1 {
+		t.Fatalf("expected read-only userId to remain 1, got %d", found.UserID)
+	}
+	if len(found.Images) != 1 || found.Images[0].FilePath != "coins/original.jpg" {
+		t.Fatalf("expected image relationship payload to be ignored, got %#v", found.Images)
+	}
+	if len(found.References) != 1 || found.References[0].Number != "1" {
+		t.Fatalf("expected omitted references to be preserved, got %#v", found.References)
+	}
+	if len(found.Tags) != 1 || found.Tags[0].ID != tag.ID {
+		t.Fatalf("expected tag relationship payload to be ignored, got %#v", found.Tags)
+	}
+	if len(found.Sets) != 1 || found.Sets[0].ID != set.ID {
+		t.Fatalf("expected set relationship payload to be ignored, got %#v", found.Sets)
+	}
+}
+
 func TestCoinHandler_Update_WithSetsPayloadPreservesMemberships(t *testing.T) {
 	router, db := setupCoinHandlerRouter(t)
 	createTestUser(t, db, 1, "updater")
@@ -381,6 +609,10 @@ func TestCoinHandler_Update_StorageLocationWithSetsPreservesMemberships(t *testi
 	if err := setRepo.AddCoinToSet(coin.ID, set.ID, 1, ""); err != nil {
 		t.Fatalf("failed to seed membership: %v", err)
 	}
+	location := models.StorageLocation{UserID: 1, Name: "Tray 1"}
+	if err := db.Create(&location).Error; err != nil {
+		t.Fatalf("failed to seed storage location: %v", err)
+	}
 
 	var originalMembership models.CoinSetMembership
 	if err := db.Where("coin_id = ? AND set_id = ?", coin.ID, set.ID).First(&originalMembership).Error; err != nil {
@@ -391,7 +623,7 @@ func TestCoinHandler_Update_StorageLocationWithSetsPreservesMemberships(t *testi
 		"name":              "Stored Coin",
 		"category":          "Roman",
 		"material":          "Silver",
-		"storageLocationId": 5,
+		"storageLocationId": location.ID,
 	}
 	body, _ := json.Marshal(updates)
 
@@ -410,8 +642,8 @@ func TestCoinHandler_Update_StorageLocationWithSetsPreservesMemberships(t *testi
 	if err := db.First(&updatedCoin, coin.ID).Error; err != nil {
 		t.Fatalf("updated coin not found: %v", err)
 	}
-	if updatedCoin.StorageLocationID == nil || *updatedCoin.StorageLocationID != 5 {
-		t.Fatalf("expected storage location 5, got %v", updatedCoin.StorageLocationID)
+	if updatedCoin.StorageLocationID == nil || *updatedCoin.StorageLocationID != location.ID {
+		t.Fatalf("expected storage location %d, got %v", location.ID, updatedCoin.StorageLocationID)
 	}
 
 	var memberships []models.CoinSetMembership
@@ -429,6 +661,381 @@ func TestCoinHandler_Update_StorageLocationWithSetsPreservesMemberships(t *testi
 	}
 	if !memberships[0].AddedAt.Equal(originalMembership.AddedAt) {
 		t.Fatalf("membership AddedAt changed from %v to %v", originalMembership.AddedAt, memberships[0].AddedAt)
+	}
+}
+
+func TestCoinHandler_Update_ClearsStorageLocationWhenExplicitNull(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+
+	location := models.StorageLocation{UserID: 1, Name: "Cabinet A"}
+	if err := db.Create(&location).Error; err != nil {
+		t.Fatalf("failed to seed storage location: %v", err)
+	}
+	coin := models.Coin{
+		Name:              "Stored Coin",
+		Category:          models.CategoryRoman,
+		Material:          models.MaterialSilver,
+		UserID:            1,
+		StorageLocationID: &location.ID,
+	}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+
+	updates := map[string]interface{}{
+		"name":              "Stored Coin",
+		"category":          "Roman",
+		"material":          "Silver",
+		"storageLocationId": nil,
+	}
+	body, _ := json.Marshal(updates)
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var updatedCoin models.Coin
+	if err := db.First(&updatedCoin, coin.ID).Error; err != nil {
+		t.Fatalf("updated coin not found: %v", err)
+	}
+	if updatedCoin.StorageLocationID != nil {
+		t.Fatalf("expected storage location to be cleared, got %v", updatedCoin.StorageLocationID)
+	}
+}
+
+func TestCoinHandler_Update_RejectsNonOwnedStorageLocation(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+	createTestUser(t, db, 2, "other")
+
+	otherLocation := models.StorageLocation{UserID: 2, Name: "Other Cabinet"}
+	if err := db.Create(&otherLocation).Error; err != nil {
+		t.Fatalf("failed to seed other storage location: %v", err)
+	}
+	coin := models.Coin{Name: "Stored Coin", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{"storageLocationId": otherLocation.ID})
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-owned storage location, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found: %v", err)
+	}
+	if found.StorageLocationID != nil {
+		t.Fatalf("expected storage location to remain unset after rejected update, got %v", found.StorageLocationID)
+	}
+}
+
+func TestCoinHandler_Update_PersistsExplicitFalseAndEmptyStringClears(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+
+	coin := models.Coin{
+		Name:               "Clearable Coin",
+		Category:           models.CategoryRoman,
+		Material:           models.MaterialSilver,
+		UserID:             1,
+		Notes:              "clear me",
+		ReferenceURL:       "https://example.test/ref",
+		ReferenceText:      "clear reference text",
+		PurchaseLocation:   "Old dealer",
+		SoldTo:             "Old buyer",
+		IsPrivate:          true,
+		IsWishlist:         true,
+		IsSold:             true,
+		ObverseDescription: "clear obverse",
+		ReverseDescription: "clear reverse",
+	}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+
+	updates := map[string]interface{}{
+		"notes":              "",
+		"referenceUrl":       "",
+		"referenceText":      "",
+		"purchaseLocation":   "",
+		"soldTo":             "",
+		"obverseDescription": "",
+		"reverseDescription": "",
+		"isPrivate":          false,
+		"isWishlist":         false,
+		"isSold":             false,
+	}
+	body, _ := json.Marshal(updates)
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("updated coin not found: %v", err)
+	}
+	if found.Notes != "" || found.ReferenceURL != "" || found.ReferenceText != "" ||
+		found.PurchaseLocation != "" || found.SoldTo != "" ||
+		found.ObverseDescription != "" || found.ReverseDescription != "" {
+		t.Fatalf("expected explicit empty strings to persist, got notes=%q refURL=%q refText=%q purchaseLocation=%q soldTo=%q obv=%q rev=%q",
+			found.Notes, found.ReferenceURL, found.ReferenceText, found.PurchaseLocation, found.SoldTo, found.ObverseDescription, found.ReverseDescription)
+	}
+	if found.IsPrivate || found.IsWishlist || found.IsSold {
+		t.Fatalf("expected explicit false booleans to persist, got private=%v wishlist=%v sold=%v", found.IsPrivate, found.IsWishlist, found.IsSold)
+	}
+	if found.Category != models.CategoryRoman || found.Material != models.MaterialSilver || found.Name != "Clearable Coin" {
+		t.Fatalf("omitted sibling fields changed unexpectedly: name=%q category=%q material=%q", found.Name, found.Category, found.Material)
+	}
+}
+
+func TestCoinHandler_Update_CurrentValueCreatesManualHistoryAndSnapshot(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+
+	currentValue := 100.0
+	coin := models.Coin{
+		Name:         "Value Coin",
+		Category:     models.CategoryGreek,
+		Material:     models.MaterialSilver,
+		UserID:       1,
+		CurrentValue: &currentValue,
+	}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{"currentValue": 125.0})
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("updated coin not found: %v", err)
+	}
+	if found.CurrentValue == nil || *found.CurrentValue != 125.0 {
+		t.Fatalf("expected current value 125, got %v", found.CurrentValue)
+	}
+	if found.CurrentValueUpdatedAt == nil {
+		t.Fatal("expected manual current-value edit to set CurrentValueUpdatedAt")
+	}
+
+	var history []models.CoinValueHistory
+	if err := db.Where("coin_id = ?", coin.ID).Find(&history).Error; err != nil {
+		t.Fatalf("failed to query value history: %v", err)
+	}
+	if len(history) != 1 || history[0].Value != 125.0 || history[0].Confidence != "manual" {
+		t.Fatalf("expected one manual value-history row for 125, got %#v", history)
+	}
+
+	var journalCount int64
+	if err := db.Model(&models.CoinJournal{}).Where("coin_id = ?", coin.ID).Count(&journalCount).Error; err != nil {
+		t.Fatalf("failed to count journal entries: %v", err)
+	}
+	if journalCount != 1 {
+		t.Fatalf("expected one journal entry, got %d", journalCount)
+	}
+	var snapshotCount int64
+	if err := db.Model(&models.ValueSnapshot{}).Where("user_id = ?", uint(1)).Count(&snapshotCount).Error; err != nil {
+		t.Fatalf("failed to count value snapshots: %v", err)
+	}
+	if snapshotCount != 1 {
+		t.Fatalf("expected one value snapshot, got %d", snapshotCount)
+	}
+}
+
+func TestCoinHandler_Update_ClearsNullableScalarsWhenExplicitNullAndPreservesWhenOmitted(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+
+	purchasePrice := 125.0
+	currentValue := 175.0
+	weight := 3.5
+	diameter := 18.0
+	purchaseDate := time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC)
+	soldPrice := 150.0
+	soldDate := time.Date(2025, time.February, 20, 0, 0, 0, 0, time.UTC)
+	coin := models.Coin{
+		Name:          "Nullable Coin",
+		Category:      models.CategoryRoman,
+		Material:      models.MaterialSilver,
+		UserID:        1,
+		PurchasePrice: &purchasePrice,
+		CurrentValue:  &currentValue,
+		WeightGrams:   &weight,
+		DiameterMm:    &diameter,
+		PurchaseDate:  &purchaseDate,
+		SoldPrice:     &soldPrice,
+		SoldDate:      &soldDate,
+	}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+
+	updates := map[string]interface{}{
+		"purchasePrice": nil,
+		"currentValue":  nil,
+		"purchaseDate":  nil,
+		"soldPrice":     nil,
+		"soldDate":      nil,
+		"weightGrams":   nil,
+		"diameterMm":    nil,
+	}
+	body, _ := json.Marshal(updates)
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("updated coin not found: %v", err)
+	}
+	if found.PurchasePrice != nil || found.CurrentValue != nil || found.PurchaseDate != nil ||
+		found.SoldPrice != nil || found.SoldDate != nil || found.WeightGrams != nil || found.DiameterMm != nil {
+		t.Fatalf("expected explicit nulls to clear nullable scalars, got purchase=%v current=%v purchaseDate=%v sold=%v soldDate=%v weight=%v diameter=%v",
+			found.PurchasePrice, found.CurrentValue, found.PurchaseDate, found.SoldPrice, found.SoldDate, found.WeightGrams, found.DiameterMm)
+	}
+	if found.Name != "Nullable Coin" || found.Category != models.CategoryRoman || found.Material != models.MaterialSilver {
+		t.Fatalf("omitted non-nullable fields changed unexpectedly: name=%q category=%q material=%q", found.Name, found.Category, found.Material)
+	}
+
+	preserved := models.Coin{
+		Name:          "Preserved Nullable Coin",
+		Category:      models.CategoryRoman,
+		Material:      models.MaterialSilver,
+		UserID:        1,
+		PurchasePrice: &purchasePrice,
+		CurrentValue:  &currentValue,
+		WeightGrams:   &weight,
+		DiameterMm:    &diameter,
+		PurchaseDate:  &purchaseDate,
+		SoldPrice:     &soldPrice,
+		SoldDate:      &soldDate,
+	}
+	if err := db.Create(&preserved).Error; err != nil {
+		t.Fatalf("failed to seed preserved coin: %v", err)
+	}
+	nameOnlyBody, _ := json.Marshal(map[string]interface{}{"name": "Renamed Preserved Nullable Coin"})
+	nameOnlyReq := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", preserved.ID), bytes.NewReader(nameOnlyBody))
+	nameOnlyReq.Header.Set("Content-Type", "application/json")
+	nameOnlyReq.Header.Set("Authorization", authHeader(1))
+	nameOnlyRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(nameOnlyRecorder, nameOnlyReq)
+
+	if nameOnlyRecorder.Code != http.StatusOK {
+		t.Fatalf("expected 200 for name-only update, got %d: %s", nameOnlyRecorder.Code, nameOnlyRecorder.Body.String())
+	}
+	var preservedFound models.Coin
+	if err := db.First(&preservedFound, preserved.ID).Error; err != nil {
+		t.Fatalf("preserved coin not found: %v", err)
+	}
+	if preservedFound.PurchasePrice == nil || *preservedFound.PurchasePrice != purchasePrice ||
+		preservedFound.CurrentValue == nil || *preservedFound.CurrentValue != currentValue ||
+		preservedFound.PurchaseDate == nil || !preservedFound.PurchaseDate.Equal(purchaseDate) ||
+		preservedFound.SoldPrice == nil || *preservedFound.SoldPrice != soldPrice ||
+		preservedFound.SoldDate == nil || !preservedFound.SoldDate.Equal(soldDate) ||
+		preservedFound.WeightGrams == nil || *preservedFound.WeightGrams != weight ||
+		preservedFound.DiameterMm == nil || *preservedFound.DiameterMm != diameter {
+		t.Fatalf("expected omitted nullable scalars to be preserved, got purchase=%v current=%v purchaseDate=%v sold=%v soldDate=%v weight=%v diameter=%v",
+			preservedFound.PurchasePrice, preservedFound.CurrentValue, preservedFound.PurchaseDate, preservedFound.SoldPrice, preservedFound.SoldDate, preservedFound.WeightGrams, preservedFound.DiameterMm)
+	}
+}
+
+func TestCoinHandler_Update_ReplacesStructuredReferences(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+
+	if err := db.Create(&models.CatalogRegistry{
+		Catalog:        "RIC",
+		DisplayName:    "Roman Imperial Coinage",
+		Era:            models.EraAncient,
+		VolumeRequired: true,
+	}).Error; err != nil {
+		t.Fatalf("failed to seed catalog registry: %v", err)
+	}
+	coin := models.Coin{Name: "Reference Coin", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+	if err := db.Create(&models.CoinReference{CoinID: coin.ID, Catalog: "RIC", Volume: "I", Number: "1"}).Error; err != nil {
+		t.Fatalf("failed to seed reference: %v", err)
+	}
+
+	updates := map[string]interface{}{
+		"name":     "Reference Coin",
+		"category": "Roman",
+		"material": "Silver",
+		"references": []map[string]interface{}{
+			{
+				"catalog": " ric ",
+				"volume":  " II ",
+				"number":  " 12 ",
+			},
+		},
+	}
+	body, _ := json.Marshal(updates)
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var refs []models.CoinReference
+	if err := db.Where("coin_id = ?", coin.ID).Find(&refs).Error; err != nil {
+		t.Fatalf("failed to query references: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected exactly 1 replacement reference, got %d", len(refs))
+	}
+	if refs[0].Catalog != "RIC" || refs[0].Volume != "II" || refs[0].Number != "12" {
+		t.Fatalf("expected normalized replacement reference RIC II 12, got %#v", refs[0])
 	}
 }
 

--- a/src/api/handlers/coin_requests.go
+++ b/src/api/handlers/coin_requests.go
@@ -1,0 +1,258 @@
+package handlers
+
+import (
+	"time"
+
+	"github.com/briandenicola/ancient-coins-api/models"
+)
+
+type CoinReferenceRequest struct {
+	Catalog       string `json:"catalog" binding:"max=32"`
+	Volume        string `json:"volume" binding:"max=64"`
+	Number        string `json:"number" binding:"max=128"`
+	InvoiceNumber string `json:"invoiceNumber" binding:"max=64"`
+	URI           string `json:"uri" binding:"max=2000"`
+}
+
+type CoinCreateRequest struct {
+	Name               string                 `json:"name" binding:"max=200"`
+	Category           models.Category        `json:"category"`
+	Denomination       string                 `json:"denomination" binding:"max=200"`
+	Ruler              string                 `json:"ruler" binding:"max=200"`
+	Era                models.Era             `json:"era" binding:"omitempty,max=64"`
+	Mint               string                 `json:"mint" binding:"max=200"`
+	Material           models.Material        `json:"material"`
+	WeightGrams        *float64               `json:"weightGrams"`
+	DiameterMm         *float64               `json:"diameterMm"`
+	Grade              string                 `json:"grade" binding:"max=100"`
+	ObverseInscription string                 `json:"obverseInscription" binding:"max=1000"`
+	ReverseInscription string                 `json:"reverseInscription" binding:"max=1000"`
+	ObverseDescription string                 `json:"obverseDescription" binding:"max=2000"`
+	ReverseDescription string                 `json:"reverseDescription" binding:"max=2000"`
+	RarityRating       string                 `json:"rarityRating" binding:"max=100"`
+	PurchasePrice      *float64               `json:"purchasePrice"`
+	CurrentValue       *float64               `json:"currentValue"`
+	PurchaseDate       *time.Time             `json:"purchaseDate"`
+	PurchaseLocation   string                 `json:"purchaseLocation" binding:"max=500"`
+	Notes              string                 `json:"notes" binding:"max=5000"`
+	ReferenceURL       string                 `json:"referenceUrl" binding:"max=2000"`
+	ReferenceText      string                 `json:"referenceText" binding:"max=2000"`
+	IsWishlist         bool                   `json:"isWishlist"`
+	IsSold             bool                   `json:"isSold"`
+	SoldPrice          *float64               `json:"soldPrice"`
+	SoldDate           *time.Time             `json:"soldDate"`
+	SoldTo             string                 `json:"soldTo"`
+	StorageLocationID  *uint                  `json:"storageLocationId"`
+	IsPrivate          bool                   `json:"isPrivate"`
+	References         []CoinReferenceRequest `json:"references"`
+}
+
+type CoinUpdateRequest struct {
+	Name               *string                `json:"name" binding:"omitempty,max=200"`
+	Category           *models.Category       `json:"category"`
+	Denomination       *string                `json:"denomination" binding:"omitempty,max=200"`
+	Ruler              *string                `json:"ruler" binding:"omitempty,max=200"`
+	Era                *models.Era            `json:"era" binding:"omitempty,max=64"`
+	Mint               *string                `json:"mint" binding:"omitempty,max=200"`
+	Material           *models.Material       `json:"material"`
+	WeightGrams        *float64               `json:"weightGrams"`
+	DiameterMm         *float64               `json:"diameterMm"`
+	Grade              *string                `json:"grade" binding:"omitempty,max=100"`
+	ObverseInscription *string                `json:"obverseInscription" binding:"omitempty,max=1000"`
+	ReverseInscription *string                `json:"reverseInscription" binding:"omitempty,max=1000"`
+	ObverseDescription *string                `json:"obverseDescription" binding:"omitempty,max=2000"`
+	ReverseDescription *string                `json:"reverseDescription" binding:"omitempty,max=2000"`
+	RarityRating       *string                `json:"rarityRating" binding:"omitempty,max=100"`
+	PurchasePrice      *float64               `json:"purchasePrice"`
+	CurrentValue       *float64               `json:"currentValue"`
+	PurchaseDate       *time.Time             `json:"purchaseDate"`
+	PurchaseLocation   *string                `json:"purchaseLocation" binding:"omitempty,max=500"`
+	Notes              *string                `json:"notes" binding:"omitempty,max=5000"`
+	ReferenceURL       *string                `json:"referenceUrl" binding:"omitempty,max=2000"`
+	ReferenceText      *string                `json:"referenceText" binding:"omitempty,max=2000"`
+	IsWishlist         *bool                  `json:"isWishlist"`
+	IsSold             *bool                  `json:"isSold"`
+	SoldPrice          *float64               `json:"soldPrice"`
+	SoldDate           *time.Time             `json:"soldDate"`
+	SoldTo             *string                `json:"soldTo"`
+	StorageLocationID  *uint                  `json:"storageLocationId"`
+	IsPrivate          *bool                  `json:"isPrivate"`
+	References         []CoinReferenceRequest `json:"references"`
+}
+
+func (r CoinCreateRequest) toCoin(userID uint) models.Coin {
+	return models.Coin{
+		Name:               r.Name,
+		Category:           r.Category,
+		Denomination:       r.Denomination,
+		Ruler:              r.Ruler,
+		Era:                r.Era,
+		Mint:               r.Mint,
+		Material:           r.Material,
+		WeightGrams:        r.WeightGrams,
+		DiameterMm:         r.DiameterMm,
+		Grade:              r.Grade,
+		ObverseInscription: r.ObverseInscription,
+		ReverseInscription: r.ReverseInscription,
+		ObverseDescription: r.ObverseDescription,
+		ReverseDescription: r.ReverseDescription,
+		RarityRating:       r.RarityRating,
+		PurchasePrice:      r.PurchasePrice,
+		CurrentValue:       r.CurrentValue,
+		PurchaseDate:       r.PurchaseDate,
+		PurchaseLocation:   r.PurchaseLocation,
+		Notes:              r.Notes,
+		ReferenceURL:       r.ReferenceURL,
+		ReferenceText:      r.ReferenceText,
+		IsWishlist:         r.IsWishlist,
+		IsSold:             r.IsSold,
+		SoldPrice:          r.SoldPrice,
+		SoldDate:           r.SoldDate,
+		SoldTo:             r.SoldTo,
+		StorageLocationID:  r.StorageLocationID,
+		IsPrivate:          r.IsPrivate,
+		UserID:             userID,
+		References:         mapCoinReferenceRequests(r.References),
+	}
+}
+
+func (r CoinUpdateRequest) toCoin(existing *models.Coin, storageLocationProvided bool, nullableScalarProvided map[string]bool) (models.Coin, []string) {
+	updates := models.Coin{ID: existing.ID, UserID: existing.UserID}
+	updateFields := make([]string, 0, 32)
+	if r.Name != nil {
+		updates.Name = *r.Name
+		updateFields = append(updateFields, "Name")
+	}
+	if r.Category != nil {
+		updates.Category = *r.Category
+		updateFields = append(updateFields, "Category")
+	}
+	if r.Denomination != nil {
+		updates.Denomination = *r.Denomination
+		updateFields = append(updateFields, "Denomination")
+	}
+	if r.Ruler != nil {
+		updates.Ruler = *r.Ruler
+		updateFields = append(updateFields, "Ruler")
+	}
+	if r.Era != nil {
+		updates.Era = *r.Era
+		updateFields = append(updateFields, "Era")
+	}
+	if r.Mint != nil {
+		updates.Mint = *r.Mint
+		updateFields = append(updateFields, "Mint")
+	}
+	if r.Material != nil {
+		updates.Material = *r.Material
+		updateFields = append(updateFields, "Material")
+	}
+	if r.WeightGrams != nil || nullableScalarProvided["WeightGrams"] {
+		updates.WeightGrams = r.WeightGrams
+		updateFields = append(updateFields, "WeightGrams")
+	}
+	if r.DiameterMm != nil || nullableScalarProvided["DiameterMm"] {
+		updates.DiameterMm = r.DiameterMm
+		updateFields = append(updateFields, "DiameterMm")
+	}
+	if r.Grade != nil {
+		updates.Grade = *r.Grade
+		updateFields = append(updateFields, "Grade")
+	}
+	if r.ObverseInscription != nil {
+		updates.ObverseInscription = *r.ObverseInscription
+		updateFields = append(updateFields, "ObverseInscription")
+	}
+	if r.ReverseInscription != nil {
+		updates.ReverseInscription = *r.ReverseInscription
+		updateFields = append(updateFields, "ReverseInscription")
+	}
+	if r.ObverseDescription != nil {
+		updates.ObverseDescription = *r.ObverseDescription
+		updateFields = append(updateFields, "ObverseDescription")
+	}
+	if r.ReverseDescription != nil {
+		updates.ReverseDescription = *r.ReverseDescription
+		updateFields = append(updateFields, "ReverseDescription")
+	}
+	if r.RarityRating != nil {
+		updates.RarityRating = *r.RarityRating
+		updateFields = append(updateFields, "RarityRating")
+	}
+	if r.PurchasePrice != nil || nullableScalarProvided["PurchasePrice"] {
+		updates.PurchasePrice = r.PurchasePrice
+		updateFields = append(updateFields, "PurchasePrice")
+	}
+	if r.CurrentValue != nil || nullableScalarProvided["CurrentValue"] {
+		updates.CurrentValue = r.CurrentValue
+		updateFields = append(updateFields, "CurrentValue")
+	}
+	if r.PurchaseDate != nil || nullableScalarProvided["PurchaseDate"] {
+		updates.PurchaseDate = r.PurchaseDate
+		updateFields = append(updateFields, "PurchaseDate")
+	}
+	if r.PurchaseLocation != nil {
+		updates.PurchaseLocation = *r.PurchaseLocation
+		updateFields = append(updateFields, "PurchaseLocation")
+	}
+	if r.Notes != nil {
+		updates.Notes = *r.Notes
+		updateFields = append(updateFields, "Notes")
+	}
+	if r.ReferenceURL != nil {
+		updates.ReferenceURL = *r.ReferenceURL
+		updateFields = append(updateFields, "ReferenceURL")
+	}
+	if r.ReferenceText != nil {
+		updates.ReferenceText = *r.ReferenceText
+		updateFields = append(updateFields, "ReferenceText")
+	}
+	if r.IsWishlist != nil {
+		updates.IsWishlist = *r.IsWishlist
+		updateFields = append(updateFields, "IsWishlist")
+	}
+	if r.IsSold != nil {
+		updates.IsSold = *r.IsSold
+		updateFields = append(updateFields, "IsSold")
+	}
+	if r.SoldPrice != nil || nullableScalarProvided["SoldPrice"] {
+		updates.SoldPrice = r.SoldPrice
+		updateFields = append(updateFields, "SoldPrice")
+	}
+	if r.SoldDate != nil || nullableScalarProvided["SoldDate"] {
+		updates.SoldDate = r.SoldDate
+		updateFields = append(updateFields, "SoldDate")
+	}
+	if r.SoldTo != nil {
+		updates.SoldTo = *r.SoldTo
+		updateFields = append(updateFields, "SoldTo")
+	}
+	if storageLocationProvided {
+		updates.StorageLocationID = r.StorageLocationID
+	}
+	if r.IsPrivate != nil {
+		updates.IsPrivate = *r.IsPrivate
+		updateFields = append(updateFields, "IsPrivate")
+	}
+	if r.References != nil {
+		updates.References = mapCoinReferenceRequests(r.References)
+	}
+	return updates, updateFields
+}
+
+func mapCoinReferenceRequests(requests []CoinReferenceRequest) []models.CoinReference {
+	if requests == nil {
+		return nil
+	}
+	refs := make([]models.CoinReference, 0, len(requests))
+	for _, ref := range requests {
+		refs = append(refs, models.CoinReference{
+			Catalog:       ref.Catalog,
+			Volume:        ref.Volume,
+			Number:        ref.Number,
+			InvoiceNumber: ref.InvoiceNumber,
+			URI:           ref.URI,
+		})
+	}
+	return refs
+}

--- a/src/api/handlers/coins.go
+++ b/src/api/handlers/coins.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/briandenicola/ancient-coins-api/models"
 	"github.com/briandenicola/ancient-coins-api/repository"
 	"github.com/briandenicola/ancient-coins-api/services"
 	"github.com/gin-gonic/gin"
@@ -28,6 +27,26 @@ var allowedListSortFields = map[string]bool{
 	"purchase_date": true,
 	"name":          true,
 	"random":        true,
+}
+
+var nullableCoinUpdateScalarFields = map[string]string{
+	"purchasePrice": "PurchasePrice",
+	"currentValue":  "CurrentValue",
+	"purchaseDate":  "PurchaseDate",
+	"soldPrice":     "SoldPrice",
+	"soldDate":      "SoldDate",
+	"weightGrams":   "WeightGrams",
+	"diameterMm":    "DiameterMm",
+}
+
+func nullableScalarFieldPresence(raw map[string]json.RawMessage) map[string]bool {
+	present := make(map[string]bool, len(nullableCoinUpdateScalarFields))
+	for jsonField, modelField := range nullableCoinUpdateScalarFields {
+		if _, ok := raw[jsonField]; ok {
+			present[modelField] = true
+		}
+	}
+	return present
 }
 
 type CoinHandler struct {
@@ -213,7 +232,7 @@ func (h *CoinHandler) Get(c *gin.Context) {
 //	@Tags			Coins
 //	@Accept			json
 //	@Produce		json
-//	@Param			body	body		models.Coin	true	"Coin data"
+//	@Param			body	body		CoinCreateRequest	true	"Coin data"
 //	@Success		201		{object}	models.Coin
 //	@Failure		400		{object}	ErrorResponse
 //	@Failure		401		{object}	ErrorResponse
@@ -224,15 +243,13 @@ func (h *CoinHandler) Create(c *gin.Context) {
 	logger := h.logger
 	userID := c.GetUint("userId")
 
-	var coin models.Coin
-	if err := c.ShouldBindJSON(&coin); err != nil {
+	var req CoinCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		respondError(c, http.StatusBadRequest, "Invalid request payload", err)
 		return
 	}
 
-	coin.UserID = userID
-	coin.ID = 0
-	coin.StorageLocation = nil
+	coin := req.toCoin(userID)
 
 	logger.Debug("coins", "Creating coin '%s' for user %d", coin.Name, userID)
 
@@ -257,7 +274,7 @@ func (h *CoinHandler) Create(c *gin.Context) {
 //	@Accept			json
 //	@Produce		json
 //	@Param			id		path		int			true	"Coin ID"
-//	@Param			body	body		models.Coin	true	"Updated coin data"
+//	@Param			body	body		CoinUpdateRequest	true	"Updated coin data"
 //	@Success		200		{object}	models.Coin
 //	@Failure		400		{object}	ErrorResponse
 //	@Failure		401		{object}	ErrorResponse
@@ -286,23 +303,23 @@ func (h *CoinHandler) Update(c *gin.Context) {
 	}
 	var raw map[string]json.RawMessage
 	storageLocationProvided := false
+	nullableScalarProvided := map[string]bool{}
 	if err := json.Unmarshal(bodyBytes, &raw); err == nil {
 		_, storageLocationProvided = raw["storageLocationId"]
+		nullableScalarProvided = nullableScalarFieldPresence(raw)
 	}
 	c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
-	var updates models.Coin
-	if err := c.ShouldBindJSON(&updates); err != nil {
+	var req CoinUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		respondError(c, http.StatusBadRequest, "Invalid request payload", err)
 		return
 	}
 
-	updates.ID = existing.ID
-	updates.UserID = userID
-	updates.StorageLocation = nil
+	updates, updateFields := req.toCoin(existing, storageLocationProvided, nullableScalarProvided)
 
 	source := c.Query("source")
-	if err := h.svc.UpdateCoin(existing, &updates, userID, source, storageLocationProvided); err != nil {
+	if err := h.svc.UpdateCoinWithFields(existing, &updates, updateFields, userID, source, storageLocationProvided); err != nil {
 		if handleCoinMutationError(c, err) {
 			return
 		}

--- a/src/api/repository/coin_repository.go
+++ b/src/api/repository/coin_repository.go
@@ -337,17 +337,23 @@ func (r *CoinRepository) Create(coin *models.Coin) error {
 	return r.db.Preload("Images").Preload("References").Preload("StorageLocation").First(coin, coin.ID).Error
 }
 
-// Update applies changes to an existing coin and reloads it with images.
-func (r *CoinRepository) Update(existing *models.Coin, updates *models.Coin) error {
+// Update applies a scalar patch to an existing coin and reloads read associations.
+// When selectFields are supplied, only those fields are persisted, including
+// explicit zero values; relationship changes stay on their dedicated paths.
+func (r *CoinRepository) Update(existing *models.Coin, updates *models.Coin, selectFields ...string) error {
 	// Relationship changes are managed through dedicated tag/set methods.
 	// Coin sets require explicit membership writes because AddedAt is NOT NULL.
-	if err := omitCoinRelationships(r.db.Model(existing)).Updates(updates).Error; err != nil {
+	query := omitCoinRelationships(r.db.Model(existing))
+	if len(selectFields) > 0 {
+		query = query.Select(selectFields)
+	}
+	if err := query.Updates(updates).Error; err != nil {
 		return err
 	}
 	return r.db.Preload("Images").Preload("References").Preload("StorageLocation").First(existing, existing.ID).Error
 }
 
-// UpdateField updates a single field on a coin.
+// UpdateField updates one explicit column without syncing loaded associations.
 func (r *CoinRepository) UpdateField(coin *models.Coin, field string, value interface{}) error {
 	if err := omitCoinRelationships(r.db.Model(coin)).Update(field, value).Error; err != nil {
 		return err
@@ -355,7 +361,7 @@ func (r *CoinRepository) UpdateField(coin *models.Coin, field string, value inte
 	return r.db.Preload("Images").Preload("References").Preload("StorageLocation").First(coin, coin.ID).Error
 }
 
-// UpdateFields updates multiple fields on a coin using a map.
+// UpdateFields updates multiple explicit columns, including zero/nil values, without syncing loaded associations.
 func (r *CoinRepository) UpdateFields(coin *models.Coin, updates map[string]interface{}) error {
 	if err := omitCoinRelationships(r.db.Model(coin)).Updates(updates).Error; err != nil {
 		return err
@@ -363,12 +369,25 @@ func (r *CoinRepository) UpdateFields(coin *models.Coin, updates map[string]inte
 	return r.db.Preload("Images").Preload("References").Preload("StorageLocation").First(coin, coin.ID).Error
 }
 
-// UpdateStorageLocationID updates a coin storage-location foreign key, including clearing it.
+// UpdateStorageLocationID updates only the storage-location foreign key, including clearing it.
 func (r *CoinRepository) UpdateStorageLocationID(coin *models.Coin, storageLocationID *uint) error {
-	if err := omitCoinRelationships(r.db.Model(coin)).Update("storage_location_id", storageLocationID).Error; err != nil {
+	query := r.db.Model(&models.Coin{}).Where("id = ? AND user_id = ?", coin.ID, coin.UserID)
+	if storageLocationID == nil {
+		if err := query.Update("storage_location_id", nil).Error; err != nil {
+			return err
+		}
+	} else {
+		if err := query.Update("storage_location_id", *storageLocationID).Error; err != nil {
+			return err
+		}
+	}
+	if err := r.db.Preload("Images").Preload("References").Preload("StorageLocation").First(coin, coin.ID).Error; err != nil {
 		return err
 	}
-	return r.db.Preload("Images").Preload("References").Preload("StorageLocation").First(coin, coin.ID).Error
+	if storageLocationID == nil {
+		coin.StorageLocation = nil
+	}
+	return nil
 }
 
 // Delete removes a coin and all associated data (images, journals, value

--- a/src/api/repository/coin_repository_test.go
+++ b/src/api/repository/coin_repository_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"testing"
+	"time"
 
 	"github.com/briandenicola/ancient-coins-api/models"
 	"github.com/glebarez/sqlite"
@@ -469,6 +470,280 @@ func TestCoinRepository_Update_WithSetsField(t *testing.T) {
 	db.Model(&models.CoinSetMembership{}).Where("coin_id = ? AND set_id = ?", coin.ID, set2.ID).Count(&set2Count)
 	if set2Count != 0 {
 		t.Error("set2 was added despite Omit('Sets'); update should not touch Sets")
+	}
+}
+
+func TestCoinRepository_Update_PreservesLoadedAssociations(t *testing.T) {
+	db := setupTestDB(t)
+	coinRepo := NewCoinRepository(db)
+	setRepo := NewSetRepository(db)
+	tagRepo := NewTagRepository(db)
+
+	location := models.StorageLocation{UserID: 1, Name: "Cabinet A"}
+	if err := db.Create(&location).Error; err != nil {
+		t.Fatalf("Create storage location failed: %v", err)
+	}
+	coin := &models.Coin{
+		Name:              "Associated Coin",
+		Category:          models.CategoryRoman,
+		Material:          models.MaterialSilver,
+		UserID:            1,
+		StorageLocationID: &location.ID,
+	}
+	if err := coinRepo.Create(coin); err != nil {
+		t.Fatalf("Create coin failed: %v", err)
+	}
+	if err := db.Create(&models.CoinImage{CoinID: coin.ID, FilePath: "coins/original.jpg", ImageType: models.ImageTypeObverse, IsPrimary: true}).Error; err != nil {
+		t.Fatalf("Create image failed: %v", err)
+	}
+	if err := db.Create(&models.CoinReference{CoinID: coin.ID, Catalog: "RIC", Volume: "I", Number: "1"}).Error; err != nil {
+		t.Fatalf("Create reference failed: %v", err)
+	}
+	tag := &models.Tag{UserID: 1, Name: "Favorites", Color: "#c9a84c"}
+	if err := tagRepo.Create(tag); err != nil {
+		t.Fatalf("Create tag failed: %v", err)
+	}
+	if err := tagRepo.AttachToCoin(coin.ID, tag.ID, 1); err != nil {
+		t.Fatalf("Attach tag failed: %v", err)
+	}
+	set := &models.CoinSet{UserID: 1, Name: "Roman Core", SetType: models.CoinSetTypeOpen}
+	if err := setRepo.Create(set); err != nil {
+		t.Fatalf("Create set failed: %v", err)
+	}
+	if err := setRepo.AddCoinToSet(coin.ID, set.ID, 1, "original"); err != nil {
+		t.Fatalf("AddCoinToSet failed: %v", err)
+	}
+
+	loaded, err := coinRepo.FindByID(coin.ID, 1)
+	if err != nil {
+		t.Fatalf("FindByID failed: %v", err)
+	}
+	if len(loaded.Images) != 1 || len(loaded.References) != 1 || len(loaded.Tags) != 1 || len(loaded.Sets) != 1 || loaded.StorageLocation == nil {
+		t.Fatalf("expected loaded associations before update, got images=%d refs=%d tags=%d sets=%d storage=%v", len(loaded.Images), len(loaded.References), len(loaded.Tags), len(loaded.Sets), loaded.StorageLocation)
+	}
+
+	incomingTag := models.Tag{ID: tag.ID + 100, UserID: 1, Name: "Incoming"}
+	incomingSet := models.CoinSet{ID: set.ID + 100, UserID: 1, Name: "Incoming Set", SetType: models.CoinSetTypeOpen}
+	updates := &models.Coin{
+		Name: "Updated Associated Coin",
+		Images: []models.CoinImage{
+			{ID: loaded.Images[0].ID + 100, CoinID: loaded.ID, FilePath: "coins/incoming.jpg", ImageType: models.ImageTypeReverse},
+		},
+		References: []models.CoinReference{
+			{ID: loaded.References[0].ID + 100, CoinID: loaded.ID, Catalog: "RIC", Volume: "II", Number: "2"},
+		},
+		Tags:            []models.Tag{incomingTag},
+		Sets:            []models.CoinSet{incomingSet},
+		StorageLocation: &models.StorageLocation{ID: location.ID + 100, UserID: 1, Name: "Incoming Location"},
+	}
+	if err := coinRepo.Update(loaded, updates); err != nil {
+		t.Fatalf("Update coin failed: %v", err)
+	}
+
+	var found models.Coin
+	if err := db.Preload("Images").Preload("References").Preload("Tags").Preload("Sets").Preload("StorageLocation").First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found after update: %v", err)
+	}
+	if found.Name != "Updated Associated Coin" {
+		t.Fatalf("expected name update, got %q", found.Name)
+	}
+	if len(found.Images) != 1 || found.Images[0].FilePath != "coins/original.jpg" {
+		t.Fatalf("expected original image to remain, got %#v", found.Images)
+	}
+	if len(found.References) != 1 || found.References[0].Number != "1" {
+		t.Fatalf("expected original reference to remain, got %#v", found.References)
+	}
+	if len(found.Tags) != 1 || found.Tags[0].ID != tag.ID {
+		t.Fatalf("expected original tag to remain, got %#v", found.Tags)
+	}
+	if len(found.Sets) != 1 || found.Sets[0].ID != set.ID {
+		t.Fatalf("expected original set to remain, got %#v", found.Sets)
+	}
+	if found.StorageLocationID == nil || *found.StorageLocationID != location.ID {
+		t.Fatalf("expected original storage location %d to remain, got %v", location.ID, found.StorageLocationID)
+	}
+	var incomingImageCount int64
+	if err := db.Model(&models.CoinImage{}).Where("file_path = ?", "coins/incoming.jpg").Count(&incomingImageCount).Error; err != nil {
+		t.Fatalf("failed to count incoming image: %v", err)
+	}
+	if incomingImageCount != 0 {
+		t.Fatal("incoming image association was persisted by scalar update")
+	}
+}
+
+func TestCoinRepository_Update_WithSelectedFieldsPersistsExplicitZeroValues(t *testing.T) {
+	db := setupTestDB(t)
+	coinRepo := NewCoinRepository(db)
+
+	purchasePrice := 125.0
+	currentValue := 175.0
+	weight := 3.5
+	diameter := 18.0
+	coin := &models.Coin{
+		Name:             "Zero Value Coin",
+		Category:         models.CategoryRoman,
+		Material:         models.MaterialSilver,
+		UserID:           1,
+		Notes:            "clear me",
+		ReferenceURL:     "https://example.test/ref",
+		ReferenceText:    "clear reference text",
+		PurchaseLocation: "Old dealer",
+		IsPrivate:        true,
+		IsWishlist:       true,
+		IsSold:           true,
+		PurchasePrice:    &purchasePrice,
+		CurrentValue:     &currentValue,
+		WeightGrams:      &weight,
+		DiameterMm:       &diameter,
+	}
+	if err := coinRepo.Create(coin); err != nil {
+		t.Fatalf("Create coin failed: %v", err)
+	}
+
+	zero := 0.0
+	updates := &models.Coin{
+		Notes:            "",
+		ReferenceURL:     "",
+		ReferenceText:    "",
+		PurchaseLocation: "",
+		IsPrivate:        false,
+		IsWishlist:       false,
+		IsSold:           false,
+		PurchasePrice:    &zero,
+		CurrentValue:     &zero,
+		WeightGrams:      &zero,
+		DiameterMm:       &zero,
+	}
+	if err := coinRepo.Update(
+		coin,
+		updates,
+		"Notes",
+		"ReferenceURL",
+		"ReferenceText",
+		"PurchaseLocation",
+		"IsPrivate",
+		"IsWishlist",
+		"IsSold",
+		"PurchasePrice",
+		"CurrentValue",
+		"WeightGrams",
+		"DiameterMm",
+	); err != nil {
+		t.Fatalf("Update coin failed: %v", err)
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found after update: %v", err)
+	}
+	if found.Notes != "" || found.ReferenceURL != "" || found.ReferenceText != "" || found.PurchaseLocation != "" {
+		t.Fatalf("expected empty string clears to persist, got notes=%q refURL=%q refText=%q purchaseLocation=%q",
+			found.Notes, found.ReferenceURL, found.ReferenceText, found.PurchaseLocation)
+	}
+	if found.IsPrivate || found.IsWishlist || found.IsSold {
+		t.Fatalf("expected false booleans to persist, got private=%v wishlist=%v sold=%v", found.IsPrivate, found.IsWishlist, found.IsSold)
+	}
+	if found.PurchasePrice == nil || *found.PurchasePrice != 0 ||
+		found.CurrentValue == nil || *found.CurrentValue != 0 ||
+		found.WeightGrams == nil || *found.WeightGrams != 0 ||
+		found.DiameterMm == nil || *found.DiameterMm != 0 {
+		t.Fatalf("expected explicit numeric zeros to persist, got purchase=%v current=%v weight=%v diameter=%v",
+			found.PurchasePrice, found.CurrentValue, found.WeightGrams, found.DiameterMm)
+	}
+	if found.Name != "Zero Value Coin" || found.Category != models.CategoryRoman || found.Material != models.MaterialSilver {
+		t.Fatalf("omitted fields changed unexpectedly: name=%q category=%q material=%q", found.Name, found.Category, found.Material)
+	}
+}
+
+func TestCoinRepository_Update_WithSelectedFieldsPersistsNilNullableScalars(t *testing.T) {
+	db := setupTestDB(t)
+	coinRepo := NewCoinRepository(db)
+
+	purchasePrice := 125.0
+	currentValue := 175.0
+	weight := 3.5
+	diameter := 18.0
+	purchaseDate := time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC)
+	soldPrice := 150.0
+	soldDate := time.Date(2025, time.February, 20, 0, 0, 0, 0, time.UTC)
+	coin := &models.Coin{
+		Name:          "Nil Nullable Coin",
+		Category:      models.CategoryRoman,
+		Material:      models.MaterialSilver,
+		UserID:        1,
+		PurchasePrice: &purchasePrice,
+		CurrentValue:  &currentValue,
+		WeightGrams:   &weight,
+		DiameterMm:    &diameter,
+		PurchaseDate:  &purchaseDate,
+		SoldPrice:     &soldPrice,
+		SoldDate:      &soldDate,
+	}
+	if err := coinRepo.Create(coin); err != nil {
+		t.Fatalf("Create coin failed: %v", err)
+	}
+
+	updates := &models.Coin{}
+	if err := coinRepo.Update(
+		coin,
+		updates,
+		"PurchasePrice",
+		"CurrentValue",
+		"PurchaseDate",
+		"SoldPrice",
+		"SoldDate",
+		"WeightGrams",
+		"DiameterMm",
+	); err != nil {
+		t.Fatalf("Update coin failed: %v", err)
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found after update: %v", err)
+	}
+	if found.PurchasePrice != nil || found.CurrentValue != nil || found.PurchaseDate != nil ||
+		found.SoldPrice != nil || found.SoldDate != nil || found.WeightGrams != nil || found.DiameterMm != nil {
+		t.Fatalf("expected selected nil nullable scalars to persist, got purchase=%v current=%v purchaseDate=%v sold=%v soldDate=%v weight=%v diameter=%v",
+			found.PurchasePrice, found.CurrentValue, found.PurchaseDate, found.SoldPrice, found.SoldDate, found.WeightGrams, found.DiameterMm)
+	}
+	if found.Name != "Nil Nullable Coin" || found.Category != models.CategoryRoman || found.Material != models.MaterialSilver {
+		t.Fatalf("omitted fields changed unexpectedly: name=%q category=%q material=%q", found.Name, found.Category, found.Material)
+	}
+}
+
+func TestCoinRepository_UpdateStorageLocationID_PersistsNullClear(t *testing.T) {
+	db := setupTestDB(t)
+	coinRepo := NewCoinRepository(db)
+
+	location := models.StorageLocation{UserID: 1, Name: "Cabinet A"}
+	if err := db.Create(&location).Error; err != nil {
+		t.Fatalf("Create storage location failed: %v", err)
+	}
+	coin := &models.Coin{
+		Name:              "Storage Clear Coin",
+		Category:          models.CategoryRoman,
+		Material:          models.MaterialSilver,
+		UserID:            1,
+		StorageLocationID: &location.ID,
+	}
+	if err := coinRepo.Create(coin); err != nil {
+		t.Fatalf("Create coin failed: %v", err)
+	}
+
+	if err := coinRepo.UpdateStorageLocationID(coin, nil); err != nil {
+		t.Fatalf("UpdateStorageLocationID clear failed: %v", err)
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found after clear: %v", err)
+	}
+	if found.StorageLocationID != nil {
+		t.Fatalf("expected storage location NULL, got %v", found.StorageLocationID)
+	}
+	if coin.StorageLocationID != nil || coin.StorageLocation != nil {
+		t.Fatalf("expected reloaded coin to have nil storage fields, got id=%v location=%v", coin.StorageLocationID, coin.StorageLocation)
 	}
 }
 

--- a/src/api/services/coin_service.go
+++ b/src/api/services/coin_service.go
@@ -109,16 +109,30 @@ func (s *CoinService) CreateCoin(coin *models.Coin) error {
 // and the source is not "estimate", it records a value history entry and a
 // journal entry. A value snapshot is always recorded afterward.
 func (s *CoinService) UpdateCoin(existing *models.Coin, updates *models.Coin, userID uint, source string, storageLocationProvided ...bool) error {
-	oldValue := existing.CurrentValue
 	updateStorageLocation := len(storageLocationProvided) > 0 && storageLocationProvided[0]
+	return s.updateCoin(existing, updates, nil, userID, source, updateStorageLocation)
+}
+
+// UpdateCoinWithFields applies a presence-aware update. Only fields named in
+// updateFields are persisted, allowing explicit zero values to be saved while
+// omitted request fields preserve existing values.
+func (s *CoinService) UpdateCoinWithFields(existing *models.Coin, updates *models.Coin, updateFields []string, userID uint, source string, storageLocationProvided bool) error {
+	return s.updateCoin(existing, updates, updateFields, userID, source, storageLocationProvided)
+}
+
+func (s *CoinService) updateCoin(existing *models.Coin, updates *models.Coin, updateFields []string, userID uint, source string, updateStorageLocation bool) error {
+	oldValue := existing.CurrentValue
 	if updateStorageLocation {
 		if err := s.validateStorageLocation(updates.StorageLocationID, userID); err != nil {
 			return err
 		}
 	}
-	updates.Era = models.Era(strings.TrimSpace(string(updates.Era)))
+	eraProvided := updateFields == nil || containsString(updateFields, "Era")
+	if eraProvided {
+		updates.Era = models.Era(strings.TrimSpace(string(updates.Era)))
+	}
 	existingEra := models.Era(strings.TrimSpace(string(existing.Era)))
-	if updates.Era != existingEra {
+	if eraProvided && updates.Era != existingEra {
 		if err := s.validateCoinEra(updates.Era); err != nil {
 			return err
 		}
@@ -127,8 +141,10 @@ func (s *CoinService) UpdateCoin(existing *models.Coin, updates *models.Coin, us
 	return s.repo.DB().Transaction(func(tx *gorm.DB) error {
 		txRepo := s.repo.WithTx(tx)
 
-		if err := txRepo.Update(existing, updates); err != nil {
-			return err
+		if updateFields == nil || len(updateFields) > 0 {
+			if err := txRepo.Update(existing, updates, updateFields...); err != nil {
+				return err
+			}
 		}
 		if updateStorageLocation {
 			if err := txRepo.UpdateStorageLocationID(existing, updates.StorageLocationID); err != nil {
@@ -150,7 +166,8 @@ func (s *CoinService) UpdateCoin(existing *models.Coin, updates *models.Coin, us
 			existing.References = normalized
 		}
 
-		if updates.CurrentValue != nil {
+		currentValueProvided := updateFields == nil || containsString(updateFields, "CurrentValue")
+		if currentValueProvided && updates.CurrentValue != nil {
 			newVal := *updates.CurrentValue
 			oldVal := 0.0
 			if oldValue != nil {
@@ -185,6 +202,15 @@ func (s *CoinService) UpdateCoin(existing *models.Coin, updates *models.Coin, us
 
 		return txRepo.RecordValueSnapshot(userID)
 	})
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }
 
 // DeleteCoin deletes a coin and records a value snapshot if rows were affected.

--- a/src/api/services/coin_service_test.go
+++ b/src/api/services/coin_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,7 +14,7 @@ import (
 
 func setupTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:coin_service_%d?mode=memory&cache=shared", time.Now().UnixNano())), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("failed to open test db: %v", err)
 	}
@@ -39,6 +40,20 @@ func newTestCoinServiceWithCatalogRegistry(db *gorm.DB) *CoinService {
 	repo := repository.NewCoinRepository(db)
 	catalogRepo := repository.NewCatalogRegistryRepository(db)
 	return NewCoinService(repo, nil).WithCatalogRegistrySupport(catalogRepo)
+}
+
+func newTestCoinServiceWithStorage(db *gorm.DB) *CoinService {
+	repo := repository.NewCoinRepository(db)
+	storageRepo := repository.NewStorageLocationRepository(db)
+	return NewCoinService(repo, nil).WithStorageLocationSupport(storageRepo)
+}
+
+func newTestCoinServiceWithReferences(db *gorm.DB) *CoinService {
+	repo := repository.NewCoinRepository(db)
+	catalogRepo := repository.NewCatalogRegistryRepository(db)
+	refRepo := repository.NewCoinReferenceRepository(db)
+	refSvc := NewCoinReferenceService(refRepo, catalogRepo)
+	return NewCoinService(repo, nil).WithReferenceSupport(refRepo, refSvc)
 }
 
 func ptrFloat(v float64) *float64 { return &v }
@@ -123,6 +138,129 @@ func TestUpdateCoin_RecordsValueHistory(t *testing.T) {
 	db.Where("coin_id = ?", coin.ID).Find(&journals)
 	if len(journals) != 1 {
 		t.Fatalf("expected 1 journal entry, got %d", len(journals))
+	}
+
+	var snapshots []models.ValueSnapshot
+	if err := db.Where("user_id = ?", uint(1)).Find(&snapshots).Error; err != nil {
+		t.Fatalf("failed to query value snapshots: %v", err)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("expected create and update value snapshots, got %d", len(snapshots))
+	}
+}
+
+func TestCreateCoin_RejectsNonOwnedStorageLocation(t *testing.T) {
+	db := setupTestDB(t)
+	svc := newTestCoinServiceWithStorage(db)
+
+	otherLocation := models.StorageLocation{UserID: 2, Name: "Other Cabinet"}
+	if err := db.Create(&otherLocation).Error; err != nil {
+		t.Fatalf("failed to seed storage location: %v", err)
+	}
+	coin := &models.Coin{
+		Name:              "Stored Coin",
+		Category:          models.CategoryRoman,
+		Material:          models.MaterialBronze,
+		UserID:            1,
+		StorageLocationID: &otherLocation.ID,
+	}
+
+	if err := svc.CreateCoin(coin); !errors.Is(err, ErrStorageLocationNotFound) {
+		t.Fatalf("expected ErrStorageLocationNotFound, got %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&models.Coin{}).Where("name = ?", "Stored Coin").Count(&count).Error; err != nil {
+		t.Fatalf("failed to count coins: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected rejected coin not to be created, got %d rows", count)
+	}
+}
+
+func TestUpdateCoin_ValidatesAndClearsStorageLocation(t *testing.T) {
+	db := setupTestDB(t)
+	svc := newTestCoinServiceWithStorage(db)
+
+	ownedLocation := models.StorageLocation{UserID: 1, Name: "Owned Cabinet"}
+	otherLocation := models.StorageLocation{UserID: 2, Name: "Other Cabinet"}
+	if err := db.Create(&ownedLocation).Error; err != nil {
+		t.Fatalf("failed to seed owned storage location: %v", err)
+	}
+	if err := db.Create(&otherLocation).Error; err != nil {
+		t.Fatalf("failed to seed other storage location: %v", err)
+	}
+	coin := &models.Coin{
+		Name:              "Stored Coin",
+		Category:          models.CategoryRoman,
+		Material:          models.MaterialSilver,
+		UserID:            1,
+		StorageLocationID: &ownedLocation.ID,
+	}
+	if err := db.Create(coin).Error; err != nil {
+		t.Fatalf("failed to seed coin: %v", err)
+	}
+
+	if err := svc.UpdateCoinWithFields(coin, &models.Coin{StorageLocationID: &otherLocation.ID}, nil, 1, "manual", true); !errors.Is(err, ErrStorageLocationNotFound) {
+		t.Fatalf("expected ErrStorageLocationNotFound for non-owned location, got %v", err)
+	}
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found: %v", err)
+	}
+	if found.StorageLocationID == nil || *found.StorageLocationID != ownedLocation.ID {
+		t.Fatalf("expected original storage location %d after rejected update, got %v", ownedLocation.ID, found.StorageLocationID)
+	}
+
+	if err := svc.UpdateCoinWithFields(coin, &models.Coin{}, nil, 1, "manual", true); err != nil {
+		t.Fatalf("expected explicit storage-location clear to succeed: %v", err)
+	}
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found after clear: %v", err)
+	}
+	if found.StorageLocationID != nil {
+		t.Fatalf("expected storage location to be cleared, got %v", found.StorageLocationID)
+	}
+}
+
+func TestUpdateCoin_NormalizesAndReplacesReferences(t *testing.T) {
+	db := setupTestDB(t)
+	svc := newTestCoinServiceWithReferences(db)
+	if err := db.Create(&models.CatalogRegistry{
+		Catalog:        "RIC",
+		DisplayName:    "Roman Imperial Coinage",
+		Era:            models.EraAncient,
+		VolumeRequired: true,
+	}).Error; err != nil {
+		t.Fatalf("failed to seed catalog registry: %v", err)
+	}
+
+	coin := &models.Coin{Name: "Reference Coin", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1}
+	if err := svc.CreateCoin(coin); err != nil {
+		t.Fatalf("setup: CreateCoin failed: %v", err)
+	}
+	if err := db.Create(&models.CoinReference{CoinID: coin.ID, Catalog: "RIC", Volume: "I", Number: "1"}).Error; err != nil {
+		t.Fatalf("failed to seed existing reference: %v", err)
+	}
+
+	updates := &models.Coin{
+		References: []models.CoinReference{
+			{Catalog: " ric ", Volume: " II ", Number: " 12 "},
+		},
+	}
+	if err := svc.UpdateCoinWithFields(coin, updates, []string{}, 1, "manual", false); err != nil {
+		t.Fatalf("UpdateCoinWithFields failed: %v", err)
+	}
+
+	var refs []models.CoinReference
+	if err := db.Where("coin_id = ?", coin.ID).Find(&refs).Error; err != nil {
+		t.Fatalf("failed to query references: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected one replacement reference, got %d", len(refs))
+	}
+	if refs[0].Catalog != "RIC" || refs[0].Volume != "II" || refs[0].Number != "12" {
+		t.Fatalf("expected normalized RIC II 12, got %#v", refs[0])
 	}
 }
 

--- a/src/api/testutil/coin_fixtures.go
+++ b/src/api/testutil/coin_fixtures.go
@@ -1,0 +1,605 @@
+package testutil
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/briandenicola/ancient-coins-api/models"
+	"gorm.io/gorm"
+)
+
+// GoldenCoinFixtureName identifies one deterministic representative coin fixture.
+type GoldenCoinFixtureName string
+
+const (
+	RomanDenariusCore         GoldenCoinFixtureName = "roman-denarius-core"
+	GreekTetradrachmValued    GoldenCoinFixtureName = "greek-tetradrachm-valued"
+	ByzantineSolidusSetMember GoldenCoinFixtureName = "byzantine-solidus-set-member"
+	WishlistAureusTarget      GoldenCoinFixtureName = "wishlist-aureus-target"
+	SoldSestertiusArchive     GoldenCoinFixtureName = "sold-sestertius-archive"
+	PrivateProvincialBronze   GoldenCoinFixtureName = "private-provincial-bronze"
+	TaggedFollisStorage       GoldenCoinFixtureName = "tagged-follis-storage"
+	ImageHeavyDrachm          GoldenCoinFixtureName = "image-heavy-drachm"
+	ReferenceRichDenarius     GoldenCoinFixtureName = "reference-rich-denarius"
+)
+
+var goldenCoinFixtureNames = []GoldenCoinFixtureName{
+	RomanDenariusCore,
+	GreekTetradrachmValued,
+	ByzantineSolidusSetMember,
+	WishlistAureusTarget,
+	SoldSestertiusArchive,
+	PrivateProvincialBronze,
+	TaggedFollisStorage,
+	ImageHeavyDrachm,
+	ReferenceRichDenarius,
+}
+
+// GoldenCoinFixtureNames returns the fixture names in deterministic order.
+func GoldenCoinFixtureNames() []GoldenCoinFixtureName {
+	return cloneFixtureNames(goldenCoinFixtureNames)
+}
+
+type GoldenCoinTrait string
+
+const (
+	TraitRoman           GoldenCoinTrait = "roman"
+	TraitGreek           GoldenCoinTrait = "greek"
+	TraitByzantine       GoldenCoinTrait = "byzantine"
+	TraitWishlist        GoldenCoinTrait = "wishlist"
+	TraitSold            GoldenCoinTrait = "sold"
+	TraitPrivate         GoldenCoinTrait = "private"
+	TraitTagged          GoldenCoinTrait = "tagged"
+	TraitSetMember       GoldenCoinTrait = "set-member"
+	TraitStorageLocation GoldenCoinTrait = "storage-location"
+	TraitImageHeavy      GoldenCoinTrait = "image-heavy"
+	TraitLegacyCustomEra GoldenCoinTrait = "legacy-custom-era"
+	TraitValued          GoldenCoinTrait = "valued"
+	TraitReferenceRich   GoldenCoinTrait = "reference-rich"
+)
+
+type GoldenCoinFixtureInfo struct {
+	Name   GoldenCoinFixtureName
+	Traits []GoldenCoinTrait
+}
+
+type CoinFixture struct {
+	Name   GoldenCoinFixtureName
+	Traits []GoldenCoinTrait
+	Coin   models.Coin
+}
+
+type CoinOption func(*models.Coin)
+
+type PersistedGoldenCollection struct {
+	Coins            []models.Coin
+	StorageLocations map[string]models.StorageLocation
+	Tags             map[string]models.Tag
+	Sets             map[string]models.CoinSet
+}
+
+const (
+	fixtureTrayAName        = "Cabinet Tray A"
+	fixtureVaultBoxName     = "Vault Box 2"
+	fixturePhotographedName = "Photographed"
+	fixtureNeedsResearch    = "Needs Research"
+	fixtureTwelveCaesars    = "Twelve Caesars"
+	fixtureByzantineGold    = "Byzantine Gold"
+)
+
+var fixtureTimestamp = time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+
+func ptrFloat(v float64) *float64    { return &v }
+func ptrTime(v time.Time) *time.Time { return &v }
+
+func GoldenCoinFixtureCatalog() []GoldenCoinFixtureInfo {
+	catalog := make([]GoldenCoinFixtureInfo, 0, len(goldenCoinFixtureNames))
+	for _, name := range goldenCoinFixtureNames {
+		catalog = append(catalog, GoldenCoinFixtureInfo{Name: name, Traits: cloneTraits(fixtureTraits[name])})
+	}
+	return catalog
+}
+
+func BuildGoldenCoinFixture(name GoldenCoinFixtureName, userID uint, opts ...CoinOption) (CoinFixture, error) {
+	builder, ok := fixtureBuilders[name]
+	if !ok {
+		return CoinFixture{}, fmt.Errorf("unknown golden coin fixture %q", name)
+	}
+	coin := builder(userID)
+	for _, opt := range opts {
+		opt(&coin)
+	}
+	return CoinFixture{Name: name, Traits: cloneTraits(fixtureTraits[name]), Coin: cloneCoin(coin)}, nil
+}
+
+func MustBuildGoldenCoinFixture(name GoldenCoinFixtureName, userID uint, opts ...CoinOption) CoinFixture {
+	fixture, err := BuildGoldenCoinFixture(name, userID, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return fixture
+}
+
+func BuildGoldenCoinFixtures(userID uint) []CoinFixture {
+	fixtures := make([]CoinFixture, 0, len(goldenCoinFixtureNames))
+	for _, name := range goldenCoinFixtureNames {
+		fixtures = append(fixtures, MustBuildGoldenCoinFixture(name, userID))
+	}
+	return fixtures
+}
+
+func BuildRomanDenariusCore(userID uint, opts ...CoinOption) models.Coin {
+	return MustBuildGoldenCoinFixture(RomanDenariusCore, userID, opts...).Coin
+}
+
+func BuildGreekTetradrachmValued(userID uint, opts ...CoinOption) models.Coin {
+	return MustBuildGoldenCoinFixture(GreekTetradrachmValued, userID, opts...).Coin
+}
+
+func BuildByzantineSolidusSetMember(userID uint, opts ...CoinOption) models.Coin {
+	return MustBuildGoldenCoinFixture(ByzantineSolidusSetMember, userID, opts...).Coin
+}
+
+func BuildWishlistAureusTarget(userID uint, opts ...CoinOption) models.Coin {
+	return MustBuildGoldenCoinFixture(WishlistAureusTarget, userID, opts...).Coin
+}
+
+func BuildSoldSestertiusArchive(userID uint, opts ...CoinOption) models.Coin {
+	return MustBuildGoldenCoinFixture(SoldSestertiusArchive, userID, opts...).Coin
+}
+
+func BuildPrivateProvincialBronze(userID uint, opts ...CoinOption) models.Coin {
+	return MustBuildGoldenCoinFixture(PrivateProvincialBronze, userID, opts...).Coin
+}
+
+func BuildTaggedFollisStorage(userID uint, opts ...CoinOption) models.Coin {
+	return MustBuildGoldenCoinFixture(TaggedFollisStorage, userID, opts...).Coin
+}
+
+func BuildImageHeavyDrachm(userID uint, opts ...CoinOption) models.Coin {
+	return MustBuildGoldenCoinFixture(ImageHeavyDrachm, userID, opts...).Coin
+}
+
+func BuildReferenceRichDenarius(userID uint, opts ...CoinOption) models.Coin {
+	return MustBuildGoldenCoinFixture(ReferenceRichDenarius, userID, opts...).Coin
+}
+
+func WithCoinMutation(mutator func(*models.Coin)) CoinOption {
+	return func(coin *models.Coin) {
+		if mutator != nil {
+			mutator(coin)
+		}
+	}
+}
+
+func BuildTestStorageLocations(userID uint) []models.StorageLocation {
+	return []models.StorageLocation{
+		{UserID: userID, Name: fixtureTrayAName, SortOrder: 1, CreatedAt: fixtureTimestamp, UpdatedAt: fixtureTimestamp},
+		{UserID: userID, Name: fixtureVaultBoxName, SortOrder: 2, CreatedAt: fixtureTimestamp, UpdatedAt: fixtureTimestamp},
+	}
+}
+
+func BuildTestTags(userID uint) []models.Tag {
+	return []models.Tag{
+		{UserID: userID, Name: fixturePhotographedName, Color: "#c9a84c"},
+		{UserID: userID, Name: fixtureNeedsResearch, Color: "#4682b4"},
+	}
+}
+
+func BuildTestCoinSets(userID uint) []models.CoinSet {
+	targetDate := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+	return []models.CoinSet{
+		{UserID: userID, Name: fixtureTwelveCaesars, Description: "Representative imperial portrait set", Color: "#c9a84c", Icon: "Crown", SetType: models.CoinSetTypeDefined, TargetCompletionDate: &targetDate, CreatedAt: fixtureTimestamp, UpdatedAt: fixtureTimestamp},
+		{UserID: userID, Name: fixtureByzantineGold, Description: "Gold issues for set-membership workflow tests", Color: "#b08d57", Icon: "CircleDot", SetType: models.CoinSetTypeOpen, CreatedAt: fixtureTimestamp, UpdatedAt: fixtureTimestamp},
+	}
+}
+
+// PersistGoldenCollection seeds the golden fixtures into a caller-managed test DB.
+// The DB must already be migrated for User, Coin, CoinImage, CoinReference,
+// StorageLocation, Tag, CoinTag, CoinSet, and CoinSetMembership models.
+func PersistGoldenCollection(db *gorm.DB, userID uint) (*PersistedGoldenCollection, error) {
+	if db == nil {
+		return nil, fmt.Errorf("db is nil")
+	}
+
+	persisted := &PersistedGoldenCollection{
+		Coins:            make([]models.Coin, 0, len(goldenCoinFixtureNames)),
+		StorageLocations: map[string]models.StorageLocation{},
+		Tags:             map[string]models.Tag{},
+		Sets:             map[string]models.CoinSet{},
+	}
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		for _, location := range BuildTestStorageLocations(userID) {
+			if err := tx.Create(&location).Error; err != nil {
+				return err
+			}
+			persisted.StorageLocations[location.Name] = location
+		}
+		for _, tag := range BuildTestTags(userID) {
+			if err := tx.Create(&tag).Error; err != nil {
+				return err
+			}
+			persisted.Tags[tag.Name] = tag
+		}
+		for _, set := range BuildTestCoinSets(userID) {
+			if err := tx.Create(&set).Error; err != nil {
+				return err
+			}
+			persisted.Sets[set.Name] = set
+		}
+
+		for _, fixture := range BuildGoldenCoinFixtures(userID) {
+			coin := cloneCoin(fixture.Coin)
+			images := cloneImages(coin.Images)
+			references := cloneReferences(coin.References)
+			tags := cloneTags(coin.Tags)
+			sets := cloneSets(coin.Sets)
+
+			coin.ID = 0
+			coin.Images = nil
+			coin.References = nil
+			coin.Tags = nil
+			coin.Sets = nil
+			if coin.StorageLocation != nil {
+				location, ok := persisted.StorageLocations[coin.StorageLocation.Name]
+				if !ok {
+					return fmt.Errorf("fixture %s references unknown storage location %q", fixture.Name, coin.StorageLocation.Name)
+				}
+				coin.StorageLocationID = &location.ID
+				coin.StorageLocation = nil
+			}
+
+			if err := tx.Create(&coin).Error; err != nil {
+				return err
+			}
+
+			for _, image := range images {
+				image.ID = 0
+				image.CoinID = coin.ID
+				if err := tx.Create(&image).Error; err != nil {
+					return err
+				}
+			}
+			for _, ref := range references {
+				ref.ID = 0
+				ref.CoinID = coin.ID
+				if err := tx.Create(&ref).Error; err != nil {
+					return err
+				}
+			}
+			for _, tag := range tags {
+				persistedTag, ok := persisted.Tags[tag.Name]
+				if !ok {
+					return fmt.Errorf("fixture %s references unknown tag %q", fixture.Name, tag.Name)
+				}
+				if err := tx.Create(&models.CoinTag{CoinID: coin.ID, TagID: persistedTag.ID}).Error; err != nil {
+					return err
+				}
+			}
+			for _, set := range sets {
+				persistedSet, ok := persisted.Sets[set.Name]
+				if !ok {
+					return fmt.Errorf("fixture %s references unknown set %q", fixture.Name, set.Name)
+				}
+				membership := models.CoinSetMembership{CoinID: coin.ID, SetID: persistedSet.ID, AddedAt: fixtureTimestamp, Notes: "golden fixture"}
+				if err := tx.Create(&membership).Error; err != nil {
+					return err
+				}
+			}
+
+			var loaded models.Coin
+			if err := tx.Preload("Images").Preload("References").Preload("Tags").Preload("Sets").Preload("StorageLocation").First(&loaded, coin.ID).Error; err != nil {
+				return err
+			}
+			persisted.Coins = append(persisted.Coins, loaded)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return persisted, nil
+}
+
+var fixtureTraits = map[GoldenCoinFixtureName][]GoldenCoinTrait{
+	RomanDenariusCore:         {TraitRoman},
+	GreekTetradrachmValued:    {TraitGreek, TraitValued},
+	ByzantineSolidusSetMember: {TraitByzantine, TraitSetMember},
+	WishlistAureusTarget:      {TraitRoman, TraitWishlist, TraitValued},
+	SoldSestertiusArchive:     {TraitRoman, TraitSold},
+	PrivateProvincialBronze:   {TraitRoman, TraitPrivate, TraitLegacyCustomEra},
+	TaggedFollisStorage:       {TraitRoman, TraitTagged, TraitStorageLocation},
+	ImageHeavyDrachm:          {TraitGreek, TraitImageHeavy},
+	ReferenceRichDenarius:     {TraitRoman, TraitReferenceRich, TraitSetMember},
+}
+
+var fixtureBuilders = map[GoldenCoinFixtureName]func(uint) models.Coin{
+	RomanDenariusCore:         romanDenariusCore,
+	GreekTetradrachmValued:    greekTetradrachmValued,
+	ByzantineSolidusSetMember: byzantineSolidusSetMember,
+	WishlistAureusTarget:      wishlistAureusTarget,
+	SoldSestertiusArchive:     soldSestertiusArchive,
+	PrivateProvincialBronze:   privateProvincialBronze,
+	TaggedFollisStorage:       taggedFollisStorage,
+	ImageHeavyDrachm:          imageHeavyDrachm,
+	ReferenceRichDenarius:     referenceRichDenarius,
+}
+
+func baseCoin(userID uint, name string) models.Coin {
+	return models.Coin{
+		Name:               name,
+		Category:           models.CategoryRoman,
+		Denomination:       "Denarius",
+		Ruler:              "Trajan",
+		Era:                models.EraAncient,
+		Mint:               "Rome",
+		Material:           models.MaterialSilver,
+		WeightGrams:        ptrFloat(3.35),
+		DiameterMm:         ptrFloat(18),
+		Grade:              "VF",
+		ObverseInscription: "IMP TRAIANO AVG GER DAC P M TR P",
+		ReverseInscription: "SPQR OPTIMO PRINCIPI",
+		ObverseDescription: "Laureate bust right",
+		ReverseDescription: "Victory standing left",
+		RarityRating:       "Common",
+		PurchasePrice:      ptrFloat(180),
+		CurrentValue:       ptrFloat(225),
+		PurchaseDate:       ptrTime(time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)),
+		PurchaseLocation:   "Fixture Dealer",
+		Notes:              "Deterministic backend fixture coin.",
+		ListingStatus:      "unlisted",
+		UserID:             userID,
+		Images: []models.CoinImage{
+			buildImage("obverse", true),
+			buildImage("reverse", false),
+		},
+		CreatedAt: fixtureTimestamp,
+		UpdatedAt: fixtureTimestamp,
+	}
+}
+
+func romanDenariusCore(userID uint) models.Coin {
+	coin := baseCoin(userID, "Trajan Denarius Core")
+	coin.ReferenceURL = "https://example.test/coins/roman-denarius-core"
+	coin.ReferenceText = "RIC II Trajan 147"
+	return coin
+}
+
+func greekTetradrachmValued(userID uint) models.Coin {
+	coin := baseCoin(userID, "Athens Owl Tetradrachm Valued")
+	coin.Category = models.CategoryGreek
+	coin.Denomination = "Tetradrachm"
+	coin.Ruler = "Athens"
+	coin.Mint = "Athens"
+	coin.Material = models.MaterialSilver
+	coin.WeightGrams = ptrFloat(17.18)
+	coin.DiameterMm = ptrFloat(24)
+	coin.PurchasePrice = ptrFloat(950)
+	coin.CurrentValue = ptrFloat(1250)
+	coin.PurchaseDate = ptrTime(time.Date(2023, 9, 10, 0, 0, 0, 0, time.UTC))
+	coin.ObverseInscription = ""
+	coin.ReverseInscription = "ΑΘΕ"
+	coin.ObverseDescription = "Helmeted head of Athena right"
+	coin.ReverseDescription = "Owl standing right, olive sprig and crescent"
+	return coin
+}
+
+func byzantineSolidusSetMember(userID uint) models.Coin {
+	coin := baseCoin(userID, "Justinian I Solidus Set Member")
+	coin.Category = models.CategoryByzantine
+	coin.Denomination = "Solidus"
+	coin.Ruler = "Justinian I"
+	coin.Mint = "Constantinople"
+	coin.Material = models.MaterialGold
+	coin.WeightGrams = ptrFloat(4.48)
+	coin.DiameterMm = ptrFloat(21)
+	coin.PurchasePrice = ptrFloat(700)
+	coin.CurrentValue = ptrFloat(875)
+	coin.Sets = []models.CoinSet{fixtureSet(userID, fixtureByzantineGold)}
+	return coin
+}
+
+func wishlistAureusTarget(userID uint) models.Coin {
+	coin := baseCoin(userID, "Augustus Aureus Wishlist Target")
+	coin.Denomination = "Aureus"
+	coin.Ruler = "Augustus"
+	coin.Material = models.MaterialGold
+	coin.WeightGrams = ptrFloat(7.9)
+	coin.DiameterMm = ptrFloat(20)
+	coin.PurchasePrice = nil
+	coin.CurrentValue = ptrFloat(8500)
+	coin.PurchaseDate = nil
+	coin.PurchaseLocation = ""
+	coin.IsWishlist = true
+	coin.Notes = "Wishlist target used for purchase workflow tests."
+	return coin
+}
+
+func soldSestertiusArchive(userID uint) models.Coin {
+	coin := baseCoin(userID, "Hadrian Sestertius Archive")
+	coin.Denomination = "Sestertius"
+	coin.Ruler = "Hadrian"
+	coin.Material = models.MaterialBronze
+	coin.WeightGrams = ptrFloat(25.1)
+	coin.DiameterMm = ptrFloat(32)
+	coin.PurchasePrice = ptrFloat(240)
+	coin.CurrentValue = ptrFloat(300)
+	coin.IsSold = true
+	coin.SoldPrice = ptrFloat(310)
+	coin.SoldDate = ptrTime(time.Date(2025, 4, 20, 0, 0, 0, 0, time.UTC))
+	coin.SoldTo = "Archive Buyer"
+	return coin
+}
+
+func privateProvincialBronze(userID uint) models.Coin {
+	coin := baseCoin(userID, "Alexandria Provincial Bronze Private")
+	coin.Denomination = "Drachm"
+	coin.Ruler = "Antoninus Pius"
+	coin.Era = models.Era("Roman Provincial Year 12")
+	coin.Mint = "Alexandria"
+	coin.Material = models.MaterialBronze
+	coin.IsPrivate = true
+	coin.ReferenceText = "Legacy handwritten tray note"
+	coin.Notes = "Private coin with a custom legacy era value."
+	return coin
+}
+
+func taggedFollisStorage(userID uint) models.Coin {
+	coin := baseCoin(userID, "Diocletian Follis Tagged Storage")
+	coin.Denomination = "Follis"
+	coin.Ruler = "Diocletian"
+	coin.Material = models.MaterialBronze
+	coin.StorageLocation = &models.StorageLocation{UserID: userID, Name: fixtureTrayAName, SortOrder: 1}
+	coin.Tags = []models.Tag{
+		{UserID: userID, Name: fixturePhotographedName, Color: "#c9a84c"},
+		{UserID: userID, Name: fixtureNeedsResearch, Color: "#4682b4"},
+	}
+	return coin
+}
+
+func imageHeavyDrachm(userID uint) models.Coin {
+	coin := baseCoin(userID, "Syracuse Drachm Image Heavy")
+	coin.Category = models.CategoryGreek
+	coin.Denomination = "Drachm"
+	coin.Ruler = "Syracuse"
+	coin.Mint = "Syracuse"
+	coin.Images = []models.CoinImage{
+		buildImage("obverse", true),
+		buildImage("reverse", false),
+		buildImage("detail", false),
+		buildImage("other", false),
+	}
+	return coin
+}
+
+func referenceRichDenarius(userID uint) models.Coin {
+	coin := baseCoin(userID, "Vespasian Denarius Reference Rich")
+	coin.Ruler = "Vespasian"
+	coin.ReferenceURL = "https://example.test/coins/reference-rich-denarius"
+	coin.ReferenceText = "RIC II.1 Vespasian 772; BMCRE 161; RSC 554"
+	coin.References = []models.CoinReference{
+		buildReference("RIC", "II.1", "772"),
+		buildReference("BMCRE", "", "161"),
+		buildReference("RSC", "", "554"),
+	}
+	coin.Sets = []models.CoinSet{fixtureSet(userID, fixtureTwelveCaesars)}
+	return coin
+}
+
+func buildImage(imageType models.ImageType, isPrimary bool) models.CoinImage {
+	return models.CoinImage{FilePath: fmt.Sprintf("uploads/test-fixtures/%s.webp", imageType), ImageType: imageType, IsPrimary: isPrimary, CreatedAt: fixtureTimestamp}
+}
+
+func buildReference(catalog, volume, number string) models.CoinReference {
+	return models.CoinReference{Catalog: catalog, Volume: volume, Number: number, InvoiceNumber: fmt.Sprintf("INV-%s-%s", catalog, number), URI: fmt.Sprintf("https://example.test/catalog/%s/%s", catalog, number), CreatedAt: fixtureTimestamp, UpdatedAt: fixtureTimestamp}
+}
+
+func fixtureSet(userID uint, name string) models.CoinSet {
+	for _, set := range BuildTestCoinSets(userID) {
+		if set.Name == name {
+			return set
+		}
+	}
+	return models.CoinSet{UserID: userID, Name: name, SetType: models.CoinSetTypeOpen}
+}
+
+func cloneCoin(coin models.Coin) models.Coin {
+	coin.WeightGrams = cloneFloatPtr(coin.WeightGrams)
+	coin.DiameterMm = cloneFloatPtr(coin.DiameterMm)
+	coin.PurchasePrice = cloneFloatPtr(coin.PurchasePrice)
+	coin.CurrentValue = cloneFloatPtr(coin.CurrentValue)
+	coin.CurrentValueUpdatedAt = cloneTimePtr(coin.CurrentValueUpdatedAt)
+	coin.PurchaseDate = cloneTimePtr(coin.PurchaseDate)
+	coin.SoldPrice = cloneFloatPtr(coin.SoldPrice)
+	coin.SoldDate = cloneTimePtr(coin.SoldDate)
+	coin.ListingCheckedAt = cloneTimePtr(coin.ListingCheckedAt)
+	coin.StorageLocationID = cloneUintPtr(coin.StorageLocationID)
+	if coin.StorageLocation != nil {
+		location := *coin.StorageLocation
+		coin.StorageLocation = &location
+	}
+	coin.Images = cloneImages(coin.Images)
+	coin.References = cloneReferences(coin.References)
+	coin.Tags = cloneTags(coin.Tags)
+	coin.Sets = cloneSets(coin.Sets)
+	return coin
+}
+
+func cloneImages(images []models.CoinImage) []models.CoinImage {
+	if images == nil {
+		return nil
+	}
+	cloned := make([]models.CoinImage, len(images))
+	copy(cloned, images)
+	return cloned
+}
+
+func cloneReferences(refs []models.CoinReference) []models.CoinReference {
+	if refs == nil {
+		return nil
+	}
+	cloned := make([]models.CoinReference, len(refs))
+	copy(cloned, refs)
+	return cloned
+}
+
+func cloneTags(tags []models.Tag) []models.Tag {
+	if tags == nil {
+		return nil
+	}
+	cloned := make([]models.Tag, len(tags))
+	copy(cloned, tags)
+	return cloned
+}
+
+func cloneSets(sets []models.CoinSet) []models.CoinSet {
+	if sets == nil {
+		return nil
+	}
+	cloned := make([]models.CoinSet, len(sets))
+	copy(cloned, sets)
+	return cloned
+}
+
+func cloneFixtureNames(names []GoldenCoinFixtureName) []GoldenCoinFixtureName {
+	if names == nil {
+		return nil
+	}
+	cloned := make([]GoldenCoinFixtureName, len(names))
+	copy(cloned, names)
+	return cloned
+}
+
+func cloneTraits(traits []GoldenCoinTrait) []GoldenCoinTrait {
+	if traits == nil {
+		return nil
+	}
+	cloned := make([]GoldenCoinTrait, len(traits))
+	copy(cloned, traits)
+	return cloned
+}
+
+func cloneFloatPtr(v *float64) *float64 {
+	if v == nil {
+		return nil
+	}
+	cloned := *v
+	return &cloned
+}
+
+func cloneUintPtr(v *uint) *uint {
+	if v == nil {
+		return nil
+	}
+	cloned := *v
+	return &cloned
+}
+
+func cloneTimePtr(v *time.Time) *time.Time {
+	if v == nil {
+		return nil
+	}
+	cloned := *v
+	return &cloned
+}

--- a/src/api/testutil/coin_fixtures_test.go
+++ b/src/api/testutil/coin_fixtures_test.go
@@ -1,0 +1,121 @@
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/briandenicola/ancient-coins-api/models"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGoldenCoinFixtureCatalogCoversRequiredTraits(t *testing.T) {
+	catalog := GoldenCoinFixtureCatalog()
+	if len(catalog) != len(GoldenCoinFixtureNames()) {
+		t.Fatalf("expected %d catalog entries, got %d", len(GoldenCoinFixtureNames()), len(catalog))
+	}
+
+	required := []GoldenCoinTrait{
+		TraitRoman,
+		TraitGreek,
+		TraitByzantine,
+		TraitWishlist,
+		TraitSold,
+		TraitPrivate,
+		TraitTagged,
+		TraitSetMember,
+		TraitStorageLocation,
+		TraitImageHeavy,
+		TraitValued,
+		TraitReferenceRich,
+		TraitLegacyCustomEra,
+	}
+	seen := map[GoldenCoinTrait]bool{}
+	for _, info := range catalog {
+		for _, trait := range info.Traits {
+			seen[trait] = true
+		}
+	}
+	for _, trait := range required {
+		if !seen[trait] {
+			t.Fatalf("missing required golden fixture trait %q", trait)
+		}
+	}
+}
+
+func TestBuildGoldenCoinFixtureReturnsIndependentClones(t *testing.T) {
+	first := BuildTaggedFollisStorage(42)
+	second := BuildTaggedFollisStorage(42)
+
+	first.Name = "mutated"
+	first.Tags[0].Name = "mutated tag"
+	first.StorageLocation.Name = "mutated storage"
+	*first.WeightGrams = 99
+
+	if second.Name == "mutated" {
+		t.Fatal("coin name mutation leaked between fixture builds")
+	}
+	if second.Tags[0].Name == "mutated tag" {
+		t.Fatal("tag mutation leaked between fixture builds")
+	}
+	if second.StorageLocation.Name == "mutated storage" {
+		t.Fatal("storage mutation leaked between fixture builds")
+	}
+	if *second.WeightGrams == 99 {
+		t.Fatal("pointer field mutation leaked between fixture builds")
+	}
+}
+
+func TestPersistGoldenCollectionSeedsAssociations(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:golden_fixtures?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.User{}, &models.StorageLocation{}, &models.Coin{}, &models.CoinImage{}, &models.CoinReference{},
+		&models.Tag{}, &models.CoinTag{}, &models.CoinSet{}, &models.CoinSetMembership{},
+	); err != nil {
+		t.Fatalf("failed to migrate test db: %v", err)
+	}
+	user := models.User{ID: 42, Username: "fixture-user", PasswordHash: "hash", Email: "fixture-user@test.example"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+
+	collection, err := PersistGoldenCollection(db, user.ID)
+	if err != nil {
+		t.Fatalf("PersistGoldenCollection failed: %v", err)
+	}
+	if len(collection.Coins) != len(GoldenCoinFixtureNames()) {
+		t.Fatalf("expected %d persisted coins, got %d", len(GoldenCoinFixtureNames()), len(collection.Coins))
+	}
+
+	var tagged, imageHeavy, referenceRich models.Coin
+	for _, coin := range collection.Coins {
+		switch coin.Name {
+		case "Diocletian Follis Tagged Storage":
+			tagged = coin
+		case "Syracuse Drachm Image Heavy":
+			imageHeavy = coin
+		case "Vespasian Denarius Reference Rich":
+			referenceRich = coin
+		}
+	}
+	if tagged.ID == 0 || tagged.StorageLocation == nil || len(tagged.Tags) != 2 {
+		t.Fatalf("expected tagged storage fixture to preload storage and two tags, got id=%d storage=%v tags=%d", tagged.ID, tagged.StorageLocation, len(tagged.Tags))
+	}
+	if len(imageHeavy.Images) != 4 {
+		t.Fatalf("expected image-heavy fixture to persist four images, got %d", len(imageHeavy.Images))
+	}
+	if len(referenceRich.References) != 3 || len(referenceRich.Sets) != 1 {
+		t.Fatalf("expected reference-rich fixture to persist three references and one set, got refs=%d sets=%d", len(referenceRich.References), len(referenceRich.Sets))
+	}
+
+	var membership models.CoinSetMembership
+	if err := db.Where("coin_id = ?", referenceRich.ID).First(&membership).Error; err != nil {
+		t.Fatalf("expected reference-rich membership: %v", err)
+	}
+	if membership.AddedAt.IsZero() || !membership.AddedAt.Equal(time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected deterministic membership AddedAt, got %v", membership.AddedAt)
+	}
+}

--- a/src/web/e2e/fixtures/workflow.ts
+++ b/src/web/e2e/fixtures/workflow.ts
@@ -1,0 +1,377 @@
+import type { Page, Route } from '@playwright/test'
+import { expect } from '@playwright/test'
+import {
+  buildRomanDenariusCore,
+  buildTestCoinSets,
+  buildTestStorageLocations,
+  buildTestTags,
+} from '../../src/test/fixtures'
+import type { Coin, CoinImage, CoinListResponse, CoinMutationPayload, CoinSet, StorageLocation, Tag, UserInfo } from '../../src/types'
+
+export const workflowUser = {
+  id: 101,
+  username: 'workflow-user',
+  role: 'admin',
+  email: 'workflow@example.test',
+  avatarPath: '',
+  isPublic: false,
+  bio: '',
+  zipCode: '',
+  numisBidsUsername: '',
+  numisBidsConfigured: false,
+  pushoverEnabled: false,
+  coinOfDayEnabled: true,
+} as const
+
+export interface WorkflowApiState {
+  coins: Coin[]
+  storageLocations: StorageLocation[]
+  tags: Tag[]
+  sets: CoinSet[]
+  createPayloads: CoinMutationPayload[]
+  updatePayloads: Array<{ id: number; payload: CoinMutationPayload }>
+  tagPayloads: Array<{ action: 'add' | 'remove'; coinId: number; tagId: number }>
+  setPayloads: Array<{ action: 'add' | 'remove'; coinId: number; setId: number }>
+  imageUploads: Array<{ coinId: number; imageType: string; isPrimary: boolean; fileName: string; contentType: string }>
+  imageDeletes: Array<{ coinId: number; imageId: number }>
+  coinQueries: Array<Record<string, string>>
+  authorizedRequests: string[]
+}
+
+export async function installAuthenticatedSession(page: Page) {
+  await page.addInitScript((user) => {
+    window.localStorage.setItem('token', 'workflow-access-token')
+    window.localStorage.setItem('refreshToken', 'workflow-refresh-token')
+    window.localStorage.setItem('user', JSON.stringify(user))
+  }, workflowUser)
+}
+
+export async function installWorkflowApiMocks(page: Page, initialCoins: Coin[] = [buildRomanDenariusCore()]): Promise<WorkflowApiState> {
+  const state: WorkflowApiState = {
+    coins: initialCoins.map((coin) => cloneCoin(coin)),
+    storageLocations: buildTestStorageLocations(),
+    tags: buildTestTags(),
+    sets: buildTestCoinSets(),
+    createPayloads: [],
+    updatePayloads: [],
+    tagPayloads: [],
+    setPayloads: [],
+    imageUploads: [],
+    imageDeletes: [],
+    coinQueries: [],
+    authorizedRequests: [],
+  }
+  let nextCoinId = 7001
+  let nextImageId = 9001
+
+  await page.route('**/uploads/**', async (route) => {
+    await route.fulfill({
+      status: 204,
+    })
+  })
+
+  await page.route('**/api/**', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    if (!url.pathname.startsWith('/api/')) {
+      await route.continue()
+      return
+    }
+    const path = url.pathname.replace(/^\/api/, '')
+    const method = request.method()
+    const authorization = request.headers()['authorization']
+    if (authorization) state.authorizedRequests.push(`${method} ${path}`)
+
+    if (path === '/auth/login' && method === 'POST') {
+      await json(route, {
+        token: 'workflow-access-token',
+        refreshToken: 'workflow-refresh-token',
+        user: workflowUser,
+      })
+      return
+    }
+
+    if (path === '/auth/me' && method === 'GET') {
+      await json(route, {
+        ...workflowUser,
+        createdAt: '2024-01-01T00:00:00Z',
+        emailMissing: false,
+      } satisfies UserInfo)
+      return
+    }
+
+    if (path === '/notifications/unread-count' && method === 'GET') {
+      await json(route, { count: 0 })
+      return
+    }
+
+    if (path === '/admin/settings' && method === 'GET') {
+      await json(route, {
+        CoinCategories: 'Roman\nGreek\nByzantine\nModern\nOther',
+        CoinEras: 'ancient\nmedieval\nmodern',
+      })
+      return
+    }
+
+    if (path === '/storage-locations' && method === 'GET') {
+      await json(route, { storageLocations: state.storageLocations })
+      return
+    }
+
+    if (path === '/tags' && method === 'GET') {
+      await json(route, { tags: state.tags })
+      return
+    }
+
+    if (path === '/sets' && method === 'GET') {
+      await json(route, {
+        sets: state.sets.map((set) => ({
+          id: set.id,
+          name: set.name,
+          color: set.color,
+          icon: set.icon,
+          setType: set.setType,
+          coinCount: state.coins.filter((coin) => coin.sets?.some((coinSet) => coinSet.id === set.id)).length,
+          totalValue: state.coins
+            .filter((coin) => coin.sets?.some((coinSet) => coinSet.id === set.id))
+            .reduce((sum, coin) => sum + (coin.currentValue ?? 0), 0),
+        })),
+      })
+      return
+    }
+
+    if (path === '/suggestions' && method === 'GET') {
+      await json(route, [])
+      return
+    }
+
+    if (path === '/coins' && method === 'GET') {
+      const filteredCoins = filterCoins(state.coins, url.searchParams)
+      state.coinQueries.push(Object.fromEntries(url.searchParams.entries()))
+      await json(route, {
+        coins: filteredCoins,
+        total: filteredCoins.length,
+        page: Number(url.searchParams.get('page') ?? 1),
+        limit: Number(url.searchParams.get('limit') ?? 50),
+      } satisfies CoinListResponse)
+      return
+    }
+
+    if (path === '/coins' && method === 'POST') {
+      const payload = request.postDataJSON() as CoinMutationPayload
+      state.createPayloads.push(payload)
+      const created = buildRomanDenariusCore({
+        ...payload,
+        id: nextCoinId++,
+        userId: workflowUser.id,
+        images: [],
+        tags: [],
+        sets: [],
+        references: [],
+      })
+      state.coins.push(created)
+      await json(route, created)
+      return
+    }
+
+    const imageUploadMatch = path.match(/^\/coins\/(\d+)\/images$/)
+    if (imageUploadMatch && method === 'POST') {
+      const coinId = Number(imageUploadMatch[1])
+      const body = (await request.postDataBuffer())?.toString('utf8') ?? ''
+      const imageType = body.match(/name="imageType"\r?\n\r?\n([^\r\n-]+)/)?.[1]?.trim() || 'other'
+      const isPrimary = body.match(/name="isPrimary"\r?\n\r?\n([^\r\n-]+)/)?.[1]?.trim() === 'true'
+      const fileName = body.match(/filename="([^"]+)"/)?.[1] ?? 'workflow-upload.png'
+      const uploadedImage: CoinImage = {
+        id: nextImageId++,
+        coinId,
+        filePath: `test-fixtures/${coinId}-${imageType}-${nextImageId}.png`,
+        imageType: imageType as CoinImage['imageType'],
+        isPrimary,
+        createdAt: '2026-06-09T00:00:00Z',
+      }
+      state.imageUploads.push({
+        coinId,
+        imageType,
+        isPrimary,
+        fileName,
+        contentType: request.headers()['content-type'] ?? '',
+      })
+      state.coins = state.coins.map((coin) => coin.id === coinId
+        ? cloneCoin({ ...coin, images: [...coin.images, uploadedImage] })
+        : coin)
+      await json(route, uploadedImage)
+      return
+    }
+
+    const imageDeleteMatch = path.match(/^\/coins\/(\d+)\/images\/(\d+)$/)
+    if (imageDeleteMatch && method === 'DELETE') {
+      const coinId = Number(imageDeleteMatch[1])
+      const imageId = Number(imageDeleteMatch[2])
+      state.imageDeletes.push({ coinId, imageId })
+      state.coins = state.coins.map((coin) => coin.id === coinId
+        ? cloneCoin({ ...coin, images: coin.images.filter((image) => image.id !== imageId) })
+        : coin)
+      await json(route, { message: 'Image deleted' })
+      return
+    }
+
+    const coinMatch = path.match(/^\/coins\/(\d+)$/)
+    if (coinMatch && method === 'GET') {
+      const id = Number(coinMatch[1])
+      const coin = state.coins.find((item) => item.id === id)
+      await coin ? json(route, coin) : json(route, { error: 'Not found' }, 404)
+      return
+    }
+
+    if (coinMatch && method === 'PUT') {
+      const id = Number(coinMatch[1])
+      const payload = request.postDataJSON() as CoinMutationPayload
+      state.updatePayloads.push({ id, payload })
+      const current = state.coins.find((item) => item.id === id) ?? buildRomanDenariusCore({ id })
+      const storageLocationId = payload.storageLocationId === undefined ? current.storageLocationId : payload.storageLocationId
+      const storageLocation = storageLocationId == null
+        ? null
+        : state.storageLocations.find((location) => location.id === storageLocationId) ?? null
+      const updated = cloneCoin({
+        ...current,
+        ...payload,
+        id,
+        storageLocationId,
+        storageLocation: storageLocation ? { id: storageLocation.id, name: storageLocation.name } : null,
+      })
+      state.coins = state.coins.map((item) => item.id === id ? updated : item)
+      await json(route, updated)
+      return
+    }
+
+    const addTagMatch = path.match(/^\/coins\/(\d+)\/tags$/)
+    if (addTagMatch && method === 'POST') {
+      const coinId = Number(addTagMatch[1])
+      const { tagId } = request.postDataJSON() as { tagId: number }
+      const tag = state.tags.find((item) => item.id === tagId)
+      if (!tag) {
+        await json(route, { error: 'Tag not found' }, 404)
+        return
+      }
+      state.tagPayloads.push({ action: 'add', coinId, tagId })
+      state.coins = state.coins.map((coin) => coin.id === coinId
+        ? cloneCoin({
+            ...coin,
+            tags: coin.tags?.some((item) => item.id === tagId) ? coin.tags : [...(coin.tags ?? []), { ...tag }],
+          })
+        : coin)
+      await json(route, { message: 'Tag attached' })
+      return
+    }
+
+    const removeTagMatch = path.match(/^\/coins\/(\d+)\/tags\/(\d+)$/)
+    if (removeTagMatch && method === 'DELETE') {
+      const coinId = Number(removeTagMatch[1])
+      const tagId = Number(removeTagMatch[2])
+      state.tagPayloads.push({ action: 'remove', coinId, tagId })
+      state.coins = state.coins.map((coin) => coin.id === coinId
+        ? cloneCoin({ ...coin, tags: coin.tags?.filter((tag) => tag.id !== tagId) ?? [] })
+        : coin)
+      await json(route, { message: 'Tag detached' })
+      return
+    }
+
+    const addSetMatch = path.match(/^\/sets\/(\d+)\/coins$/)
+    if (addSetMatch && method === 'POST') {
+      const setId = Number(addSetMatch[1])
+      const { coinId } = request.postDataJSON() as { coinId: number }
+      const set = state.sets.find((item) => item.id === setId)
+      if (!set) {
+        await json(route, { error: 'Set not found' }, 404)
+        return
+      }
+      state.setPayloads.push({ action: 'add', coinId, setId })
+      state.coins = state.coins.map((coin) => coin.id === coinId
+        ? cloneCoin({
+            ...coin,
+            sets: coin.sets?.some((item) => item.id === setId) ? coin.sets : [...(coin.sets ?? []), { ...set }],
+          })
+        : coin)
+      await json(route, { message: 'Coin added to set' })
+      return
+    }
+
+    const removeSetMatch = path.match(/^\/sets\/(\d+)\/coins\/(\d+)$/)
+    if (removeSetMatch && method === 'DELETE') {
+      const setId = Number(removeSetMatch[1])
+      const coinId = Number(removeSetMatch[2])
+      state.setPayloads.push({ action: 'remove', coinId, setId })
+      state.coins = state.coins.map((coin) => coin.id === coinId
+        ? cloneCoin({ ...coin, sets: coin.sets?.filter((set) => set.id !== setId) ?? [] })
+        : coin)
+      await json(route, { message: 'Coin removed from set' })
+      return
+    }
+
+    await json(route, {})
+  })
+
+  return state
+}
+
+export function coinFormControl(page: Page, labelText: string) {
+  return page.locator('.form-group').filter({ hasText: labelText }).first().locator('input, textarea, select').first()
+}
+
+export async function expectAuthenticatedApiCall(state: WorkflowApiState, requestName: string) {
+  await expect.poll(() => state.authorizedRequests).toContain(requestName)
+}
+
+function cloneCoin(coin: Coin): Coin {
+  return {
+    ...coin,
+    storageLocation: coin.storageLocation ? { ...coin.storageLocation } : null,
+    images: coin.images.map((image) => ({ ...image })),
+    references: coin.references?.map((reference) => ({ ...reference })),
+    tags: coin.tags?.map((tag) => ({ ...tag })),
+    sets: coin.sets?.map((set) => ({ ...set })),
+  }
+}
+
+function filterCoins(coins: Coin[], searchParams: URLSearchParams): Coin[] {
+  const search = searchParams.get('search')?.trim().toLowerCase()
+  const category = searchParams.get('category')?.trim()
+  const era = searchParams.get('era')?.trim()
+  const tag = searchParams.get('tag')?.trim()
+  const set = searchParams.get('set')?.trim()
+  const wishlist = searchParams.get('wishlist')
+  const sold = searchParams.get('sold')
+
+  return coins.filter((coin) => {
+    if (wishlist === 'false' && coin.isWishlist) return false
+    if (wishlist === 'true' && !coin.isWishlist) return false
+    if (sold === 'false' && coin.isSold) return false
+    if (sold === 'true' && !coin.isSold) return false
+    if (category && coin.category !== category) return false
+    if (era && coin.era !== era) return false
+    if (tag && !coin.tags?.some((coinTag) => String(coinTag.id) === tag)) return false
+    if (set && !coin.sets?.some((coinSet) => String(coinSet.id) === set)) return false
+    if (search) {
+      const haystack = [
+        coin.name,
+        coin.ruler,
+        coin.denomination,
+        coin.mint,
+        coin.obverseInscription,
+        coin.reverseInscription,
+        coin.obverseDescription,
+        coin.reverseDescription,
+      ].join(' ').toLowerCase()
+      if (!haystack.includes(search)) return false
+    }
+    return true
+  })
+}
+
+async function json(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  })
+}

--- a/src/web/e2e/fixtures/workflow.ts
+++ b/src/web/e2e/fixtures/workflow.ts
@@ -219,7 +219,11 @@ export async function installWorkflowApiMocks(page: Page, initialCoins: Coin[] =
     if (coinMatch && method === 'GET') {
       const id = Number(coinMatch[1])
       const coin = state.coins.find((item) => item.id === id)
-      await coin ? json(route, coin) : json(route, { error: 'Not found' }, 404)
+      if (coin) {
+        await json(route, coin)
+      } else {
+        await json(route, { error: 'Not found' }, 404)
+      }
       return
     }
 

--- a/src/web/e2e/workflows/auth.spec.ts
+++ b/src/web/e2e/workflows/auth.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test'
+import {
+  expectAuthenticatedApiCall,
+  installAuthenticatedSession,
+  installWorkflowApiMocks,
+  workflowUser,
+} from '../fixtures/workflow'
+
+test('login stores the authenticated session and opens the collection', async ({ page }) => {
+  await installWorkflowApiMocks(page)
+
+  await page.goto('/login')
+  await page.getByRole('textbox').first().fill(workflowUser.username)
+  await page.locator('input[type="password"]').fill('correct-password')
+  await page.getByRole('button', { name: 'Sign In' }).click()
+
+  await expect(page).toHaveURL('/')
+  await expect(page.getByRole('button', { name: 'Coin Collection' })).toBeVisible()
+  await expect(page.evaluate(() => window.localStorage.getItem('token'))).resolves.toBe('workflow-access-token')
+})
+
+test('authenticated setup helper opens protected workflows without a live backend', async ({ page }) => {
+  await installAuthenticatedSession(page)
+  const api = await installWorkflowApiMocks(page)
+
+  await page.goto('/add')
+
+  await expect(page.getByRole('heading', { name: 'Add Coin' })).toBeVisible()
+  await expectAuthenticatedApiCall(api, 'GET /storage-locations')
+})

--- a/src/web/e2e/workflows/coin-form.spec.ts
+++ b/src/web/e2e/workflows/coin-form.spec.ts
@@ -1,0 +1,211 @@
+import { expect, test } from '@playwright/test'
+import {
+  coinFormControl,
+  installAuthenticatedSession,
+  installWorkflowApiMocks,
+} from '../fixtures/workflow'
+import {
+  buildGoldenCoinFixtures,
+  buildImageHeavyDrachm,
+  buildRomanDenariusCore,
+  buildTaggedFollisStorage,
+  buildTestTags,
+} from '../../src/test/fixtures'
+
+test.beforeEach(async ({ page }) => {
+  await installAuthenticatedSession(page)
+})
+
+test('manual add coin saves deterministic fixture-shaped data', async ({ page }) => {
+  const api = await installWorkflowApiMocks(page)
+
+  await page.goto('/add')
+  await expect(page.getByRole('heading', { name: 'Add Coin' })).toBeVisible()
+
+  await coinFormControl(page, 'Name').fill('Browser Workflow Denarius')
+  await coinFormControl(page, 'Denomination').fill('Denarius')
+  await coinFormControl(page, 'Ruler').fill('Trajan')
+  await coinFormControl(page, 'Mint').fill('Rome')
+  await coinFormControl(page, 'Weight').fill('3.41')
+  await coinFormControl(page, 'Purchase Price').fill('180')
+  await page.getByRole('button', { name: 'Add to Collection' }).click()
+
+  await expect(page).toHaveURL(/\/coin\/7001$/)
+  await expect(page.getByRole('heading', { name: 'Browser Workflow Denarius' })).toBeVisible()
+  expect(api.createPayloads).toHaveLength(1)
+  expect(api.createPayloads[0]).toMatchObject({
+    name: 'Browser Workflow Denarius',
+    denomination: 'Denarius',
+    ruler: 'Trajan',
+    mint: 'Rome',
+    weightGrams: 3.41,
+    purchasePrice: 180,
+  })
+})
+
+test('edit one field preserves the loaded golden fixture workflow', async ({ page }) => {
+  const coin = buildRomanDenariusCore()
+  const api = await installWorkflowApiMocks(page, [coin])
+
+  await page.goto(`/coin/${coin.id}`)
+  await page.getByRole('link', { name: 'Edit' }).click()
+  await expect(page.getByRole('heading', { name: 'Edit Coin' })).toBeVisible()
+
+  await coinFormControl(page, 'Name').fill('Trajan Denarius Retitled')
+  await page.getByRole('button', { name: 'Save Changes' }).click()
+
+  await expect(page).toHaveURL(`/coin/${coin.id}`)
+  await expect(page.getByRole('heading', { name: 'Trajan Denarius Retitled' })).toBeVisible()
+  expect(api.updatePayloads).toHaveLength(1)
+  expect(api.updatePayloads[0]?.payload).toMatchObject({
+    id: coin.id,
+    name: 'Trajan Denarius Retitled',
+    tags: coin.tags,
+    sets: coin.sets,
+  })
+})
+
+test('edit storage location changes and clears the golden fixture location', async ({ page }) => {
+  const coin = buildTaggedFollisStorage()
+  const api = await installWorkflowApiMocks(page, [coin])
+  const vaultBox = api.storageLocations.find((location) => location.name === 'Vault Box 2')
+  if (!vaultBox) throw new Error('Vault Box 2 fixture is required for the storage workflow')
+
+  await page.goto(`/coin/${coin.id}`)
+  await page.getByRole('link', { name: 'Edit' }).click()
+  await expect(page.getByRole('heading', { name: 'Edit Coin' })).toBeVisible()
+
+  await coinFormControl(page, 'Storage Location').selectOption(String(vaultBox.id))
+  await page.getByRole('button', { name: 'Save Changes' }).click()
+
+  await expect(page).toHaveURL(`/coin/${coin.id}`)
+  await expect(page.locator('.metadata-row').filter({ hasText: 'Storage Location' })).toContainText(vaultBox.name)
+
+  await page.getByRole('link', { name: 'Edit' }).click()
+  await expect(page.getByRole('heading', { name: 'Edit Coin' })).toBeVisible()
+
+  await coinFormControl(page, 'Storage Location').selectOption('')
+  await page.getByRole('button', { name: 'Save Changes' }).click()
+
+  await expect(page).toHaveURL(`/coin/${coin.id}`)
+  await expect(page.locator('.metadata-row').filter({ hasText: 'Storage Location' })).toContainText('—')
+  expect(api.updatePayloads.map(({ payload }) => payload.storageLocationId)).toEqual([vaultBox.id, null])
+})
+
+test('edit tags and sets updates detail-page associations deterministically', async ({ page }) => {
+  const photographed = buildTestTags().find((tag) => tag.name === 'Photographed')
+  if (!photographed) throw new Error('Photographed fixture tag is required for the tags workflow')
+  const coin = buildTaggedFollisStorage({ tags: [photographed], sets: [] })
+  const api = await installWorkflowApiMocks(page, [coin])
+  const needsResearch = api.tags.find((tag) => tag.name === 'Needs Research')
+  const twelveCaesars = api.sets.find((set) => set.name === 'Twelve Caesars')
+  if (!needsResearch || !twelveCaesars) throw new Error('Tag and set fixtures are required for the association workflow')
+
+  await page.goto(`/coin/${coin.id}`)
+  const tagsSection = page.locator('section').filter({ has: page.getByRole('heading', { name: 'Tags & Sets' }) })
+  await expect(tagsSection.getByText('Photographed')).toBeVisible()
+
+  await tagsSection.getByRole('button', { name: 'Remove Photographed tag' }).click()
+  await expect(tagsSection.getByText('Photographed')).toBeHidden()
+
+  await tagsSection.getByRole('button', { name: '+ Tag or Set' }).click()
+  await tagsSection.locator('select').selectOption(`tag:${needsResearch.id}`)
+  await expect(tagsSection.getByText('Needs Research')).toBeVisible()
+
+  await tagsSection.getByRole('button', { name: '+ Tag or Set' }).click()
+  await tagsSection.locator('select').selectOption(`set:${twelveCaesars.id}`)
+  await expect(tagsSection.getByText('Twelve Caesars')).toBeVisible()
+
+  await tagsSection.getByRole('button', { name: 'Remove Twelve Caesars set' }).click()
+  await expect(tagsSection.getByText('Twelve Caesars')).toBeHidden()
+  expect(api.tagPayloads).toEqual([
+    { action: 'remove', coinId: coin.id, tagId: photographed.id },
+    { action: 'add', coinId: coin.id, tagId: needsResearch.id },
+  ])
+  expect(api.setPayloads).toEqual([
+    { action: 'add', coinId: coin.id, setId: twelveCaesars.id },
+    { action: 'remove', coinId: coin.id, setId: twelveCaesars.id },
+  ])
+})
+
+test('upload and delete image workflow updates deterministic image routes', async ({ page }) => {
+  const coin = buildImageHeavyDrachm()
+  const api = await installWorkflowApiMocks(page, [coin])
+  const obverse = coin.images.find((image) => image.imageType === 'obverse')
+  const reverse = coin.images.find((image) => image.imageType === 'reverse')
+  if (!obverse || !reverse) throw new Error('Image-heavy fixture must include obverse and reverse images')
+
+  await page.goto(`/coin/${coin.id}`)
+  await page.getByRole('link', { name: 'Edit' }).click()
+  await expect(page.getByRole('heading', { name: 'Edit Coin' })).toBeVisible()
+
+  await page.getByLabel('Remove obverse image').click()
+  await page.getByLabel('Upload reverse image').setInputFiles({
+    name: 'workflow-reverse.png',
+    mimeType: 'image/png',
+    buffer: Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+  })
+  await page.getByRole('button', { name: 'Save Changes' }).click()
+
+  await expect(page).toHaveURL(`/coin/${coin.id}`)
+  await expect.poll(() => api.imageDeletes).toEqual([
+    { coinId: coin.id, imageId: obverse.id },
+    { coinId: coin.id, imageId: reverse.id },
+  ])
+  expect(api.imageUploads).toEqual([
+    expect.objectContaining({
+      coinId: coin.id,
+      imageType: 'reverse',
+      isPrimary: false,
+      fileName: 'workflow-reverse.png',
+    }),
+  ])
+  await expect(page.locator('.hero-slot').first().getByText('No image')).toBeVisible()
+  await expect(page.getByAltText('Reverse')).toBeVisible()
+})
+
+test('collection search and filters query deterministic fixture data', async ({ page }) => {
+  const api = await installWorkflowApiMocks(page, buildGoldenCoinFixtures())
+
+  await page.goto('/')
+  await expect(page.getByRole('heading', { name: 'Trajan Denarius Core' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Syracuse Drachm Image Heavy' })).toBeVisible()
+
+  await page.getByPlaceholder('Search coins by name, ruler, inscription...').fill('Syracuse')
+  await expect(page.getByRole('heading', { name: 'Syracuse Drachm Image Heavy' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Trajan Denarius Core' })).toBeHidden()
+  await expect.poll(() => api.coinQueries.some((query) => query.search === 'Syracuse')).toBe(true)
+
+  await page.getByPlaceholder('Search coins by name, ruler, inscription...').fill('')
+  await page.getByRole('button', { name: 'Greek' }).click()
+  await expect(page.getByRole('heading', { name: 'Athens Owl Tetradrachm Valued' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Trajan Denarius Core' })).toBeHidden()
+  await expect.poll(() => api.coinQueries.some((query) => query.category === 'Greek')).toBe(true)
+
+  await page.getByRole('button', { name: 'All', exact: true }).click()
+  await page.locator('.tag-filter-select').selectOption({ label: 'Needs Research' })
+  await expect(page.getByRole('heading', { name: 'Diocletian Follis Tagged Storage' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Athens Owl Tetradrachm Valued' })).toBeHidden()
+  await expect.poll(() => api.coinQueries.some((query) => query.tag === '302')).toBe(true)
+})
+
+test('mobile viewport edit workflow saves without desktop-only controls', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  const coin = buildRomanDenariusCore()
+  const api = await installWorkflowApiMocks(page, [coin])
+
+  await page.goto(`/coin/${coin.id}`)
+  await page.getByRole('link', { name: 'Edit' }).click()
+  await expect(page.getByRole('heading', { name: 'Edit Coin' })).toBeVisible()
+
+  await coinFormControl(page, 'Name').fill('Mobile Edited Denarius')
+  await page.getByRole('button', { name: 'Save Changes' }).click()
+
+  await expect(page).toHaveURL(`/coin/${coin.id}`)
+  await expect(page.getByRole('heading', { name: 'Mobile Edited Denarius' })).toBeVisible()
+  expect(api.updatePayloads).toHaveLength(1)
+  expect(api.updatePayloads[0]?.payload).toMatchObject({
+    id: coin.id,
+    name: 'Mobile Edited Denarius',
+  })
+})

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.60.0",
         "@testing-library/vue": "^8.1.0",
         "@tsconfig/node24": "^24.0.4",
         "@types/dompurify": "^3.2.0",
@@ -2652,6 +2653,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -8098,6 +8115,53 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -11,6 +11,7 @@
     "type-check": "vue-tsc --build",
     "lint": "eslint . --ext .vue,.ts,.tsx",
     "test": "vitest run",
+    "test:browser": "playwright test",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/vue": "^8.1.0",
     "@tsconfig/node24": "^24.0.4",
     "@types/dompurify": "^3.2.0",

--- a/src/web/playwright.config.ts
+++ b/src/web/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    serviceWorkers: 'block',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'npm.cmd run dev -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/src/web/src/components/CoinForm.vue
+++ b/src/web/src/components/CoinForm.vue
@@ -98,10 +98,10 @@
             <label class="form-label">Obverse Image</label>
             <div v-if="obversePreview || existingObverse" class="image-preview-box">
               <img :src="obversePreview || existingObverse!" alt="Obverse" class="image-preview" />
-              <button type="button" class="image-remove-btn" @click="clearObverse" title="Remove"><X :size="12" /></button>
+              <button type="button" class="image-remove-btn" @click="clearObverse" title="Remove" aria-label="Remove obverse image"><X :size="12" /></button>
             </div>
             <div class="file-input-row">
-              <input type="file" accept=".jpg,.jpeg,.png" class="form-input file-input" @change="onObverseFile" ref="obverseInput" />
+              <input type="file" accept=".jpg,.jpeg,.png" class="form-input file-input" aria-label="Upload obverse image" @change="onObverseFile" ref="obverseInput" />
               <label v-if="isPwa" class="btn btn-secondary btn-sm camera-btn">
                 <Camera :size="14" /> Photo
                 <input type="file" accept="image/*" capture="environment" hidden @change="onObverseFile" />
@@ -112,10 +112,10 @@
             <label class="form-label">Reverse Image</label>
             <div v-if="reversePreview || existingReverse" class="image-preview-box">
               <img :src="reversePreview || existingReverse!" alt="Reverse" class="image-preview" />
-              <button type="button" class="image-remove-btn" @click="clearReverse" title="Remove"><X :size="12" /></button>
+              <button type="button" class="image-remove-btn" @click="clearReverse" title="Remove" aria-label="Remove reverse image"><X :size="12" /></button>
             </div>
             <div class="file-input-row">
-              <input type="file" accept=".jpg,.jpeg,.png" class="form-input file-input" @change="onReverseFile" ref="reverseInput" />
+              <input type="file" accept=".jpg,.jpeg,.png" class="form-input file-input" aria-label="Upload reverse image" @change="onReverseFile" ref="reverseInput" />
               <label v-if="isPwa" class="btn btn-secondary btn-sm camera-btn">
                 <Camera :size="14" /> Photo
                 <input type="file" accept="image/*" capture="environment" hidden @change="onReverseFile" />
@@ -178,9 +178,9 @@
           <p class="form-hint">Upload a photo of the store card. Text will be extracted automatically and saved to Notes.</p>
           <div v-if="cardPreview" class="image-preview-box">
             <img :src="cardPreview" alt="Store card" class="image-preview" />
-            <button type="button" class="image-remove-btn" @click="clearCard" title="Remove"><X :size="12" /></button>
+            <button type="button" class="image-remove-btn" @click="clearCard" title="Remove" aria-label="Remove store card image"><X :size="12" /></button>
           </div>
-          <input type="file" accept=".jpg,.jpeg,.png" class="form-input file-input" @change="onCardFile" ref="cardInput" />
+          <input type="file" accept=".jpg,.jpeg,.png" class="form-input file-input" aria-label="Upload store card image" @change="onCardFile" ref="cardInput" />
         </div>
         <div class="form-group">
           <label class="form-label">Notes</label>

--- a/src/web/src/test/fixtures/coins.test.ts
+++ b/src/web/src/test/fixtures/coins.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GOLDEN_COIN_FIXTURE_NAMES,
+  buildGoldenCoinFixture,
+  buildGoldenCoinFixtures,
+  goldenCoinFixtureCatalog,
+  type GoldenCoinTrait,
+} from './coins'
+
+describe('golden coin fixtures', () => {
+  it('catalog covers every required F013 workflow trait', () => {
+    expect(goldenCoinFixtureCatalog).toHaveLength(GOLDEN_COIN_FIXTURE_NAMES.length)
+
+    const requiredTraits: GoldenCoinTrait[] = [
+      'roman',
+      'greek',
+      'byzantine',
+      'wishlist',
+      'sold',
+      'private',
+      'tagged',
+      'set-member',
+      'storage-location',
+      'image-heavy',
+      'legacy-custom-era',
+    ]
+    const seenTraits = new Set(goldenCoinFixtureCatalog.flatMap((fixture) => fixture.traits))
+
+    for (const trait of requiredTraits) {
+      expect(seenTraits.has(trait), `missing golden fixture trait ${trait}`).toBe(true)
+    }
+  })
+
+  it('builders return independent fixture clones with expected associations', () => {
+    const first = buildGoldenCoinFixture('tagged-follis-storage')
+    const second = buildGoldenCoinFixture('tagged-follis-storage')
+
+    if (!first.tags?.[0] || !second.tags?.[0]) {
+      throw new Error('tagged fixture must include tags')
+    }
+
+    first.tags[0].name = 'Mutated'
+    first.storageLocation = { id: 999, name: 'Mutated' }
+
+    expect(second.tags[0].name).toBe('Photographed')
+    expect(second.storageLocation?.name).toBe('Cabinet Tray A')
+
+    const fixtures = buildGoldenCoinFixtures()
+    expect(fixtures).toHaveLength(GOLDEN_COIN_FIXTURE_NAMES.length)
+    expect(buildGoldenCoinFixture('image-heavy-drachm').images).toHaveLength(4)
+    expect(buildGoldenCoinFixture('reference-rich-denarius').references).toHaveLength(3)
+    expect(buildGoldenCoinFixture('byzantine-solidus-set-member').sets).toHaveLength(1)
+  })
+})

--- a/src/web/src/test/fixtures/coins.ts
+++ b/src/web/src/test/fixtures/coins.ts
@@ -1,0 +1,413 @@
+import type { Coin, CoinImage, CoinReference, CoinSet, StorageLocation, Tag } from '@/types'
+
+export const GOLDEN_COIN_FIXTURE_NAMES = [
+  'roman-denarius-core',
+  'greek-tetradrachm-valued',
+  'byzantine-solidus-set-member',
+  'wishlist-aureus-target',
+  'sold-sestertius-archive',
+  'private-provincial-bronze',
+  'tagged-follis-storage',
+  'image-heavy-drachm',
+  'reference-rich-denarius',
+] as const
+
+export type GoldenCoinFixtureName = typeof GOLDEN_COIN_FIXTURE_NAMES[number]
+
+export type GoldenCoinTrait =
+  | 'roman'
+  | 'greek'
+  | 'byzantine'
+  | 'wishlist'
+  | 'sold'
+  | 'private'
+  | 'tagged'
+  | 'set-member'
+  | 'storage-location'
+  | 'image-heavy'
+  | 'legacy-custom-era'
+  | 'valued'
+  | 'reference-rich'
+
+export interface GoldenCoinFixtureInfo {
+  name: GoldenCoinFixtureName
+  traits: readonly GoldenCoinTrait[]
+}
+
+export type CoinFixtureOverrides = Partial<Omit<Coin, 'images' | 'references' | 'tags' | 'sets' | 'storageLocation'>> & {
+  images?: readonly CoinImage[]
+  references?: readonly CoinReference[]
+  tags?: readonly Tag[]
+  sets?: readonly CoinSet[]
+  storageLocation?: Coin['storageLocation']
+}
+
+interface CoinFixtureDefinition {
+  coin: Coin
+  traits: readonly GoldenCoinTrait[]
+}
+
+const fixtureUserId = 101
+const createdAt = '2026-01-15T12:00:00Z'
+const updatedAt = '2026-01-15T12:00:00Z'
+
+const storageLocations = {
+  trayA: {
+    id: 201,
+    userId: fixtureUserId,
+    name: 'Cabinet Tray A',
+    sortOrder: 1,
+  },
+  vaultBox: {
+    id: 202,
+    userId: fixtureUserId,
+    name: 'Vault Box 2',
+    sortOrder: 2,
+  },
+} satisfies Record<string, StorageLocation>
+
+const tags = {
+  photographed: {
+    id: 301,
+    userId: fixtureUserId,
+    name: 'Photographed',
+    color: '#c9a84c',
+  },
+  needsResearch: {
+    id: 302,
+    userId: fixtureUserId,
+    name: 'Needs Research',
+    color: '#4682b4',
+  },
+} satisfies Record<string, Tag>
+
+const sets = {
+  twelveCaesars: {
+    id: 401,
+    userId: fixtureUserId,
+    name: 'Twelve Caesars',
+    description: 'Representative imperial portrait set',
+    color: '#c9a84c',
+    icon: 'Crown',
+    setType: 'defined',
+    parentSetId: null,
+    targetCompletionDate: '2026-12-31',
+    createdAt,
+    updatedAt,
+  },
+  byzantineGold: {
+    id: 402,
+    userId: fixtureUserId,
+    name: 'Byzantine Gold',
+    description: 'Gold issues for set-membership workflow tests',
+    color: '#b08d57',
+    icon: 'CircleDot',
+    setType: 'open',
+    parentSetId: null,
+    targetCompletionDate: null,
+    createdAt,
+    updatedAt,
+  },
+} satisfies Record<string, CoinSet>
+
+function buildImage(coinId: number, id: number, imageType: CoinImage['imageType'], isPrimary = false): CoinImage {
+  return {
+    id,
+    coinId,
+    filePath: `/uploads/test-fixtures/${coinId}-${imageType}-${id}.webp`,
+    imageType,
+    isPrimary,
+    createdAt,
+  }
+}
+
+function buildReference(coinId: number, id: number, catalog: string, number: string, volume = ''): CoinReference {
+  return {
+    id,
+    coinId,
+    catalog,
+    volume,
+    number,
+    invoiceNumber: `INV-${coinId}-${id}`,
+    uri: `https://example.test/catalog/${catalog.toLowerCase()}/${number}`,
+    createdAt,
+    updatedAt,
+  }
+}
+
+function baseCoin(id: number, name: string): Coin {
+  return {
+    id,
+    name,
+    category: 'Roman',
+    denomination: 'Denarius',
+    ruler: 'Trajan',
+    era: 'ancient',
+    mint: 'Rome',
+    material: 'Silver',
+    weightGrams: 3.35,
+    diameterMm: 18,
+    grade: 'VF',
+    obverseInscription: 'IMP TRAIANO AVG GER DAC P M TR P',
+    reverseInscription: 'SPQR OPTIMO PRINCIPI',
+    obverseDescription: 'Laureate bust right',
+    reverseDescription: 'Victory standing left',
+    rarityRating: 'Common',
+    purchasePrice: 180,
+    currentValue: 225,
+    purchaseDate: '2024-03-15T00:00:00Z',
+    purchaseLocation: 'Fixture Dealer',
+    storageLocationId: null,
+    storageLocation: null,
+    notes: 'Deterministic frontend fixture coin.',
+    aiAnalysis: '',
+    obverseAnalysis: '',
+    reverseAnalysis: '',
+    referenceUrl: '',
+    referenceText: '',
+    isWishlist: false,
+    isSold: false,
+    soldPrice: null,
+    soldDate: null,
+    soldTo: '',
+    isPrivate: false,
+    listingStatus: 'unlisted',
+    listingCheckedAt: null,
+    listingCheckReason: '',
+    userId: fixtureUserId,
+    images: [buildImage(id, id * 10 + 1, 'obverse', true), buildImage(id, id * 10 + 2, 'reverse')],
+    references: [],
+    tags: [],
+    sets: [],
+    createdAt,
+    updatedAt,
+  }
+}
+
+const fixtureDefinitions = {
+  'roman-denarius-core': {
+    coin: {
+      ...baseCoin(1001, 'Trajan Denarius Core'),
+      referenceUrl: 'https://example.test/coins/roman-denarius-core',
+      referenceText: 'RIC II Trajan 147',
+    },
+    traits: ['roman'],
+  },
+  'greek-tetradrachm-valued': {
+    coin: {
+      ...baseCoin(1002, 'Athens Owl Tetradrachm Valued'),
+      category: 'Greek',
+      denomination: 'Tetradrachm',
+      ruler: 'Athens',
+      mint: 'Athens',
+      material: 'Silver',
+      weightGrams: 17.18,
+      diameterMm: 24,
+      purchasePrice: 950,
+      currentValue: 1250,
+      purchaseDate: '2023-09-10T00:00:00Z',
+      obverseInscription: '',
+      reverseInscription: 'ΑΘΕ',
+      obverseDescription: 'Helmeted head of Athena right',
+      reverseDescription: 'Owl standing right, olive sprig and crescent',
+    },
+    traits: ['greek', 'valued'],
+  },
+  'byzantine-solidus-set-member': {
+    coin: {
+      ...baseCoin(1003, 'Justinian I Solidus Set Member'),
+      category: 'Byzantine',
+      denomination: 'Solidus',
+      ruler: 'Justinian I',
+      mint: 'Constantinople',
+      material: 'Gold',
+      weightGrams: 4.48,
+      diameterMm: 21,
+      purchasePrice: 700,
+      currentValue: 875,
+      sets: [{ ...sets.byzantineGold }],
+    },
+    traits: ['byzantine', 'set-member'],
+  },
+  'wishlist-aureus-target': {
+    coin: {
+      ...baseCoin(1004, 'Augustus Aureus Wishlist Target'),
+      denomination: 'Aureus',
+      ruler: 'Augustus',
+      material: 'Gold',
+      weightGrams: 7.9,
+      diameterMm: 20,
+      purchasePrice: null,
+      currentValue: 8500,
+      purchaseDate: null,
+      purchaseLocation: '',
+      isWishlist: true,
+      notes: 'Wishlist target used for purchase workflow tests.',
+    },
+    traits: ['roman', 'wishlist', 'valued'],
+  },
+  'sold-sestertius-archive': {
+    coin: {
+      ...baseCoin(1005, 'Hadrian Sestertius Archive'),
+      denomination: 'Sestertius',
+      ruler: 'Hadrian',
+      material: 'Bronze',
+      weightGrams: 25.1,
+      diameterMm: 32,
+      purchasePrice: 240,
+      currentValue: 300,
+      isSold: true,
+      soldPrice: 310,
+      soldDate: '2025-04-20T00:00:00Z',
+      soldTo: 'Archive Buyer',
+    },
+    traits: ['roman', 'sold'],
+  },
+  'private-provincial-bronze': {
+    coin: {
+      ...baseCoin(1006, 'Alexandria Provincial Bronze Private'),
+      denomination: 'Drachm',
+      ruler: 'Antoninus Pius',
+      era: 'Roman Provincial Year 12',
+      mint: 'Alexandria',
+      material: 'Bronze',
+      isPrivate: true,
+      referenceText: 'Legacy handwritten tray note',
+      notes: 'Private coin with a custom legacy era value.',
+    },
+    traits: ['roman', 'private', 'legacy-custom-era'],
+  },
+  'tagged-follis-storage': {
+    coin: {
+      ...baseCoin(1007, 'Diocletian Follis Tagged Storage'),
+      denomination: 'Follis',
+      ruler: 'Diocletian',
+      material: 'Bronze',
+      storageLocationId: storageLocations.trayA.id,
+      storageLocation: { id: storageLocations.trayA.id, name: storageLocations.trayA.name },
+      tags: [{ ...tags.photographed }, { ...tags.needsResearch }],
+    },
+    traits: ['roman', 'tagged', 'storage-location'],
+  },
+  'image-heavy-drachm': {
+    coin: {
+      ...baseCoin(1008, 'Syracuse Drachm Image Heavy'),
+      category: 'Greek',
+      denomination: 'Drachm',
+      ruler: 'Syracuse',
+      mint: 'Syracuse',
+      images: [
+        buildImage(1008, 10081, 'obverse', true),
+        buildImage(1008, 10082, 'reverse'),
+        buildImage(1008, 10083, 'detail'),
+        buildImage(1008, 10084, 'other'),
+      ],
+    },
+    traits: ['greek', 'image-heavy'],
+  },
+  'reference-rich-denarius': {
+    coin: {
+      ...baseCoin(1009, 'Vespasian Denarius Reference Rich'),
+      ruler: 'Vespasian',
+      referenceUrl: 'https://example.test/coins/reference-rich-denarius',
+      referenceText: 'RIC II.1 Vespasian 772; BMCRE 161; RSC 554',
+      references: [
+        buildReference(1009, 1, 'RIC', '772', 'II.1'),
+        buildReference(1009, 2, 'BMCRE', '161'),
+        buildReference(1009, 3, 'RSC', '554'),
+      ],
+      sets: [{ ...sets.twelveCaesars }],
+    },
+    traits: ['roman', 'reference-rich', 'set-member'],
+  },
+} satisfies Record<GoldenCoinFixtureName, CoinFixtureDefinition>
+
+function cloneCoin(coin: Coin): Coin {
+  return {
+    ...coin,
+    storageLocation: coin.storageLocation ? { ...coin.storageLocation } : null,
+    images: coin.images.map((image) => ({ ...image })),
+    references: coin.references?.map((reference) => ({ ...reference })),
+    tags: coin.tags?.map((tag) => ({ ...tag })),
+    sets: coin.sets?.map((set) => ({ ...set })),
+  }
+}
+
+function applyCoinOverrides(coin: Coin, overrides: CoinFixtureOverrides): Coin {
+  return {
+    ...coin,
+    ...overrides,
+    storageLocation: overrides.storageLocation === undefined
+      ? coin.storageLocation
+      : overrides.storageLocation
+        ? { ...overrides.storageLocation }
+        : null,
+    images: overrides.images === undefined ? coin.images : overrides.images.map((image) => ({ ...image })),
+    references: overrides.references === undefined
+      ? coin.references
+      : overrides.references.map((reference) => ({ ...reference })),
+    tags: overrides.tags === undefined ? coin.tags : overrides.tags.map((tag) => ({ ...tag })),
+    sets: overrides.sets === undefined ? coin.sets : overrides.sets.map((set) => ({ ...set })),
+  }
+}
+
+export const goldenCoinFixtureCatalog: readonly GoldenCoinFixtureInfo[] = GOLDEN_COIN_FIXTURE_NAMES.map((name) => ({
+  name,
+  traits: fixtureDefinitions[name].traits,
+}))
+
+export function buildGoldenCoinFixture(name: GoldenCoinFixtureName, overrides: CoinFixtureOverrides = {}): Coin {
+  return applyCoinOverrides(cloneCoin(fixtureDefinitions[name].coin), overrides)
+}
+
+export function buildGoldenCoinFixtures(overrides: Partial<Record<GoldenCoinFixtureName, CoinFixtureOverrides>> = {}): Coin[] {
+  return GOLDEN_COIN_FIXTURE_NAMES.map((name) => buildGoldenCoinFixture(name, overrides[name]))
+}
+
+export function buildRomanDenariusCore(overrides?: CoinFixtureOverrides): Coin {
+  return buildGoldenCoinFixture('roman-denarius-core', overrides)
+}
+
+export function buildGreekTetradrachmValued(overrides?: CoinFixtureOverrides): Coin {
+  return buildGoldenCoinFixture('greek-tetradrachm-valued', overrides)
+}
+
+export function buildByzantineSolidusSetMember(overrides?: CoinFixtureOverrides): Coin {
+  return buildGoldenCoinFixture('byzantine-solidus-set-member', overrides)
+}
+
+export function buildWishlistAureusTarget(overrides?: CoinFixtureOverrides): Coin {
+  return buildGoldenCoinFixture('wishlist-aureus-target', overrides)
+}
+
+export function buildSoldSestertiusArchive(overrides?: CoinFixtureOverrides): Coin {
+  return buildGoldenCoinFixture('sold-sestertius-archive', overrides)
+}
+
+export function buildPrivateProvincialBronze(overrides?: CoinFixtureOverrides): Coin {
+  return buildGoldenCoinFixture('private-provincial-bronze', overrides)
+}
+
+export function buildTaggedFollisStorage(overrides?: CoinFixtureOverrides): Coin {
+  return buildGoldenCoinFixture('tagged-follis-storage', overrides)
+}
+
+export function buildImageHeavyDrachm(overrides?: CoinFixtureOverrides): Coin {
+  return buildGoldenCoinFixture('image-heavy-drachm', overrides)
+}
+
+export function buildReferenceRichDenarius(overrides?: CoinFixtureOverrides): Coin {
+  return buildGoldenCoinFixture('reference-rich-denarius', overrides)
+}
+
+export function buildTestStorageLocations(): StorageLocation[] {
+  return Object.values(storageLocations).map((location) => ({ ...location }))
+}
+
+export function buildTestTags(): Tag[] {
+  return Object.values(tags).map((tag) => ({ ...tag }))
+}
+
+export function buildTestCoinSets(): CoinSet[] {
+  return Object.values(sets).map((set) => ({ ...set }))
+}

--- a/src/web/src/test/fixtures/index.ts
+++ b/src/web/src/test/fixtures/index.ts
@@ -1,0 +1,1 @@
+export * from './coins'


### PR DESCRIPTION
## Summary
- Complete F013 critical workflow hardening with typed coin create/update request DTOs and explicit nullable/zero-value semantics
- Add backend regression coverage and golden fixture builders for critical coin mutation paths
- Add deterministic Playwright browser workflows plus `task test-critical-workflows`
- Document critical workflow coverage and fixture setup

## Validation
- `go test -v ./...` from `src/api`
- `go vet ./...` from `src/api`
- `npm.cmd run type-check` from `src/web`
- `npm.cmd test -- --run` from `src/web` (99 tests)
- `npm.cmd run test:browser` from `src/web` (9 workflows)
- `task test-critical-workflows` from repo root
- `git --no-pager diff --check`

## Constitution / Spec Coverage
- Principle III: Strict Types and Explicit Contracts
- Principle IV: Simple, Complete Changes
- Principle IX: Automated Enforcement Over Manual Memory
- §17 Quality Gate
- Feature: `specs/220-critical-workflow-hardening`