### PR TITLE
fix: remove desktop era filter

### DIFF
--- a/src/web/src/components/collection/DesktopCollectionHeader.vue
+++ b/src/web/src/components/collection/DesktopCollectionHeader.vue
@@ -11,7 +11,6 @@
     <div class="collection-toolbar">
       <div class="toolbar-filters">
         <CategoryFilter :model-value="selectedCategory" @update:model-value="$emit('update:selectedCategory', $event)" />
-        <EraFilter :model-value="selectedEra" @update:model-value="$emit('update:selectedEra', $event)" />
         <select v-if="userTags.length" :value="selectedTag" @change="$emit('update:selectedTag', ($event.target as HTMLSelectElement).value)" class="tag-filter-select">
           <option value="">All Sets</option>
           <option v-for="tag in userTags" :key="tag.filterValue" :value="tag.filterValue">{{ tag.name }}</option>
@@ -38,7 +37,6 @@
 <script setup lang="ts">
 import type { CollectionSetOption, ImageType } from '@/types'
 import CategoryFilter from '@/components/CategoryFilter.vue'
-import EraFilter from '@/components/collection/EraFilter.vue'
 import SearchBar from '@/components/SearchBar.vue'
 import SortSelect from '@/components/SortSelect.vue'
 import { CirclePlus, CheckSquare } from 'lucide-vue-next'
@@ -47,7 +45,6 @@ defineProps<{
   search: string
   selectMode: boolean
   selectedCategory: string
-  selectedEra: string
   selectedTag: string
   userTags: CollectionSetOption[]
   sortKey: string
@@ -57,7 +54,6 @@ defineProps<{
 defineEmits<{
   'update:search': [value: string]
   'update:selectedCategory': [value: string]
-  'update:selectedEra': [value: string]
   'update:selectedTag': [value: string]
   'update:sortKey': [value: string]
   'update:gridSide': [value: ImageType | null]

--- a/src/web/src/pages/CollectionPage.vue
+++ b/src/web/src/pages/CollectionPage.vue
@@ -24,7 +24,6 @@
       v-if="!isPwa"
       v-model:search="search"
       v-model:selected-category="selectedCategory"
-      v-model:selected-era="selectedEra"
       v-model:selected-tag="selectedTag"
       v-model:sort-key="sortKey"
       v-model:grid-side="gridSide"


### PR DESCRIPTION
Remove the EraFilter from the desktop collection toolbar while preserving category and set filters. PWA filtering remains unchanged.

Constitution: Principle IV, Principle VI, §17.

## Summary
<!-- 1-3 sentences: what changes and why -->

## Constitution self-check
- Principle(s) touched: <!-- e.g., I (Clear Layered Architecture), IV (Simple Complete Changes) -->
- Operational section(s): <!-- e.g., §17 Quality Gate, §21 DoD -->
- ADR added? <!-- yes/no — required for material design choices, §22 -->
- Principle IV check: <!-- simple, complete, proportional; note workflow/sibling paths tested -->

## Linked work
- Issue: #
- Spec: `specs/NNN-*/spec.md`
- Tasks completed: <!-- specs/NNN-*/tasks.md line(s) -->

## Definition of Done (§21)
- [ ] 1. Code compiles (`go build ./...`, `npm run build`, `pip install -e ".[dev]"` as applicable)
- [ ] 2. Architecture tests green (`go test -run TestArchitecture ./...`)
- [ ] 3. Unit tests pass (`go test ./...`, `pytest tests/`)
- [ ] 4. Type checks pass (`vue-tsc --build`, Go compile)
- [ ] 5. Linters clean (`go vet`, `ruff check`)
- [ ] 6. New service methods have ≥1 unit test
- [ ] 7. Public handlers have Swagger annotations
- [ ] 8. If API changed: `task openapi` run and `docs/openapi.json` updated
- [ ] 9. If material design choice: ADR added in `docs/adr/` *(when Phase 3 lands)*
- [ ] 10. Active `specs/NNN-*/tasks.md` items checked off
- [ ] 11. `.squad/decisions/inbox/` written if cross-cutting decision made
- [ ] 12. Simple Complete Changes self-check complete (Principle IV)
- [ ] 13. Secrets scan clean (no credentials in diff)
- [ ] 14. Conventional commit messages
- [ ] 15. `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer present when AI-assisted

## Notes for reviewer
<!-- Anything reviewer should pay special attention to -->
