### PR TITLE
feat: add coin of the day pushover links

### DIFF
--- a/.squad/agents/aurelia/history.md
+++ b/.squad/agents/aurelia/history.md
@@ -52,6 +52,15 @@
    - Task T015 marked complete
    - Orchestration log: `.squad/orchestration-log/2026-06-09T12-51-39Z-aurelia.md`
 
+- **2026-06-10:** Coin of the Day Pushover Public URL Configuration Revision
+   - Cassius initially implemented with relative `/coin/{coinID}` links; Brutus blocked (relative URLs not usable outside app context)
+   - Added `PublicAppURL` admin setting in System tab (`AdminSystemSection.vue`) with validation and frontend type (`src/web/src/types/index.ts`)
+   - Coin of the Day Pushover links now build as absolute URLs (trim trailing slashes, join host + path) when setting is configured; omit link entirely when blank/invalid
+   - In-app notification behavior unchanged (in-app notification uses `ReferenceID = FeaturedCoin.ID` for modal)
+   - Tests pass: `npm run type-check`, `npm run build` ✅
+   - Brutus cleared BLOCK. Decision merged to `decisions.md`
+   - Orchestration log: `.squad/orchestration-log/2026-06-10T20-31-52Z-aurelia.md`
+
 - **2026-06-01:** Legacy catalog reference migration UI added to Settings → Data. New bordered section with Database and RefreshCw icons from lucide-vue-next, explanatory text (non-destructive, keeps originals, records outcomes in journal), trigger button with loading state, and result counts grid showing Succeeded (gold accent), Skipped, Failed (amber). Client function `migrateLegacyReferences()` calls `POST /references/migrate-legacy` and returns `LegacyMigrationResult { succeeded, skipped, failed, message? }` type. Results display uses design tokens (`--accent-gold`, `--text-muted`, `--bg-input`, `--border-subtle`, `--radius-sm`) and mobile-responsive stacked layout. Build and lint pass (no new warnings).
 
 - **2026-06-01:** Coin detail back navigation bug fixed. Root cause: EditCoinPage used `router.replace('/coin/:id')` after save, which Vue Router treated as a new Detail entry, leaving the stack as [Gallery, Detail_old, Detail_new]. Changed to `router.back()` which properly pops the Edit entry and returns to the original Detail, maintaining the correct Gallery → Detail → Back → Gallery flow. The pattern: when a child form/edit view saves and should return to parent, prefer `router.back()` over `router.replace()` to avoid polluting the history stack with duplicate parent entries.
@@ -212,3 +221,5 @@ Added navigator.permissions.query pre-check to CameraCaptureModal.vue. Persisted
    - **Orchestration Log:** `.squad/orchestration-log/2026-06-09T13-45-22Z-aurelia.md`
 
 - **2026-06-10:** Collection Pagination Count Summary — Added "Showing X–Y of Z coins" range display to CollectionPagination.vue (grid mode) to clarify total collection size when pagination limits to 50 per page. Responsive layout: mobile shows range above page number (vertical stack), desktop shows range + page number inline with bullet separator. Computed properties angeStart and angeEnd calculate current page item range. Updated tests to verify range formatting for first/last/partial pages. Type-check + tests pass. Preserves existing active-collection filters (wishlist:false, sold:false). PWA swipe mode already shows "X / Total" counter; only grid mode needed explicit range summary.
+
+- **2026-06-10:** Coin of the Day Pushover links need an explicit `PublicAppURL` admin setting because Pushover opens outside the PWA/app route context. When configured, backend builds absolute `http(s)://host/coin/{coinID}` links after trimming trailing slashes; when blank or invalid, keep HTML message formatting but omit both `url` and `<a>` so no broken relative `/coin/{id}` link ships.

--- a/.squad/agents/brutus/history.md
+++ b/.squad/agents/brutus/history.md
@@ -63,6 +63,13 @@
   - **Strict Lockout Remediation:** Aurelia's browser suite BLOCKED by Maximus on .gitignore gaps + generated outputs present + stale docs TODO
   - **Independent QA Fix:** Added `.gitignore` entries for Playwright output paths (`src/web/test-results/`, `src/web/playwright-report/`), removed generated `src/web/test-results/` directory, removed stale browser E2E TODO from `docs/testing.md`
   - **Validation:** `npm run test:browser` — 4 tests passing, `git diff --check` — no formatting violations, design token changes only to `.gitignore` and docs
+
+- **2026-06-10:** Coin of the Day Pushover Link Review (Cycle 1 BLOCK → Cycle 2 APPROVED)
+  - **Cycle 1:** Cassius initial implementation used relative `/coin/{coinID}` URLs in Pushover payloads. Issue: Pushover notifications open in system notification center outside app context; relative URLs fail to navigate. ISSUED BLOCK (STRICT LOCKOUT §18.2). Assigned revision to Aurelia.
+  - **Cycle 2:** Aurelia added `PublicAppURL` admin setting; links now build as absolute `http(s)://host/coin/{coinID}` (trim trailing slashes, join host + path). When setting blank/invalid, Pushover alerts omit the `url` field and HTML link anchor. In-app notification `ReferenceID = FeaturedCoin.ID` behavior unchanged.
+  - **Coverage:** Test assertions added for configured and unconfigured link behavior; backend `go test -v ./services` ✅; frontend `npm run type-check`, `npm run build` ✅.
+  - **Verdict:** BLOCK CLEARED. Feature ready for merge. Pushover external-link workflow is now explicit, tested, and deployment-configurable per Principle V.
+  - Orchestration log: `.squad/orchestration-log/2026-06-10T20-31-52Z-brutus.md`
   - **Principle Compliance:** Principle VI (Testing Infrastructure), Principle VIII (CI/CD & Build Hygiene), §18.2 (Strict Lockout)
   - **Review Outcome:** Maximus Lead Re-review APPROVED revised state with all issues resolved
   - **Key Learning:** Playwright generates deterministic artifacts (test-results/, playwright-report/, test data); must be `.gitignore`-excluded before integration into CI baseline

--- a/.squad/agents/cassius/history.md
+++ b/.squad/agents/cassius/history.md
@@ -35,6 +35,8 @@
 
 ## Learnings
 
+- **Coin of the Day Pushover Link Configuration (2026-06-10):** Initial implementation used relative `/coin/{coinID}` links in Pushover payloads; Brutus blocked (STRICT LOCKOUT, §18.2) because Pushover opens notifications outside app context where relative URLs are not usable. Aurelia revised by adding `PublicAppURL` admin setting: links now build as absolute `http(s)://host/coin/{coinID}` by trimming trailing slashes, and omit the link entirely when setting is blank/invalid. Brutus reviewed revised implementation and CLEARED BLOCK. Decision merged to `decisions.md`. See orchestration logs: `.squad/orchestration-log/2026-06-10T20-31-52Z-{cassius,aurelia,brutus}.md`
+
 ### 2026-06-10 — Collection Count Invariant
 
 **Files:**

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,6 +2,36 @@
 
 ## Active Decisions
 
+### Decision: Coin of the Day Pushover Link Configuration
+
+**Date:** 2026-06-10  
+**Agents:** Cassius (initial), Brutus (review), Aurelia (revision)  
+**Status:** APPROVED — BLOCK CLEARED  
+
+## Context
+
+Coin of the Day Pushover notifications require external-world navigation. Cassius initially used relative `/coin/{id}` URLs in notification payloads, which are not usable when opened from system notification center outside app context. Brutus blocked with STRICT LOCKOUT per constitution §18.2.
+
+## Decision
+
+Add an explicit admin setting `PublicAppURL` (surfaced in System Settings). Coin of the Day Pushover links are built as absolute `http(s)://host/coin/{coinID}` by trimming trailing slashes and joining. When the setting is blank or invalid, Pushover alerts omit both the `url` field and the HTML anchor, keeping the formatted notification body but removing the clickable link.
+
+In-app notifications retain `ReferenceID = FeaturedCoin.ID` for modal behavior unchanged.
+
+## Constitution Alignment
+
+- Principle IV: fixes the real external-link workflow explicitly, no hidden behavior.
+- Principle V: makes deployment-specific URL configuration explicit and user-settable.
+- Principle IX: added tests for configured and unconfigured Pushover link behavior.
+- §18.2: BLOCK CLEARED after revision to absolute-URL requirement.
+
+## Files Touched
+
+Backend: `services/coin_of_day_scheduler.go`, `services/notification_service.go`, `services/pushover_service.go`, `services/pushover_service_test.go`, `services/settings_service.go`, `services/settings_service_test.go`  
+Frontend: `components/admin/AdminSystemSection.vue`, `composables/useAdminConfig.ts`, `pages/AdminPage.vue`, `types/index.ts`
+
+---
+
 ### Decision: F013 Defines Deterministic Critical Workflow Baseline
 
 **Date:** 2026-06-09

--- a/src/api/services/coin_of_day_scheduler.go
+++ b/src/api/services/coin_of_day_scheduler.go
@@ -190,7 +190,7 @@ func (s *CoinOfDayScheduler) runCycleWithTrigger(triggerType string) (int, int, 
 			continue
 		}
 
-		s.notifSvc.NotifyCoinOfDay(user.ID, fc.ID, coin.Name, summary)
+		s.notifSvc.NotifyCoinOfDay(user.ID, fc.ID, coin.ID, coin.Name, summary)
 
 		s.mu.Lock()
 		s.lastPicked[user.ID] = today

--- a/src/api/services/notification_service.go
+++ b/src/api/services/notification_service.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"fmt"
+	"html"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -144,7 +146,7 @@ func (s *NotificationService) NotifyFollowRequest(followerID, targetID uint) {
 // NotifyCoinOfDay creates an in-app notification and Pushover alert for the
 // user's daily featured coin. The ReferenceID points to the FeaturedCoin record
 // so the frontend can open the dedicated modal.
-func (s *NotificationService) NotifyCoinOfDay(userID uint, featuredCoinID uint, coinName, summary string) {
+func (s *NotificationService) NotifyCoinOfDay(userID uint, featuredCoinID, coinID uint, coinName, summary string) {
 	if coinName == "" {
 		coinName = "Today's coin"
 	}
@@ -172,7 +174,7 @@ func (s *NotificationService) NotifyCoinOfDay(userID uint, featuredCoinID uint, 
 		s.logger.Error("notifications", "Failed to create coin-of-day notification for user %d: %v", userID, err)
 	}
 
-	go s.sendPushover(userID, title, message, "")
+	go s.sendPushoverMessage(userID, buildCoinOfDayPushoverMessage(title, coinID, coinName, summary, s.publicAppBaseURL()))
 }
 
 // NotifyAPIKeyRotationRequired creates a single actionable notification that lists
@@ -216,6 +218,15 @@ func (s *NotificationService) NotifyAPIKeyRotationRequired(userID uint, keyNames
 
 // sendPushover checks if the user has Pushover enabled and sends a push notification.
 func (s *NotificationService) sendPushover(userID uint, title, message, refURL string) {
+	s.sendPushoverMessage(userID, PushoverMessage{
+		Title:   title,
+		Message: message,
+		URL:     refURL,
+	})
+}
+
+// sendPushoverMessage checks if the user has Pushover enabled and sends a push notification.
+func (s *NotificationService) sendPushoverMessage(userID uint, message PushoverMessage) {
 	if s.pushoverSvc == nil || s.userRepo == nil {
 		return
 	}
@@ -229,7 +240,61 @@ func (s *NotificationService) sendPushover(userID uint, title, message, refURL s
 		return
 	}
 
-	if err := s.pushoverSvc.SendNotification(user.PushoverUserKey, title, message, refURL); err != nil {
+	message.UserKey = user.PushoverUserKey
+	if err := s.pushoverSvc.SendMessage(message); err != nil {
 		s.logger.Error("pushover", "Failed to send Pushover notification to user %d: %v", userID, err)
 	}
+}
+
+func (s *NotificationService) publicAppBaseURL() string {
+	if s == nil || s.pushoverSvc == nil || s.pushoverSvc.settingsSvc == nil {
+		return ""
+	}
+	return s.pushoverSvc.settingsSvc.GetSetting(SettingPublicAppURL)
+}
+
+func buildCoinOfDayPushoverMessage(title string, coinID uint, coinName, summary, publicAppBaseURL string) PushoverMessage {
+	if coinName == "" {
+		coinName = "Today's coin"
+	}
+
+	body := fmt.Sprintf("<b>%s</b>", html.EscapeString(coinName))
+	if summary != "" {
+		body = fmt.Sprintf("%s — %s", body, html.EscapeString(truncateRunes(summary, 140)))
+	}
+
+	coinURL := buildCoinOfDayURL(publicAppBaseURL, coinID)
+	if coinURL != "" {
+		body = fmt.Sprintf("%s — <a href=\"%s\">Open coin</a>", body, html.EscapeString(coinURL))
+	}
+
+	return PushoverMessage{
+		Title:   title,
+		Message: body,
+		URL:     coinURL,
+		HTML:    true,
+	}
+}
+
+func buildCoinOfDayURL(publicAppBaseURL string, coinID uint) string {
+	base := strings.TrimRight(strings.TrimSpace(publicAppBaseURL), "/")
+	if base == "" {
+		return ""
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return ""
+	}
+	return fmt.Sprintf("%s/coin/%d", base, coinID)
+}
+
+func truncateRunes(value string, max int) string {
+	runes := []rune(value)
+	if len(runes) <= max {
+		return value
+	}
+	return string(runes[:max-3]) + "..."
 }

--- a/src/api/services/pushover_service.go
+++ b/src/api/services/pushover_service.go
@@ -16,6 +16,17 @@ var ErrPushoverNotConfigured = fmt.Errorf("pushover not configured")
 type PushoverService struct {
 	logger      *Logger
 	settingsSvc *SettingsService
+	httpClient  *http.Client
+	apiURL      string
+}
+
+// PushoverMessage describes a single Pushover notification payload.
+type PushoverMessage struct {
+	UserKey string
+	Title   string
+	Message string
+	URL     string
+	HTML    bool
 }
 
 // NewPushoverService creates a new PushoverService.
@@ -23,31 +34,56 @@ func NewPushoverService(settingsSvc *SettingsService, logger *Logger) *PushoverS
 	return &PushoverService{
 		settingsSvc: settingsSvc,
 		logger:      logger,
+		httpClient:  http.DefaultClient,
+		apiURL:      pushoverAPIURL,
 	}
 }
 
 // SendNotification sends a push notification to the specified user via Pushover.
 // The app token is read from admin settings; userKey is per-user.
 func (s *PushoverService) SendNotification(userKey, title, message, refURL string) error {
+	return s.SendMessage(PushoverMessage{
+		UserKey: userKey,
+		Title:   title,
+		Message: message,
+		URL:     refURL,
+	})
+}
+
+// SendMessage sends a push notification to the specified user via Pushover.
+// The app token is read from admin settings; userKey is per-user.
+func (s *PushoverService) SendMessage(message PushoverMessage) error {
 	appToken := s.settingsSvc.GetSetting(SettingPushoverAppToken)
 	if appToken == "" {
 		s.logger.Warn("pushover", "Pushover app token not configured in admin settings")
 		return ErrPushoverNotConfigured
 	}
-	if userKey == "" {
+	if message.UserKey == "" {
 		return ErrPushoverNotConfigured
 	}
 
 	form := url.Values{}
 	form.Set("token", appToken)
-	form.Set("user", userKey)
-	form.Set("title", title)
-	form.Set("message", message)
-	if refURL != "" {
-		form.Set("url", refURL)
+	form.Set("user", message.UserKey)
+	form.Set("title", message.Title)
+	form.Set("message", message.Message)
+	if message.URL != "" {
+		form.Set("url", message.URL)
+	}
+	if message.HTML {
+		form.Set("html", "1")
 	}
 
-	resp, err := http.Post(pushoverAPIURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	client := s.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	apiURL := s.apiURL
+	if apiURL == "" {
+		apiURL = pushoverAPIURL
+	}
+
+	resp, err := client.Post(apiURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		return fmt.Errorf("pushover request failed: %w", err)
 	}
@@ -57,6 +93,6 @@ func (s *PushoverService) SendNotification(userKey, title, message, refURL strin
 		return fmt.Errorf("pushover returned status %d", resp.StatusCode)
 	}
 
-	s.logger.Debug("pushover", "Notification sent to user (title: %s)", title)
+	s.logger.Debug("pushover", "Notification sent to user (title: %s)", message.Title)
 	return nil
 }

--- a/src/api/services/pushover_service_test.go
+++ b/src/api/services/pushover_service_test.go
@@ -1,0 +1,113 @@
+package services
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func newTestPushoverService(t *testing.T, captured *url.Values) (*PushoverService, func()) {
+	t.Helper()
+
+	settingsSvc, _ := newTestSettingsService(t)
+	if err := settingsSvc.SetSetting(SettingPushoverAppToken, "app-token"); err != nil {
+		t.Fatalf("failed to set pushover token: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("failed to parse form: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		*captured = r.PostForm
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	svc := NewPushoverService(settingsSvc, NewLogger(10))
+	svc.httpClient = server.Client()
+	svc.apiURL = server.URL
+
+	return svc, server.Close
+}
+
+func TestPushoverServiceSendMessage_CoinOfDayUsesHTMLAndAbsoluteCoinLink(t *testing.T) {
+	var captured url.Values
+	svc, cleanup := newTestPushoverService(t, &captured)
+	defer cleanup()
+
+	message := buildCoinOfDayPushoverMessage("Coin of the Day", 42, "<Rare & Coin>", "Summary with <script>bad</script>", "https://coins.example.com/")
+	message.UserKey = "user-key"
+
+	if err := svc.SendMessage(message); err != nil {
+		t.Fatalf("SendMessage() error = %v", err)
+	}
+
+	if got := captured.Get("html"); got != "1" {
+		t.Fatalf("html form field = %q, want 1", got)
+	}
+	if got := captured.Get("url"); got != "https://coins.example.com/coin/42" {
+		t.Fatalf("url form field = %q, want absolute coin URL", got)
+	}
+
+	body := captured.Get("message")
+	if !strings.Contains(body, `<b>&lt;Rare &amp; Coin&gt;</b>`) {
+		t.Fatalf("message did not escape and bold coin name: %q", body)
+	}
+	if !strings.Contains(body, `<a href="https://coins.example.com/coin/42">Open coin</a>`) {
+		t.Fatalf("message did not include coin link: %q", body)
+	}
+	if strings.Contains(body, "<script>") {
+		t.Fatalf("message contains unescaped script tag: %q", body)
+	}
+}
+
+func TestPushoverServiceSendMessage_CoinOfDayOmitsBrokenRelativeCoinLinkWhenUnconfigured(t *testing.T) {
+	var captured url.Values
+	svc, cleanup := newTestPushoverService(t, &captured)
+	defer cleanup()
+
+	message := buildCoinOfDayPushoverMessage("Coin of the Day", 42, "Rare Coin", "Summary", "")
+	message.UserKey = "user-key"
+
+	if err := svc.SendMessage(message); err != nil {
+		t.Fatalf("SendMessage() error = %v", err)
+	}
+
+	if got := captured.Get("html"); got != "1" {
+		t.Fatalf("html form field = %q, want 1", got)
+	}
+	if _, ok := captured["url"]; ok {
+		t.Fatalf("url form field should be omitted when public app URL is unconfigured")
+	}
+
+	body := captured.Get("message")
+	if !strings.Contains(body, `<b>Rare Coin</b>`) {
+		t.Fatalf("message did not keep HTML formatting: %q", body)
+	}
+	if strings.Contains(body, `href="/coin/42"`) || strings.Contains(body, `/coin/42`) {
+		t.Fatalf("message contains broken relative coin link: %q", body)
+	}
+}
+
+func TestPushoverServiceSendNotification_RemainsPlain(t *testing.T) {
+	var captured url.Values
+	svc, cleanup := newTestPushoverService(t, &captured)
+	defer cleanup()
+
+	if err := svc.SendNotification("user-key", "Ancient Coins", "Pushover notifications are working!", ""); err != nil {
+		t.Fatalf("SendNotification() error = %v", err)
+	}
+
+	if got := captured.Get("html"); got != "" {
+		t.Fatalf("html form field = %q, want empty for plain notification", got)
+	}
+	if got := captured.Get("message"); got != "Pushover notifications are working!" {
+		t.Fatalf("message form field = %q, want plain text", got)
+	}
+	if _, ok := captured["url"]; ok {
+		t.Fatalf("url form field should be omitted when no reference URL is provided")
+	}
+}

--- a/src/api/services/settings_service.go
+++ b/src/api/services/settings_service.go
@@ -15,6 +15,7 @@ const (
 	SettingTextExtractionPrompt               = "TextExtractionPrompt"
 	SettingOllamaTimeout                      = "OllamaTimeout"
 	SettingLogLevel                           = "LogLevel"
+	SettingPublicAppURL                       = "PublicAppURL"
 	SettingNumistaAPIKey                      = "NumistaAPIKey"
 	SettingAnthropicAPIKey                    = "AnthropicAPIKey"
 	SettingAnthropicModel                     = "AnthropicModel"
@@ -75,6 +76,7 @@ var settingDefaults = map[string]string{
 	SettingTextExtractionPrompt:               DefaultTextExtractionPrompt,
 	SettingOllamaTimeout:                      "300",
 	SettingLogLevel:                           "info",
+	SettingPublicAppURL:                       "",
 	SettingNumistaAPIKey:                      "",
 	SettingAnthropicAPIKey:                    "",
 	SettingAnthropicModel:                     "claude-sonnet-4-20250514",

--- a/src/api/services/settings_service_test.go
+++ b/src/api/services/settings_service_test.go
@@ -229,3 +229,12 @@ func TestGetAllSettings_IncludesCoinCategoriesAndEras(t *testing.T) {
 		t.Errorf("GetAllSettings[CoinEras] = %q, want default %q", all[SettingCoinEras], expectedEras)
 	}
 }
+
+func TestGetAllSettings_IncludesPublicAppURLDefault(t *testing.T) {
+	svc, _ := newTestSettingsService(t)
+
+	all := svc.GetAllSettings()
+	if got, ok := all[SettingPublicAppURL]; !ok || got != "" {
+		t.Errorf("GetAllSettings[PublicAppURL] = %q (present %v), want blank default", got, ok)
+	}
+}

--- a/src/web/src/components/admin/AdminSystemSection.vue
+++ b/src/web/src/components/admin/AdminSystemSection.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="admin-section card">
     <h2>System Settings</h2>
-    <form @submit.prevent="$emit('save', { numistaApiKey: localNumistaApiKey, logLevel: localLogLevel, pushoverAppToken: localPushoverAppToken })">
+    <form @submit.prevent="$emit('save', { numistaApiKey: localNumistaApiKey, logLevel: localLogLevel, pushoverAppToken: localPushoverAppToken, publicAppUrl: localPublicAppUrl })">
       <div class="form-group">
         <label class="form-label">Numista API Key</label>
         <input v-model="localNumistaApiKey" class="form-input" type="password" placeholder="Enter your Numista API key" />
@@ -11,6 +11,11 @@
         <label class="form-label">Pushover API Token</label>
         <input v-model="localPushoverAppToken" class="form-input" type="password" placeholder="Enter your Pushover application API token" />
         <span class="form-hint">Create an app at <a href="https://pushover.net/apps" target="_blank" rel="noopener">pushover.net/apps</a> to get a token. Users provide their own User Key in Account Settings.</span>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Public App URL</label>
+        <input v-model="localPublicAppUrl" class="form-input" type="url" placeholder="https://coins.example.com" />
+        <span class="form-hint">Full browser URL for this app. Used to make Pushover Coin of the Day links open directly to a coin; leave blank to send the alert without an external link.</span>
       </div>
       <div class="form-group">
         <label class="form-label">Log Level</label>
@@ -37,6 +42,7 @@ import { ref, watch } from 'vue'
 const props = defineProps<{
   numistaApiKey: string
   pushoverAppToken: string
+  publicAppUrl: string
   logLevel: string
   logLevels: readonly string[]
   saving: boolean
@@ -47,15 +53,17 @@ const props = defineProps<{
 }>()
 
 defineEmits<{
-  save: [settings: { numistaApiKey: string; logLevel: string; pushoverAppToken: string }]
+  save: [settings: { numistaApiKey: string; logLevel: string; pushoverAppToken: string; publicAppUrl: string }]
 }>()
 
 const localNumistaApiKey = ref(props.numistaApiKey)
 const localPushoverAppToken = ref(props.pushoverAppToken)
+const localPublicAppUrl = ref(props.publicAppUrl)
 const localLogLevel = ref(props.logLevel)
 
 watch(() => props.numistaApiKey, (v) => { localNumistaApiKey.value = v })
 watch(() => props.pushoverAppToken, (v) => { localPushoverAppToken.value = v })
+watch(() => props.publicAppUrl, (v) => { localPublicAppUrl.value = v })
 watch(() => props.logLevel, (v) => { localLogLevel.value = v })
 </script>
 

--- a/src/web/src/composables/useAdminConfig.ts
+++ b/src/web/src/composables/useAdminConfig.ts
@@ -20,6 +20,7 @@ export function useAdminConfig() {
     OllamaTimeout: '300',
     SearXNGURL: '',
     LogLevel: 'info',
+    PublicAppURL: '',
     CoinCategories: '',
     CoinEras: '',
   })
@@ -33,6 +34,7 @@ export function useAdminConfig() {
     OllamaTimeout: '',
     SearXNGURL: '',
     LogLevel: '',
+    PublicAppURL: '',
     CoinCategories: '',
     CoinEras: '',
   })

--- a/src/web/src/pages/AdminPage.vue
+++ b/src/web/src/pages/AdminPage.vue
@@ -77,6 +77,7 @@
           v-if="activeTab === 'system'"
           :numista-api-key="settings.NumistaAPIKey ?? ''"
           :pushover-app-token="settings.PushoverAppToken ?? ''"
+          :public-app-url="settings.PublicAppURL ?? ''"
           :log-level="settings.LogLevel ?? ''"
           :log-levels="LOG_LEVELS"
           :saving="settingsSaving"
@@ -338,10 +339,11 @@ function exportLogs() {
   URL.revokeObjectURL(url)
 }
 
-function onSystemSave(payload: { numistaApiKey: string; logLevel: string; pushoverAppToken: string }) {
+function onSystemSave(payload: { numistaApiKey: string; logLevel: string; pushoverAppToken: string; publicAppUrl: string }) {
   settings.value.NumistaAPIKey = payload.numistaApiKey
   settings.value.LogLevel = payload.logLevel
   settings.value.PushoverAppToken = payload.pushoverAppToken
+  settings.value.PublicAppURL = payload.publicAppUrl
   saveSettings()
 }
 

--- a/src/web/src/types/index.ts
+++ b/src/web/src/types/index.ts
@@ -546,6 +546,7 @@ export interface AppSettings {
   OllamaTimeout: string
   SearXNGURL: string
   LogLevel: string
+  PublicAppURL?: string
   CoinCategories?: string
   CoinEras?: string
   [key: string]: string | undefined


### PR DESCRIPTION
Add HTML-formatted Coin of the Day Pushover messages with absolute coin links when PublicAppURL is configured. Preserve FeaturedCoin modal ReferenceID behavior and omit external links when no valid public app URL exists.

Constitution: Principle III, Principle IV, Principle IX, §17

## Summary
<!-- 1-3 sentences: what changes and why -->

## Constitution self-check
- Principle(s) touched: <!-- e.g., I (Clear Layered Architecture), IV (Simple Complete Changes) -->
- Operational section(s): <!-- e.g., §17 Quality Gate, §21 DoD -->
- ADR added? <!-- yes/no — required for material design choices, §22 -->
- Principle IV check: <!-- simple, complete, proportional; note workflow/sibling paths tested -->

## Linked work
- Issue: #
- Spec: `specs/NNN-*/spec.md`
- Tasks completed: <!-- specs/NNN-*/tasks.md line(s) -->

## Definition of Done (§21)
- [ ] 1. Code compiles (`go build ./...`, `npm run build`, `pip install -e ".[dev]"` as applicable)
- [ ] 2. Architecture tests green (`go test -run TestArchitecture ./...`)
- [ ] 3. Unit tests pass (`go test ./...`, `pytest tests/`)
- [ ] 4. Type checks pass (`vue-tsc --build`, Go compile)
- [ ] 5. Linters clean (`go vet`, `ruff check`)
- [ ] 6. New service methods have ≥1 unit test
- [ ] 7. Public handlers have Swagger annotations
- [ ] 8. If API changed: `task openapi` run and `docs/openapi.json` updated
- [ ] 9. If material design choice: ADR added in `docs/adr/` *(when Phase 3 lands)*
- [ ] 10. Active `specs/NNN-*/tasks.md` items checked off
- [ ] 11. `.squad/decisions/inbox/` written if cross-cutting decision made
- [ ] 12. Simple Complete Changes self-check complete (Principle IV)
- [ ] 13. Secrets scan clean (no credentials in diff)
- [ ] 14. Conventional commit messages
- [ ] 15. `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer present when AI-assisted

## Notes for reviewer
<!-- Anything reviewer should pay special attention to -->
