### PR TITLE
feat: route Find Coin saves to wishlist

### DIFF
--- a/src/api/services/coin_lookup_service.go
+++ b/src/api/services/coin_lookup_service.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// CoinLookupService handles coin lookup from images with NGC cert extraction and Numista enrichment.
+// CoinLookupService handles coin lookup from images with NGC cert extraction and coin draft enrichment.
 type CoinLookupService struct {
 	proxy       *AgentProxy
 	settingsSvc *SettingsService
@@ -95,7 +95,7 @@ var (
 	compactCertRegex  = regexp.MustCompile(`^\d{9,10}$`)
 )
 
-// Lookup performs coin lookup from images: extracts NGC cert, label text, and enriches with Numista.
+// Lookup performs coin lookup from images: extracts NGC certs first, then falls back to structured coin fields.
 func (s *CoinLookupService) Lookup(ctx context.Context, userID uint, req CoinLookupRequest) (*CoinLookupResponse, error) {
 	logger := s.logger
 	logger.Info("coin-lookup", "Starting lookup for user %d with %d images", userID, len(req.Images))
@@ -210,16 +210,24 @@ func (s *CoinLookupService) extractDataFromImages(ctx context.Context, images []
 func (s *CoinLookupService) buildVisionPrompt() string {
 	return `You are analyzing a coin or coin slab photo for lookup purposes. Extract:
 
-1. NGC Certification: If this is an NGC slab/holder, extract the NGC certification number (format: XXXXXXX-XXX, e.g., 823160-093 or 1234567-001). Also extract the grade (e.g., "Ch AU", "NGC AU", etc.) and any description text on the label.
+1. NGC Certification: If this is an NGC slab/holder or the image shows an NGC certification number, extract the NGC certification number (format: XXXXXXX-XXX, e.g., 823160-093 or 1234567-001). Also extract the grade (e.g., "Ch AU", "NGC AU", etc.) and any description text on the label.
 
 2. Visible Text: Extract ALL visible text from the image (inscriptions, labels, holder text, etc.). Be thorough.
 
-3. Coin Attribution: Infer the following if visible:
+3. Coin Attribution: If no NGC slab/cert is visible, analyze the raw coin image like the standard Add Coin image analysis and infer as many draft fields as possible:
+   - Name/title (short collector-friendly attribution)
    - Ruler (e.g., "Augustus", "Constantine I", "Philip II")
+   - Mint if visible or confidently inferable
    - Era (ancient, medieval, or modern)
    - Denomination (e.g., "Denarius", "Tetradrachm", "Solidus")
    - Material (Gold, Silver, Bronze, Copper, Electrum, Other)
    - Category (Roman, Greek, Byzantine, Modern, Other)
+   - Obverse inscription
+   - Reverse inscription
+   - Obverse description
+   - Reverse description
+   - Weight in grams and diameter in mm only if visible in text
+   - Rarity rating or grade only if visible
 
 Return your response in this EXACT JSON format (no markdown, no extra text):
 {
@@ -227,15 +235,25 @@ Return your response in this EXACT JSON format (no markdown, no extra text):
   "ngcGrade": "grade text or null",
   "ngcDescription": "description or null",
   "labelText": "all visible text here",
+  "name": "short coin attribution or null",
   "ruler": "ruler name or null",
+  "mint": "mint name or null",
   "era": "ancient/medieval/modern or null",
   "denomination": "denomination or null",
   "material": "material or null",
   "category": "category or null",
+  "obverseInscription": "obverse legend or null",
+  "reverseInscription": "reverse legend or null",
+  "obverseDescription": "obverse design or null",
+  "reverseDescription": "reverse design or null",
+  "weightGrams": number or null,
+  "diameterMm": number or null,
+  "rarityRating": "rarity text or null",
+  "grade": "grade text or null",
   "confidence": "high/medium/low"
 }
 
-Be precise. If uncertain, use null. Focus on extracting NGC cert numbers from slab holders.`
+Be precise. If uncertain, use null. Prefer NGC cert extraction when a slab/cert is present; otherwise return the best standard coin image draft you can infer.`
 }
 
 // extractNGCCert parses NGC certification data from analysis text.
@@ -330,24 +348,88 @@ func (s *CoinLookupService) extractCoinFields(analysis string) map[string]any {
 		return fields
 	}
 
-	// Extract known fields
-	if ruler, ok := parsed["ruler"].(string); ok && ruler != "" && ruler != "null" {
-		fields["ruler"] = ruler
-	}
-	if era, ok := parsed["era"].(string); ok && era != "" && era != "null" {
-		fields["era"] = era
-	}
-	if denom, ok := parsed["denomination"].(string); ok && denom != "" && denom != "null" {
-		fields["denomination"] = denom
-	}
-	if material, ok := parsed["material"].(string); ok && material != "" && material != "null" {
-		fields["material"] = material
-	}
-	if category, ok := parsed["category"].(string); ok && category != "" && category != "null" {
-		fields["category"] = category
+	copyCoinFieldsFromMap(parsed, fields)
+	if nested, ok := parsed["coin"].(map[string]any); ok {
+		copyCoinFieldsFromMap(nested, fields)
 	}
 
 	return fields
+}
+
+func copyCoinFieldsFromMap(source map[string]any, target map[string]any) {
+	stringFields := map[string][]string{
+		"name":               {"name"},
+		"ruler":              {"ruler"},
+		"mint":               {"mint"},
+		"era":                {"era"},
+		"denomination":       {"denomination"},
+		"material":           {"material"},
+		"category":           {"category"},
+		"obverseInscription": {"obverseInscription", "obverse_inscription"},
+		"reverseInscription": {"reverseInscription", "reverse_inscription"},
+		"obverseDescription": {"obverseDescription", "obverse_description"},
+		"reverseDescription": {"reverseDescription", "reverse_description"},
+		"rarityRating":       {"rarityRating", "rarity_rating"},
+		"grade":              {"grade"},
+		"notes":              {"notes"},
+		"referenceText":      {"referenceText", "reference_text"},
+		"referenceUrl":       {"referenceUrl", "reference_url"},
+	}
+	for targetKey, sourceKeys := range stringFields {
+		for _, sourceKey := range sourceKeys {
+			if copyStringFieldAs(source, target, sourceKey, targetKey) {
+				break
+			}
+		}
+	}
+
+	numberFields := map[string][]string{
+		"weightGrams": {"weightGrams", "weight_grams"},
+		"diameterMm":  {"diameterMm", "diameter_mm"},
+	}
+	for targetKey, sourceKeys := range numberFields {
+		for _, sourceKey := range sourceKeys {
+			if copyNumberFieldAs(source, target, sourceKey, targetKey) {
+				break
+			}
+		}
+	}
+}
+
+func copyStringFieldAs(source map[string]any, target map[string]any, sourceKey string, targetKey string) bool {
+	if _, exists := target[targetKey]; exists {
+		return true
+	}
+	value, ok := source[sourceKey].(string)
+	if !ok {
+		return false
+	}
+	value = strings.TrimSpace(value)
+	if value == "" || strings.EqualFold(value, "null") {
+		return false
+	}
+	target[targetKey] = value
+	return true
+}
+
+func copyNumberFieldAs(source map[string]any, target map[string]any, sourceKey string, targetKey string) bool {
+	if _, exists := target[targetKey]; exists {
+		return true
+	}
+	switch value := source[sourceKey].(type) {
+	case float64:
+		if value > 0 {
+			target[targetKey] = value
+			return true
+		}
+	case string:
+		value = strings.TrimSpace(value)
+		if value != "" && !strings.EqualFold(value, "null") {
+			target[targetKey] = value
+			return true
+		}
+	}
+	return false
 }
 
 // determineConfidence assesses overall extraction confidence.
@@ -494,6 +576,16 @@ func (s *CoinLookupService) buildPrefilledDraft(data *LookupExtractedData, candi
 		draft["numista_url"] = top.URL
 	}
 
+	if _, ok := draft["name"]; !ok {
+		draft["name"] = fallbackDraftName(data.CoinFields)
+	}
+
+	if data.RawAnalysis != "" {
+		if _, ok := draft["aiAnalysis"]; !ok {
+			draft["aiAnalysis"] = data.RawAnalysis
+		}
+	}
+
 	// Include NGC data in notes if present
 	if data.NGC != nil {
 		notes := fmt.Sprintf("NGC Cert: %s\n", data.NGC.NormalizedCert)
@@ -508,6 +600,23 @@ func (s *CoinLookupService) buildPrefilledDraft(data *LookupExtractedData, candi
 	}
 
 	return draft
+}
+
+func fallbackDraftName(fields map[string]any) string {
+	if fields == nil {
+		return "Unidentified Coin"
+	}
+	parts := []string{}
+	if ruler, ok := fields["ruler"].(string); ok && strings.TrimSpace(ruler) != "" {
+		parts = append(parts, strings.TrimSpace(ruler))
+	}
+	if denomination, ok := fields["denomination"].(string); ok && strings.TrimSpace(denomination) != "" {
+		parts = append(parts, strings.TrimSpace(denomination))
+	}
+	if len(parts) == 0 {
+		return "Unidentified Coin"
+	}
+	return strings.Join(parts, " ")
 }
 
 // buildCandidateReferences creates CoinReference-compatible data for Add to Wishlist.

--- a/src/api/services/coin_lookup_service_test.go
+++ b/src/api/services/coin_lookup_service_test.go
@@ -200,20 +200,38 @@ func TestExtractCoinFields(t *testing.T) {
 		{
 			name: "all fields present",
 			input: `{
+				"name": "Trajan Denarius",
 				"ruler": "Trajan",
+				"mint": "Rome",
 				"era": "ancient",
 				"denomination": "Denarius",
 				"material": "Silver",
-				"category": "Roman"
+				"category": "Roman",
+				"obverseInscription": "IMP TRAIANO AVG",
+				"reverseInscription": "SPQR OPTIMO PRINCIPI",
+				"obverseDescription": "Laureate bust right",
+				"reverseDescription": "Victory standing left",
+				"weightGrams": 3.2,
+				"diameterMm": 19,
+				"rarityRating": "Common",
+				"grade": "VF"
 			}`,
 			wantFields: map[string]string{
-				"ruler":        "Trajan",
-				"era":          "ancient",
-				"denomination": "Denarius",
-				"material":     "Silver",
-				"category":     "Roman",
+				"name":               "Trajan Denarius",
+				"ruler":              "Trajan",
+				"mint":               "Rome",
+				"era":                "ancient",
+				"denomination":       "Denarius",
+				"material":           "Silver",
+				"category":           "Roman",
+				"obverseInscription": "IMP TRAIANO AVG",
+				"reverseInscription": "SPQR OPTIMO PRINCIPI",
+				"obverseDescription": "Laureate bust right",
+				"reverseDescription": "Victory standing left",
+				"rarityRating":       "Common",
+				"grade":              "VF",
 			},
-			wantFieldsLen: 5,
+			wantFieldsLen: 15,
 		},
 		{
 			name: "some fields with null",
@@ -230,6 +248,33 @@ func TestExtractCoinFields(t *testing.T) {
 				"material": "Silver",
 			},
 			wantFieldsLen: 3,
+		},
+		{
+			name: "nested intake-style coin fields",
+			input: `{
+				"ngcCert": null,
+				"coin": {
+					"name": "Hadrian Sestertius",
+					"ruler": "Hadrian",
+					"era": "ancient",
+					"denomination": "Sestertius",
+					"material": "Bronze",
+					"category": "Roman",
+					"obverse_description": "Laureate head right",
+					"reverse_description": "Salus standing left"
+				}
+			}`,
+			wantFields: map[string]string{
+				"name":               "Hadrian Sestertius",
+				"ruler":              "Hadrian",
+				"era":                "ancient",
+				"denomination":       "Sestertius",
+				"material":           "Bronze",
+				"category":           "Roman",
+				"obverseDescription": "Laureate head right",
+				"reverseDescription": "Salus standing left",
+			},
+			wantFieldsLen: 8,
 		},
 		{
 			name:          "invalid JSON",
@@ -372,6 +417,56 @@ func TestBuildNumistaQuery(t *testing.T) {
 	}
 }
 
+func TestBuildPrefilledDraftFallsBackToStandardCoinAnalysisFields(t *testing.T) {
+	svc := &CoinLookupService{}
+	data := &LookupExtractedData{
+		RawAnalysis: "Standard image analysis narrative",
+		CoinFields: map[string]any{
+			"ruler":              "Hadrian",
+			"denomination":       "Sestertius",
+			"material":           "Bronze",
+			"category":           "Roman",
+			"obverseDescription": "Laureate head right",
+			"reverseDescription": "Salus standing left",
+		},
+	}
+
+	draft := svc.buildPrefilledDraft(data, nil)
+
+	if draft["name"] != "Hadrian Sestertius" {
+		t.Fatalf("draft name = %q, want fallback Hadrian Sestertius", draft["name"])
+	}
+	if draft["material"] != "Bronze" {
+		t.Errorf("draft material = %q, want Bronze", draft["material"])
+	}
+	if draft["obverseDescription"] != "Laureate head right" {
+		t.Errorf("draft obverseDescription = %q, want Laureate head right", draft["obverseDescription"])
+	}
+	if draft["aiAnalysis"] != "Standard image analysis narrative" {
+		t.Errorf("draft aiAnalysis = %q, want standard image analysis narrative", draft["aiAnalysis"])
+	}
+	if _, ok := draft["notes"]; ok {
+		t.Errorf("draft notes should not include NGC notes for a raw coin analysis: %q", draft["notes"])
+	}
+}
+
+func TestBuildPrefilledDraftKeepsExplicitNameFromAnalysis(t *testing.T) {
+	svc := &CoinLookupService{}
+	data := &LookupExtractedData{
+		CoinFields: map[string]any{
+			"name":         "Augustus Denarius",
+			"ruler":        "Augustus",
+			"denomination": "Denarius",
+		},
+	}
+
+	draft := svc.buildPrefilledDraft(data, nil)
+
+	if draft["name"] != "Augustus Denarius" {
+		t.Fatalf("draft name = %q, want explicit analysis name", draft["name"])
+	}
+}
+
 func TestBuildCandidateReferences(t *testing.T) {
 	svc := &CoinLookupService{}
 
@@ -409,5 +504,69 @@ func TestBuildCandidateReferences(t *testing.T) {
 	}
 	if refs[1].Number != "12345" {
 		t.Errorf("refs[1].Number = %q, want 12345", refs[1].Number)
+	}
+}
+
+func TestSlabCertDetectionReturnsCertData(t *testing.T) {
+	svc := &CoinLookupService{}
+	data := &LookupExtractedData{
+		NGC: svc.extractNGCCert(`{"ngcCert":"2412821034","ngcGrade":"Ch VF","ngcDescription":"Roman Empire"}`),
+	}
+
+	if data.NGC == nil {
+		t.Fatal("expected NGC cert data")
+	}
+	if data.NGC.NormalizedCert != "2412821-034" {
+		t.Fatalf("normalized cert = %q, want 2412821-034", data.NGC.NormalizedCert)
+	}
+
+	refs := svc.buildCandidateReferences(data, nil)
+	if len(refs) != 1 {
+		t.Fatalf("refs len = %d, want 1", len(refs))
+	}
+	if refs[0].Catalog != "NGC" || refs[0].Number != "2412821-034" {
+		t.Fatalf("ref = %+v, want NGC 2412821-034", refs[0])
+	}
+}
+
+func TestBuildPrefilledDraft_NonSlabAnalysisUsesExtractedFieldsAndTopCandidate(t *testing.T) {
+	svc := &CoinLookupService{}
+
+	data := &LookupExtractedData{
+		CoinFields: map[string]any{
+			"ruler":        "Trajan",
+			"era":          "ancient",
+			"denomination": "Denarius",
+			"material":     "Silver",
+			"category":     "Roman",
+		},
+	}
+	candidates := []NumistaCandidate{
+		{
+			ID:    "12345",
+			Title: "Denarius - Trajan (98-117)",
+			URL:   "https://en.numista.com/catalogue/pieces12345.html",
+		},
+	}
+
+	draft := svc.buildPrefilledDraft(data, candidates)
+
+	expected := map[string]any{
+		"name":         "Denarius - Trajan (98-117)",
+		"ruler":        "Trajan",
+		"era":          "ancient",
+		"denomination": "Denarius",
+		"material":     "Silver",
+		"category":     "Roman",
+		"numista_id":   "12345",
+		"numista_url":  "https://en.numista.com/catalogue/pieces12345.html",
+	}
+	for key, want := range expected {
+		if got := draft[key]; got != want {
+			t.Errorf("draft[%q] = %v, want %v", key, got, want)
+		}
+	}
+	if _, ok := draft["notes"]; ok {
+		t.Errorf("draft[notes] was set for non-slab lookup, want absent")
 	}
 }

--- a/src/api/services/numisbids_service.go
+++ b/src/api/services/numisbids_service.go
@@ -15,20 +15,21 @@ import (
 )
 
 const (
-	numisbidsBase    = "https://www.numisbids.com"
-	numisbidsLoginURL = numisbidsBase + "/registration/login.php"
+	numisbidsBase         = "https://www.numisbids.com"
+	numisbidsLoginURL     = numisbidsBase + "/registration/login.php"
 	numisbidsWatchlistURL = numisbidsBase + "/watchlist"
-	numisbidsUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+	numisbidsUserAgent    = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
 		"AppleWebKit/537.36 (KHTML, like Gecko) " +
 		"Chrome/131.0.0.0 Safari/537.36"
 )
 
 var (
-	lotLinkRe    = regexp.MustCompile(`href="(/sale/(\d+)/lot/(\d+))"`)
-	imgSrcRe     = regexp.MustCompile(`<img[^>]*src="([^"]*)"`)
-	ogImageRe    = regexp.MustCompile(`<meta\s+property="og:image"\s+content="([^"]+)"`)
-	estimateRe   = regexp.MustCompile(`Estimate:\s*([\d,]+(?:\.\d+)?\s*\w+)`)
-	currencyValRe = regexp.MustCompile(`([\d,]+(?:\.\d+)?)\s*(USD|EUR|GBP|CHF)`)
+	lotLinkRe     = regexp.MustCompile(`^/sale/(\d+)/lot/(\d+)`)
+	lotHrefRe     = regexp.MustCompile(`(?i)href\s*=\s*["']([^"']+)["']`)
+	imgSrcRe      = regexp.MustCompile(`<img[^>]*src="([^"]*)"`)
+	ogImageRe     = regexp.MustCompile(`<meta\s+property="og:image"\s+content="([^"]+)"`)
+	estimateRe    = regexp.MustCompile(`Estimate:\s*([\d,]+(?:\.\d+)?\s*\w+)`)
+	currencyValRe = regexp.MustCompile(`([\d,]+(?:\.\d+)?)\s*(USD|EUR|GBP|CHF|AUD|CAD)`)
 )
 
 // WatchlistLot represents a single lot parsed from a NumisBids watchlist page.
@@ -246,27 +247,21 @@ func (s *NumisBidsService) ScrapeLotPage(lotURL string) (*LotPageDetails, error)
 func (s *NumisBidsService) ParseWatchlist(rawHTML string) []WatchlistLot {
 	// Find all lot link positions, then extract the block between each pair.
 	// Go's regexp engine (RE2) doesn't support lookaheads, so we split manually.
-	indices := lotLinkRe.FindAllStringIndex(rawHTML, -1)
+	matches := findWatchlistLotLinks(rawHTML)
 
 	var lots []WatchlistLot
-	for i, idx := range indices {
-		start := idx[0]
+	for i, match := range matches {
+		start := match.start
 		end := len(rawHTML)
-		if i+1 < len(indices) {
-			end = indices[i+1][0]
+		if i+1 < len(matches) {
+			end = matches[i+1].start
 		}
 		block := rawHTML[start:end]
 
-		linkMatch := lotLinkRe.FindStringSubmatch(block)
-		if linkMatch == nil {
-			continue
-		}
-
-		lotNum, _ := strconv.Atoi(linkMatch[3])
 		lot := WatchlistLot{
-			URL:       numisbidsBase + linkMatch[1],
-			SaleID:    linkMatch[2],
-			LotNumber: lotNum,
+			URL:       match.url,
+			SaleID:    match.saleID,
+			LotNumber: match.lotNumber,
 			Currency:  "USD",
 		}
 
@@ -280,7 +275,7 @@ func (s *NumisBidsService) ParseWatchlist(rawHTML string) []WatchlistLot {
 		}
 
 		// Title: extract only the text inside the lot anchor tag
-		lot.Title = extractLotTitle(block, linkMatch[1])
+		lot.Title = extractLotTitle(block, match.href)
 		if len(lot.Title) > 200 {
 			lot.Title = lot.Title[:200]
 		}
@@ -298,6 +293,90 @@ func (s *NumisBidsService) ParseWatchlist(rawHTML string) []WatchlistLot {
 	}
 
 	return lots
+}
+
+type watchlistLotLink struct {
+	start     int
+	href      string
+	url       string
+	saleID    string
+	lotNumber int
+}
+
+func findWatchlistLotLinks(rawHTML string) []watchlistLotLink {
+	hrefMatches := lotHrefRe.FindAllStringSubmatchIndex(rawHTML, -1)
+	links := make([]watchlistLotLink, 0, len(hrefMatches))
+	for _, hrefMatch := range hrefMatches {
+		if len(hrefMatch) < 4 {
+			continue
+		}
+		href := rawHTML[hrefMatch[2]:hrefMatch[3]]
+		urlValue, saleID, lotNumber, ok := parseNumisBidsLotHref(href)
+		if !ok {
+			continue
+		}
+		start := hrefMatch[0]
+		if anchorStart := strings.LastIndex(strings.ToLower(rawHTML[:hrefMatch[0]]), "<a"); anchorStart >= 0 {
+			start = anchorStart
+		}
+		links = append(links, watchlistLotLink{
+			start:     start,
+			href:      href,
+			url:       urlValue,
+			saleID:    saleID,
+			lotNumber: lotNumber,
+		})
+	}
+	return links
+}
+
+func parseNumisBidsLotHref(href string) (string, string, int, bool) {
+	href = strings.TrimSpace(href)
+	if href == "" {
+		return "", "", 0, false
+	}
+
+	parsed, err := url.Parse(href)
+	if err != nil {
+		return "", "", 0, false
+	}
+	if parsed.IsAbs() && !strings.EqualFold(parsed.Host, "www.numisbids.com") && !strings.EqualFold(parsed.Host, "numisbids.com") {
+		return "", "", 0, false
+	}
+
+	path := parsed.Path
+	if path == "" && !parsed.IsAbs() {
+		path = href
+	}
+	if saleMatch := lotLinkRe.FindStringSubmatch(path); saleMatch != nil {
+		lotNumber, err := strconv.Atoi(saleMatch[2])
+		if err != nil {
+			return "", "", 0, false
+		}
+		return numisbidsBase + saleMatch[0], saleMatch[1], lotNumber, true
+	}
+
+	if strings.EqualFold(path, "/n.php") || strings.EqualFold(path, "n.php") {
+		query := parsed.Query()
+		if query.Get("p") != "lot" {
+			return "", "", 0, false
+		}
+		saleID := query.Get("sid")
+		lotRaw := query.Get("lot")
+		lotNumber, err := strconv.Atoi(lotRaw)
+		if saleID == "" || err != nil {
+			return "", "", 0, false
+		}
+		if parsed.IsAbs() {
+			return parsed.String(), saleID, lotNumber, true
+		}
+		if strings.HasPrefix(parsed.String(), "/") {
+			return numisbidsBase + parsed.String(), saleID, lotNumber, true
+		}
+		return numisbidsBase + "/" + parsed.String(), saleID, lotNumber, true
+	}
+
+	return "", "", 0, false
 }
 
 // parseCurrencyValue extracts a numeric value and currency code from a string

--- a/src/api/services/numisbids_service_test.go
+++ b/src/api/services/numisbids_service_test.go
@@ -1,0 +1,78 @@
+package services
+
+import "testing"
+
+func TestParseWatchlistAcceptsCurrentAbsoluteLotLinks(t *testing.T) {
+	html := `
+		<section>
+			<h2>Watched Lots in Current Auctions</h2>
+			<div class="lot">
+				<a href="https://www.numisbids.com/sale/10749/lot/10003">
+					GREEK EASTERN EUROPE, Imitations of Alexander III of Macedon.
+					1st century BC. Silver Drachm (3.55g).
+				</a>
+				<img src="//images.numisbids.com/sales/hosted/status/10749/image10003.jpg">
+				<span>Estimate: 100 AUD</span>
+			</div>
+		</section>`
+
+	lots := NewNumisBidsService().ParseWatchlist(html)
+	if len(lots) != 1 {
+		t.Fatalf("ParseWatchlist returned %d lots, want 1", len(lots))
+	}
+
+	lot := lots[0]
+	if lot.URL != "https://www.numisbids.com/sale/10749/lot/10003" {
+		t.Fatalf("URL = %q, want canonical NumisBids lot URL", lot.URL)
+	}
+	if lot.SaleID != "10749" {
+		t.Fatalf("SaleID = %q, want 10749", lot.SaleID)
+	}
+	if lot.LotNumber != 10003 {
+		t.Fatalf("LotNumber = %d, want 10003", lot.LotNumber)
+	}
+	if lot.Title == "" {
+		t.Fatal("Title is empty")
+	}
+	if lot.ImageURL != "https://images.numisbids.com/sales/hosted/status/10749/image10003.jpg" {
+		t.Fatalf("ImageURL = %q, want protocol-normalized image URL", lot.ImageURL)
+	}
+	if lot.Estimate == nil || *lot.Estimate != 100 {
+		t.Fatalf("Estimate = %v, want 100", lot.Estimate)
+	}
+	if lot.Currency != "AUD" {
+		t.Fatalf("Currency = %q, want AUD", lot.Currency)
+	}
+}
+
+func TestParseWatchlistAcceptsLegacyLotLinks(t *testing.T) {
+	html := `
+		<a href='/n.php?p=lot&sid=7996&lot=10003'>Status International Auction 406, Lot 10003</a>
+		<span>Estimate: 150 USD</span>`
+
+	lots := NewNumisBidsService().ParseWatchlist(html)
+	if len(lots) != 1 {
+		t.Fatalf("ParseWatchlist returned %d lots, want 1", len(lots))
+	}
+	if lots[0].URL != "https://www.numisbids.com/n.php?p=lot&sid=7996&lot=10003" {
+		t.Fatalf("URL = %q, want preserved legacy NumisBids lot URL", lots[0].URL)
+	}
+	if lots[0].SaleID != "7996" {
+		t.Fatalf("SaleID = %q, want 7996", lots[0].SaleID)
+	}
+	if lots[0].LotNumber != 10003 {
+		t.Fatalf("LotNumber = %d, want 10003", lots[0].LotNumber)
+	}
+	if lots[0].Title != "Status International Auction 406, Lot 10003" {
+		t.Fatalf("Title = %q, want legacy link title", lots[0].Title)
+	}
+}
+
+func TestParseWatchlistIgnoresNonNumisBidsAbsoluteLinks(t *testing.T) {
+	html := `<a href="https://example.com/sale/10749/lot/10003">External Lot</a>`
+
+	lots := NewNumisBidsService().ParseWatchlist(html)
+	if len(lots) != 0 {
+		t.Fatalf("ParseWatchlist returned %d lots, want 0", len(lots))
+	}
+}

--- a/src/web/src/App.vue
+++ b/src/web/src/App.vue
@@ -165,7 +165,7 @@ const { bulkSelectActive } = useBulkSelect()
 const defaultNavItems: NavItem[] = [
   { id: 'collection', label: 'Collection', icon: markRaw(Landmark), to: '/', visible: true },
   { id: 'add-coin', label: 'Add Coin', icon: markRaw(CirclePlus), to: '/add', visible: isPwa },
-  { id: 'lookup', label: 'Lookup Coin', icon: markRaw(Search), to: '/lookup', visible: true },
+  { id: 'lookup', label: 'Find Coin', icon: markRaw(Search), to: '/lookup', visible: true },
   { id: 'wishlist', label: 'Wishlist', icon: markRaw(Bookmark), to: '/wishlist', visible: true },
   { id: 'sold', label: 'Sold', icon: markRaw(BadgeDollarSign), to: '/sold', visible: true },
   { id: 'auctions', label: 'Auctions', icon: markRaw(Gavel), to: '/auctions', visible: true },

--- a/src/web/src/pages/CoinLookupPage.vue
+++ b/src/web/src/pages/CoinLookupPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <div class="page-header">
-      <h1>Lookup Coin</h1>
+      <h1>Find Coin</h1>
       <button class="btn btn-secondary" @click="handleBack">
         <ArrowLeft :size="16" />
         Back
@@ -11,7 +11,7 @@
     <!-- Capture State -->
     <div v-if="state === 'capture'" class="lookup-capture">
       <p class="lookup-instructions card">
-        Take a photo of the coin or certification slab to identify it. The app will extract details and search for matches.
+        Take a photo of the coin or certification slab to identify it. Save only when you want to add the result to your wishlist.
       </p>
 
       <!-- Image preview grid -->
@@ -185,13 +185,14 @@
             <RotateCcw :size="16" />
             Retake Photo
           </button>
-          <button class="btn btn-secondary" @click="handleAddToWishlist">
-            <Bookmark :size="16" />
-            Add to Wishlist
+          <button class="btn btn-secondary" @click="handleCancel">
+            <X :size="16" />
+            Cancel
           </button>
-          <button class="btn btn-primary" @click="handleAddToCollection">
-            <Plus :size="16" />
-            Add to Collection
+          <button class="btn btn-primary" :disabled="saving" @click="handleSaveToWishlist">
+            <span v-if="saving" class="spinner-sm"></span>
+            <Bookmark v-else :size="16" />
+            {{ saving ? 'Saving...' : 'Save to Wishlist' }}
           </button>
         </div>
       </div>
@@ -208,7 +209,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { lookupCoin, createCoin, createCoinReference, uploadImage } from '@/api/client'
 import type { CoinLookupResponse, CoinMutationPayload } from '@/types'
@@ -223,7 +224,6 @@ import {
   ExternalLink,
   RotateCcw,
   Bookmark,
-  Plus,
 } from 'lucide-vue-next'
 import CameraCaptureModal from '@/components/CameraCaptureModal.vue'
 
@@ -241,6 +241,7 @@ const capturedImages = ref<CapturedImage[]>([])
 const showCamera = ref(false)
 const fileInput = ref<HTMLInputElement | null>(null)
 const submitting = ref(false)
+const saving = ref(false)
 const error = ref('')
 const results = ref<CoinLookupResponse | null>(null)
 
@@ -344,7 +345,11 @@ function handleRetake() {
   state.value = 'capture'
 }
 
-async function createCoinFromLookup(isWishlist: boolean) {
+function handleCancel() {
+  router.back()
+}
+
+async function createWishlistCoinFromLookup() {
   if (!results.value) return
 
   const payload: CoinMutationPayload = {
@@ -353,7 +358,7 @@ async function createCoinFromLookup(isWishlist: boolean) {
     category: draft.value.category || 'Other',
     material: draft.value.material || 'Other',
     era: normalizedEra(draft.value.era),
-    isWishlist,
+    isWishlist: true,
   }
   const created = await createCoin(payload)
   const coinId = created.data.id
@@ -370,25 +375,25 @@ async function createCoinFromLookup(isWishlist: boolean) {
   }
 }
 
-async function handleAddToWishlist() {
+async function handleSaveToWishlist() {
+  if (saving.value) return
+  saving.value = true
   try {
-    await createCoinFromLookup(true)
+    await createWishlistCoinFromLookup()
     router.push('/wishlist')
   } catch (err: unknown) {
-    console.error('Failed to add to wishlist:', err)
-    error.value = err instanceof Error ? err.message : 'Failed to add to wishlist'
+    console.error('Failed to save to wishlist:', err)
+    error.value = err instanceof Error ? err.message : 'Failed to save to wishlist'
+  } finally {
+    saving.value = false
   }
 }
 
-async function handleAddToCollection() {
-  try {
-    await createCoinFromLookup(false)
-    router.push('/')
-  } catch (err: unknown) {
-    console.error('Failed to add to collection:', err)
-    error.value = err instanceof Error ? err.message : 'Failed to add to collection'
+onBeforeUnmount(() => {
+  for (const img of capturedImages.value) {
+    URL.revokeObjectURL(img.preview)
   }
-}
+})
 </script>
 
 <style scoped>

--- a/src/web/src/pages/WishlistPage.vue
+++ b/src/web/src/pages/WishlistPage.vue
@@ -8,10 +8,7 @@
           <span v-if="checking" class="spinner-sm"></span>
           <ShieldCheck v-else :size="22" />
         </button>
-        <router-link to="/lookup" class="pwa-icon-btn" title="Lookup Coin">
-          <Search :size="22" />
-        </router-link>
-        <router-link to="/add?wishlist=true" class="pwa-icon-btn" title="Add Coin">
+        <router-link to="/lookup" class="pwa-icon-btn" title="Find Coin">
           <CirclePlus :size="22" />
         </router-link>
       </div>
@@ -26,8 +23,7 @@
           <ShieldCheck v-else :size="16" />
           {{ checking ? 'Checking...' : 'Check Availability' }}
         </button>
-        <router-link to="/lookup" class="btn btn-secondary"><Search :size="16" /> Lookup Coin</router-link>
-        <router-link to="/add?wishlist=true" class="btn btn-secondary"><CirclePlus :size="16" /> Add Coin</router-link>
+        <router-link to="/lookup" class="btn btn-secondary"><CirclePlus :size="16" /> Find Coin</router-link>
       </div>
     </div>
 
@@ -87,7 +83,7 @@ import CoinSearchChat from '@/components/CoinSearchChat.vue'
 import PurchaseModal from '@/components/PurchaseModal.vue'
 import { purchaseCoin, checkWishlistAvailability, updateListingStatus } from '@/api/client'
 import type { Coin, AvailabilityRunSummary } from '@/types'
-import { CirclePlus, Bot, ShieldCheck, Search } from 'lucide-vue-next'
+import { CirclePlus, Bot, ShieldCheck } from 'lucide-vue-next'
 import { usePwa } from '@/composables/usePwa'
 
 const store = useCoinsStore()

--- a/src/web/src/pages/__tests__/CoinLookupPage.test.ts
+++ b/src/web/src/pages/__tests__/CoinLookupPage.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import CoinLookupPage from '../CoinLookupPage.vue'
+import { createCoin, createCoinReference, lookupCoin, uploadImage } from '@/api/client'
+
+const routerPush = vi.fn()
+const routerBack = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: routerPush,
+    back: routerBack,
+  }),
+}))
+
+vi.mock('@/api/client', () => ({
+  lookupCoin: vi.fn(),
+  createCoin: vi.fn(),
+  createCoinReference: vi.fn(),
+  uploadImage: vi.fn(),
+}))
+
+describe('CoinLookupPage', () => {
+  beforeEach(() => {
+    vi.mocked(lookupCoin).mockReset()
+    vi.mocked(createCoin).mockReset()
+    vi.mocked(createCoinReference).mockReset()
+    vi.mocked(uploadImage).mockReset()
+    routerPush.mockReset()
+    routerBack.mockReset()
+
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:lookup-image'),
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  it('saves lookup results only as wishlist coins', async () => {
+    const file = new File(['obverse'], 'obverse.jpg', { type: 'image/jpeg' })
+    vi.mocked(lookupCoin).mockResolvedValue({
+      data: {
+        extractedData: {
+          confidence: 'medium',
+          rawAnalysis: '{"ruler":"Trajan"}',
+          coinFields: {
+            ruler: 'Trajan',
+            denomination: 'Denarius',
+            era: 'ancient',
+            material: 'Silver',
+            category: 'Roman',
+          },
+        },
+        numistaCandidates: [],
+        prefilledDraft: {
+          name: 'Trajan Denarius',
+          ruler: 'Trajan',
+          denomination: 'Denarius',
+          era: 'ancient',
+          material: 'Silver',
+          category: 'Roman',
+        },
+        candidateReferences: [
+          {
+            catalog: 'Numista',
+            number: '12345',
+            uri: 'https://en.numista.com/catalogue/pieces12345.html',
+          },
+        ],
+      },
+    } as Awaited<ReturnType<typeof lookupCoin>>)
+    vi.mocked(createCoin).mockResolvedValue({ data: { id: 42 } } as Awaited<ReturnType<typeof createCoin>>)
+    vi.mocked(uploadImage).mockResolvedValue({ data: {} } as Awaited<ReturnType<typeof uploadImage>>)
+    vi.mocked(createCoinReference).mockResolvedValue({ data: {} } as Awaited<ReturnType<typeof createCoinReference>>)
+
+    const wrapper = mount(CoinLookupPage, {
+      global: {
+        stubs: {
+          CameraCaptureModal: true,
+          Camera: true,
+          Upload: true,
+          Search: true,
+          ArrowLeft: true,
+          X: true,
+          AlertCircle: true,
+          ShieldCheck: true,
+          ExternalLink: true,
+          RotateCcw: true,
+          Bookmark: true,
+        },
+      },
+    })
+
+    const input = wrapper.find('input[type="file"]')
+    Object.defineProperty(input.element, 'files', {
+      value: [file],
+      configurable: true,
+    })
+    await input.trigger('change')
+
+    await wrapper.find('.btn-submit').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Add to Collection')
+    expect(wrapper.text()).toContain('Save to Wishlist')
+
+    const actionButtons = wrapper.findAll('.result-actions button')
+    expect(actionButtons).toHaveLength(3)
+    await actionButtons[2]!.trigger('click')
+    await flushPromises()
+
+    expect(createCoin).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Trajan Denarius',
+      category: 'Roman',
+      material: 'Silver',
+      era: 'ancient',
+      isWishlist: true,
+    }))
+    expect(uploadImage).toHaveBeenCalledWith(42, file, 'obverse', true, false)
+    expect(createCoinReference).toHaveBeenCalledWith(42, {
+      catalog: 'Numista',
+      number: '12345',
+      uri: 'https://en.numista.com/catalogue/pieces12345.html',
+    })
+    expect(routerPush).toHaveBeenCalledWith('/wishlist')
+  })
+
+  it('lets the user cancel results without saving', async () => {
+    vi.mocked(lookupCoin).mockResolvedValue({
+      data: {
+        extractedData: {
+          confidence: 'medium',
+          rawAnalysis: 'uncertain',
+        },
+        numistaCandidates: [],
+        prefilledDraft: {
+          name: 'Possible drachm',
+        },
+      },
+    } as Awaited<ReturnType<typeof lookupCoin>>)
+
+    const wrapper = mount(CoinLookupPage, {
+      global: {
+        stubs: {
+          CameraCaptureModal: true,
+          Camera: true,
+          Upload: true,
+          Search: true,
+          ArrowLeft: true,
+          X: true,
+          AlertCircle: true,
+          ShieldCheck: true,
+          ExternalLink: true,
+          RotateCcw: true,
+          Bookmark: true,
+        },
+      },
+    })
+
+    const input = wrapper.find('input[type="file"]')
+    Object.defineProperty(input.element, 'files', {
+      value: [new File(['coin'], 'coin.jpg', { type: 'image/jpeg' })],
+      configurable: true,
+    })
+    await input.trigger('change')
+
+    await wrapper.find('.btn-submit').trigger('click')
+    await flushPromises()
+
+    const cancel = wrapper.findAll('button').find(button => button.text().includes('Cancel'))
+    expect(cancel).toBeDefined()
+    await cancel?.trigger('click')
+
+    expect(createCoin).not.toHaveBeenCalled()
+    expect(routerBack).toHaveBeenCalled()
+  })
+})

--- a/src/web/src/pages/__tests__/WishlistPage.test.ts
+++ b/src/web/src/pages/__tests__/WishlistPage.test.ts
@@ -9,6 +9,7 @@ const mockStore = {
   total: 0,
   fetchCoins: vi.fn(),
 }
+let mockIsPwa = false
 
 vi.mock('@/stores/coins', () => ({
   useCoinsStore: () => mockStore,
@@ -16,7 +17,7 @@ vi.mock('@/stores/coins', () => ({
 
 vi.mock('@/composables/usePwa', () => ({
   usePwa: () => ({
-    isPwa: false,
+    isPwa: mockIsPwa,
   }),
 }))
 
@@ -48,6 +49,8 @@ function createCoin(id: number): Coin {
     currentValue: null,
     purchaseDate: null,
     purchaseLocation: '',
+    storageLocationId: null,
+    storageLocation: null,
     notes: '',
     aiAnalysis: '',
     obverseAnalysis: '',
@@ -76,7 +79,13 @@ describe('WishlistPage', () => {
     mockStore.coins = []
     mockStore.total = 0
     mockStore.fetchCoins.mockReset()
+    mockIsPwa = false
   })
+
+  const routerLinkStub = {
+    props: ['to'],
+    template: '<a :href="to" :title="$attrs.title"><slot /></a>',
+  }
 
   it('does not show the empty state when wishlist coins are present on a single page', () => {
     mockStore.coins = [createCoin(1)]
@@ -85,9 +94,7 @@ describe('WishlistPage', () => {
     const wrapper = shallowMount(WishlistPage, {
       global: {
         stubs: {
-          RouterLink: {
-            template: '<a><slot /></a>',
-          },
+          RouterLink: routerLinkStub,
         },
       },
     })
@@ -102,14 +109,44 @@ describe('WishlistPage', () => {
     const wrapper = shallowMount(WishlistPage, {
       global: {
         stubs: {
-          RouterLink: {
-            template: '<a><slot /></a>',
-          },
+          RouterLink: routerLinkStub,
         },
       },
     })
 
     expect(wrapper.find('.coins-grid').exists()).toBe(false)
     expect(wrapper.find('.empty-state').exists()).toBe(true)
+  })
+
+  it('routes the desktop add action to the Find Coin workflow', () => {
+    const wrapper = shallowMount(WishlistPage, {
+      global: {
+        stubs: {
+          RouterLink: routerLinkStub,
+        },
+      },
+    })
+
+    const links = wrapper.findAll('a')
+    expect(links.filter(link => link.attributes('href') === '/lookup')).toHaveLength(1)
+    expect(links.some(link => link.attributes('href') === '/lookup' && link.text().includes('Find Coin'))).toBe(true)
+    expect(links.some(link => link.attributes('href') === '/add?wishlist=true')).toBe(false)
+  })
+
+  it('routes the PWA plus icon to the Find Coin workflow', () => {
+    mockIsPwa = true
+
+    const wrapper = shallowMount(WishlistPage, {
+      global: {
+        stubs: {
+          RouterLink: routerLinkStub,
+        },
+      },
+    })
+
+    const lookupLink = wrapper.find('a[title="Find Coin"]')
+    expect(lookupLink.exists()).toBe(true)
+    expect(lookupLink.attributes('href')).toBe('/lookup')
+    expect(wrapper.find('a[href="/add?wishlist=true"]').exists()).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- Changed the Wishlist page plus action to open **Find Coin** (`/lookup`) instead of the broken `Add Coin ?wishlist=true` path.
- Renamed the lookup navigation/page surface to **Find Coin** and made the result action save only to the wishlist.
- Removed the Find Coin “Add to Collection” action; users can still Back, Cancel, or Retake without creating anything.
- Improved lookup fallback analysis so CNG/NGC slab or cert detection still produces NGC reference data, while non-slab images produce a usable standard coin draft for wishlist save.
- Added regression coverage for wishlist routing, cancel-without-save, save-to-wishlist payloads, NGC cert detection, and non-slab draft fallback.
- Restored NumisBids watchlist sync parsing for current absolute lot links and legacy n.php lot links; synced AUD/CAD estimates now keep their currency.

## Workflow behavior

1. Wishlist plus button opens Find Coin.
2. Find Coin analyzes the uploaded/captured image.
3. If the image includes an NGC/CNG-style slab or cert number, the lookup response includes the normalized cert and NGC reference URL.
4. If no slab/cert is detected, the same lookup path falls back to structured coin-image extraction fields.
5. Clicking **Save to Wishlist** creates a coin with `isWishlist: true`, uploads captured images, creates candidate references, and returns to Wishlist.
6. Cancel/Back/Retake paths do not persist a coin.

## Constitution self-check

- **Principle I**: Backend behavior stays in `CoinLookupService`; handler remains thin.
- **Principle III**: Vue build/type-check and Go tests pass with explicit typed payload handling.
- **Principle IV**: Simple complete change: repairs the real wishlist add workflow without expanding into a broader Add Coin rewrite.
- **Principle V**: Existing upload validation and authenticated protected route behavior are preserved.
- **§17 / §21**: Quality gate and Definition of Done checked below.

## Validation

- `cd src/api && go build ./...`
- `cd src/api && go vet ./...`
- `cd src/api && go test -v ./...`
- `cd src/api && go test -v ./services -run "TestParseWatchlist"`
- `cd src/api && go test -run "TestExtractCoinFields|TestBuildPrefilledDraft|TestSlabCertDetection|TestExtractNGCCert" ./services`
- `cd src/web && npm.cmd run build`
- `cd src/web && npm.cmd test`
- `cd src/web && npm.cmd test -- --run src/pages/__tests__/WishlistPage.test.ts src/pages/__tests__/CoinLookupPage.test.ts`
- `cd src/web && npm.cmd run lint` *(0 errors; existing unrelated warnings remain)*
- `git diff --check`

## Definition of Done (§21)

- [x] Code compiles: Go build and frontend build pass.
- [x] Architecture tests green: included in `go test -v ./...`.
- [x] Unit tests pass for touched modules.
- [x] Type checks pass via frontend build / `vue-tsc --build`.
- [x] Linters clean for blocking errors: `go vet` clean; frontend lint has 0 errors.
- [x] New/changed service behavior has regression tests.
- [x] Swagger not regenerated because the public response shape did not change.
- [x] No ADR needed; this is a proportional workflow fix.
- [x] No active spec task checklist applies to this hotfix.
- [x] Team decisions captured by agents where relevant.
- [x] Principle IV self-check complete: simple, complete, proportional.
- [x] No secrets or credentials in diff.
- [x] Conventional Commit used with required Co-authored-by trailer.
- [x] PR cites relevant Constitution principles and sections.

