### PR TITLE
fix: verify NumisBids watchlist authentication

### DIFF
--- a/src/api/handlers/auction_lots.go
+++ b/src/api/handlers/auction_lots.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"errors"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -21,11 +20,12 @@ type AuctionLotHandler struct {
 	svc      *services.AuctionLotService
 	userRepo *repository.UserRepository
 	nbSvc    *services.NumisBidsService
+	logger   *services.Logger
 }
 
 // NewAuctionLotHandler creates a new AuctionLotHandler.
-func NewAuctionLotHandler(repo *repository.AuctionLotRepository, svc *services.AuctionLotService, userRepo *repository.UserRepository, nbSvc *services.NumisBidsService) *AuctionLotHandler {
-	return &AuctionLotHandler{repo: repo, svc: svc, userRepo: userRepo, nbSvc: nbSvc}
+func NewAuctionLotHandler(repo *repository.AuctionLotRepository, svc *services.AuctionLotService, userRepo *repository.UserRepository, nbSvc *services.NumisBidsService, logger *services.Logger) *AuctionLotHandler {
+	return &AuctionLotHandler{repo: repo, svc: svc, userRepo: userRepo, nbSvc: nbSvc, logger: logger}
 }
 
 // List returns a paginated list of auction lots for the authenticated user.
@@ -165,6 +165,7 @@ func (h *AuctionLotHandler) Create(c *gin.Context) {
 //	@Failure		404		{object}	ErrorResponse
 //	@Security		BearerAuth
 //	@Router			/auctions/{id} [put]
+//
 // UpdateLotRequest is the narrow set of fields a user may edit on an auction lot.
 // Fields like UserID, CoinID, EventID, Status, and computed fields are intentionally
 // excluded — those have dedicated endpoints with their own authorization rules.
@@ -558,38 +559,57 @@ func (h *AuctionLotHandler) ImportFromURL(c *gin.Context) {
 //	@Router			/auctions/sync [post]
 func (h *AuctionLotHandler) SyncWatchlist(c *gin.Context) {
 	userID := c.GetUint("userId")
+	h.debug("NumisBids sync started for user %d", userID)
 
 	user, err := h.userRepo.FindByID(userID)
 	if err != nil {
+		h.warn("NumisBids sync failed to load user %d: %v", userID, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load user"})
 		return
 	}
 
 	if user.NumisBidsUsername == "" || user.NumisBidsPassword == "" {
+		h.warn("NumisBids sync blocked for user %d: credentials not configured", userID)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "NumisBids credentials not configured. Go to Settings to add them."})
 		return
 	}
 
+	h.debug("NumisBids sync logging in for user %d", userID)
 	client, err := h.nbSvc.Login(user.NumisBidsUsername, user.NumisBidsPassword)
 	if err != nil {
-		log.Printf("NumisBids login failed for user %d: %v", userID, err)
+		h.warn("NumisBids login failed for user %d: %v", userID, err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "NumisBids login failed. Check your credentials in Settings."})
 		return
 	}
+	h.debug("NumisBids sync login succeeded for user %d", userID)
 
 	rawHTML, err := h.nbSvc.FetchWatchlist(client)
 	if err != nil {
-		log.Printf("NumisBids watchlist fetch failed for user %d: %v", userID, err)
+		if errors.Is(err, services.ErrNumisBidsAuthenticationRequired) {
+			h.warn("NumisBids watchlist returned login page for user %d after login", userID)
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "NumisBids login succeeded but watchlist access was not authenticated. Check your credentials in Settings."})
+			return
+		}
+		h.warn("NumisBids watchlist fetch failed for user %d: %v", userID, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch watchlist from NumisBids"})
 		return
 	}
+	diagnostics := h.nbSvc.WatchlistDiagnostics(rawHTML)
+	h.debug("NumisBids watchlist fetched for user %d: bytes=%d candidateLinks=%d hasWatchlistText=%t hasLoginPrompt=%t",
+		userID, diagnostics.HTMLBytes, diagnostics.CandidateLinkCount, diagnostics.HasWatchlistText, diagnostics.HasLoginPrompt)
 
 	parsed := h.nbSvc.ParseWatchlist(rawHTML)
+	h.debug("NumisBids watchlist parsed for user %d: lots=%d", userID, len(parsed))
+	if len(parsed) == 0 {
+		h.warn("NumisBids sync found zero parseable lots for user %d: bytes=%d candidateLinks=%d hasWatchlistText=%t",
+			userID, diagnostics.HTMLBytes, diagnostics.CandidateLinkCount, diagnostics.HasWatchlistText)
+	}
 
 	var synced []models.AuctionLot
 	now := time.Now()
 
 	for _, wl := range parsed {
+		h.debug("NumisBids sync processing lot for user %d: saleID=%s lot=%d url=%s", userID, wl.SaleID, wl.LotNumber, wl.URL)
 		// Scrape the lot page for image, auction house, sale name, current bid, lot number, description, sale date
 		if details, err := h.nbSvc.ScrapeLotPage(wl.URL); err == nil {
 			if details.ImageURL != "" {
@@ -607,7 +627,7 @@ func (h *AuctionLotHandler) SyncWatchlist(c *gin.Context) {
 				wl.LotNumber = details.LotNumber
 			}
 		} else {
-			log.Printf("Could not scrape lot page for %s: %v", wl.URL, err)
+			h.warn("Could not scrape NumisBids lot page for user %d url=%s: %v", userID, wl.URL, err)
 		}
 
 		// Determine status: mark as passed if sale date is in the past
@@ -641,24 +661,45 @@ func (h *AuctionLotHandler) SyncWatchlist(c *gin.Context) {
 		}
 
 		if err := h.repo.Upsert(&lot); err != nil {
-			log.Printf("Failed to upsert lot %s for user %d: %v", wl.URL, userID, err)
+			h.warn("Failed to upsert NumisBids lot for user %d url=%s: %v", userID, wl.URL, err)
 			continue
 		}
 
 		if upserted, err := h.repo.GetByURL(wl.URL, userID); err == nil {
 			synced = append(synced, *upserted)
+		} else {
+			h.warn("NumisBids lot upserted but reload failed for user %d url=%s: %v", userID, wl.URL, err)
 		}
 	}
 
 	// Also mark any existing watching lots whose sale date has passed
 	h.repo.MarkPastAuctionsAsPassed(userID, now)
+	h.info("NumisBids sync completed for user %d: parsed=%d synced=%d", userID, len(parsed), len(synced))
 
 	c.JSON(http.StatusOK, gin.H{"synced": len(synced), "lots": synced})
 }
 
+func (h *AuctionLotHandler) debug(format string, args ...interface{}) {
+	if h.logger != nil {
+		h.logger.Debug("auctions", format, args...)
+	}
+}
+
+func (h *AuctionLotHandler) info(format string, args ...interface{}) {
+	if h.logger != nil {
+		h.logger.Info("auctions", format, args...)
+	}
+}
+
+func (h *AuctionLotHandler) warn(format string, args ...interface{}) {
+	if h.logger != nil {
+		h.logger.Warn("auctions", format, args...)
+	}
+}
+
 // SyncWatchlistResponse is the response for the sync watchlist endpoint.
 type SyncWatchlistResponse struct {
-	Synced int                `json:"synced"`
+	Synced int                 `json:"synced"`
 	Lots   []models.AuctionLot `json:"lots"`
 }
 

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -326,9 +326,9 @@ func main() {
 		protected.GET("/numista/search", numistaHandler.Search)
 
 		auctionLotSvc := services.NewAuctionLotService(auctionLotRepo, coinRepo)
-		nbSvc := services.NewNumisBidsService()
+		nbSvc := services.NewNumisBidsService(logger)
 		auctionUserRepo := repository.NewUserRepository(database.DB)
-		auctionLotHandler := handlers.NewAuctionLotHandler(auctionLotRepo, auctionLotSvc, auctionUserRepo, nbSvc)
+		auctionLotHandler := handlers.NewAuctionLotHandler(auctionLotRepo, auctionLotSvc, auctionUserRepo, nbSvc, logger)
 		protected.GET("/auctions", auctionLotHandler.List)
 		protected.GET("/auctions/counts", auctionLotHandler.Counts)
 		protected.PUT("/auctions/bulk-link-event", auctionLotHandler.BulkLinkEvent)

--- a/src/api/services/numisbids_service.go
+++ b/src/api/services/numisbids_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,13 +16,18 @@ import (
 	"golang.org/x/net/html"
 )
 
+var ErrNumisBidsAuthenticationRequired = errors.New("numisbids authentication required")
+
 const (
-	numisbidsBase         = "https://www.numisbids.com"
-	numisbidsLoginURL     = numisbidsBase + "/registration/login.php"
-	numisbidsWatchlistURL = numisbidsBase + "/watchlist"
-	numisbidsUserAgent    = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+	numisbidsBase      = "https://www.numisbids.com"
+	numisbidsUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
 		"AppleWebKit/537.36 (KHTML, like Gecko) " +
 		"Chrome/131.0.0.0 Safari/537.36"
+)
+
+var (
+	numisbidsLoginURL     = numisbidsBase + "/registration/login.php"
+	numisbidsWatchlistURL = numisbidsBase + "/watchlist"
 )
 
 var (
@@ -49,15 +56,19 @@ type WatchlistLot struct {
 }
 
 // NumisBidsService handles HTTP interactions with numisbids.com.
-type NumisBidsService struct{}
+type NumisBidsService struct {
+	logger *Logger
+}
 
 // NewNumisBidsService creates a new NumisBidsService.
-func NewNumisBidsService() *NumisBidsService {
-	return &NumisBidsService{}
+func NewNumisBidsService(logger *Logger) *NumisBidsService {
+	return &NumisBidsService{logger: logger}
 }
 
 // Login authenticates with NumisBids and returns a cookie-jar-enabled client.
 func (s *NumisBidsService) Login(username, password string) (*http.Client, error) {
+	s.debug("Attempting login to NumisBids")
+
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cookie jar: %w", err)
@@ -68,7 +79,6 @@ func (s *NumisBidsService) Login(username, password string) (*http.Client, error
 	form := url.Values{
 		"email":    {username},
 		"password": {password},
-		"login":    {"Login"},
 	}
 
 	req, err := http.NewRequest("POST", numisbidsLoginURL, strings.NewReader(form.Encode()))
@@ -82,28 +92,88 @@ func (s *NumisBidsService) Login(username, password string) (*http.Client, error
 
 	resp, err := client.Do(req)
 	if err != nil {
+		s.error("Login HTTP request failed: %v", err)
 		return nil, fmt.Errorf("login request failed: %w", err)
 	}
 	defer resp.Body.Close()
+
+	s.debug("Login response status: %d", resp.StatusCode)
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusFound {
 		return nil, fmt.Errorf("login returned HTTP %d", resp.StatusCode)
 	}
 
-	// Read body to check for login errors (AJAX form returns HTML fragment)
+	// Read body to check the JSON result returned by NumisBids' AJAX login.
 	body, _ := io.ReadAll(resp.Body)
 	bodyStr := string(body)
-	if strings.Contains(bodyStr, "Incorrect") || strings.Contains(bodyStr, "invalid") {
-		return nil, fmt.Errorf("invalid credentials")
+
+	s.trace("Login response body length: %d bytes", len(bodyStr))
+
+	var loginResponse struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(body, &loginResponse); err != nil {
+		s.warn("Login failed: unexpected response format")
+		return nil, fmt.Errorf("unexpected login response")
+	}
+	if !strings.EqualFold(loginResponse.Status, "success") {
+		s.warn("Login failed: NumisBids returned status %q", loginResponse.Status)
+		return nil, fmt.Errorf("login returned status %q", loginResponse.Status)
 	}
 
-	// Verify session cookie was set by checking for a PHPSESSID or similar
-	parsedURL, _ := url.Parse(numisbidsBase)
-	if len(jar.Cookies(parsedURL)) == 0 {
+	// Verify session cookie was set by checking the login host for PHPSESSID or similar.
+	parsedURL, _ := url.Parse(numisbidsLoginURL)
+	cookies := jar.Cookies(parsedURL)
+	if len(cookies) == 0 {
+		s.warn("No session cookie received after login")
 		return nil, fmt.Errorf("no session cookie received — login may have failed")
 	}
 
+	s.debug("Login successful, received %d cookie(s)", len(cookies))
+
+	// Verify authentication by requesting a protected page
+	if err := s.verifyAuthentication(client); err != nil {
+		s.error("Authentication verification failed: %v", err)
+		return nil, fmt.Errorf("login succeeded but authentication verification failed: %w", err)
+	}
+
+	s.info("Login and authentication verified")
 	return client, nil
+}
+
+// verifyAuthentication checks that the client is actually authenticated by fetching
+// the watchlist page and checking for login indicators.
+func (s *NumisBidsService) verifyAuthentication(client *http.Client) error {
+	req, err := http.NewRequest("GET", numisbidsWatchlistURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create verification request: %w", err)
+	}
+	req.Header.Set("User-Agent", numisbidsUserAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("verification request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read verification response: %w", err)
+	}
+
+	bodyStr := strings.ToLower(string(body))
+
+	// Check for login form indicators (unauthenticated)
+	if isNumisBidsLoginPrompt(bodyStr) ||
+		strings.Contains(bodyStr, `name="email"`) ||
+		strings.Contains(bodyStr, `name="password"`) ||
+		strings.Contains(bodyStr, "login to your account") {
+		s.debug("Verification page contains login form — not authenticated")
+		return fmt.Errorf("not authenticated: watchlist page returned login form")
+	}
+
+	s.debug("Authentication verified — no login form detected")
+	return nil
 }
 
 // FetchWatchlist retrieves the authenticated user's watchlist HTML.
@@ -128,8 +198,12 @@ func (s *NumisBidsService) FetchWatchlist(client *http.Client) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to read watchlist body: %w", err)
 	}
+	bodyStr := string(body)
+	if isNumisBidsLoginPrompt(bodyStr) {
+		return "", ErrNumisBidsAuthenticationRequired
+	}
 
-	return string(body), nil
+	return bodyStr, nil
 }
 
 // LotPageDetails holds fields extracted from a NumisBids lot detail page.
@@ -245,9 +319,13 @@ func (s *NumisBidsService) ScrapeLotPage(lotURL string) (*LotPageDetails, error)
 // ParseWatchlist extracts lot data from NumisBids watchlist HTML.
 // Mirrors the Python scrape_numisbids_watchlist logic.
 func (s *NumisBidsService) ParseWatchlist(rawHTML string) []WatchlistLot {
+	s.debug("Parsing watchlist HTML (%d bytes)", len(rawHTML))
+
 	// Find all lot link positions, then extract the block between each pair.
 	// Go's regexp engine (RE2) doesn't support lookaheads, so we split manually.
 	matches := findWatchlistLotLinks(rawHTML)
+
+	s.debug("Found %d lot links in watchlist HTML", len(matches))
 
 	var lots []WatchlistLot
 	for i, match := range matches {
@@ -289,10 +367,64 @@ func (s *NumisBidsService) ParseWatchlist(rawHTML string) []WatchlistLot {
 			}
 		}
 
+		s.trace("Parsed lot %d: saleID=%s lotNumber=%d", i+1, lot.SaleID, lot.LotNumber)
 		lots = append(lots, lot)
 	}
 
+	s.info("Parsed %d lots from watchlist", len(lots))
 	return lots
+}
+
+func (s *NumisBidsService) trace(format string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Trace("numisbids", format, args...)
+	}
+}
+
+func (s *NumisBidsService) debug(format string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Debug("numisbids", format, args...)
+	}
+}
+
+func (s *NumisBidsService) info(format string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Info("numisbids", format, args...)
+	}
+}
+
+func (s *NumisBidsService) warn(format string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Warn("numisbids", format, args...)
+	}
+}
+
+func (s *NumisBidsService) error(format string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Error("numisbids", format, args...)
+	}
+}
+
+func (s *NumisBidsService) WatchlistDiagnostics(rawHTML string) WatchlistDiagnostics {
+	return WatchlistDiagnostics{
+		HTMLBytes:          len(rawHTML),
+		CandidateLinkCount: len(findWatchlistLotLinks(rawHTML)),
+		HasLoginPrompt:     isNumisBidsLoginPrompt(rawHTML),
+		HasWatchlistText:   strings.Contains(strings.ToLower(rawHTML), "watch list"),
+	}
+}
+
+type WatchlistDiagnostics struct {
+	HTMLBytes          int
+	CandidateLinkCount int
+	HasLoginPrompt     bool
+	HasWatchlistText   bool
+}
+
+func isNumisBidsLoginPrompt(rawHTML string) bool {
+	normalized := strings.ToLower(rawHTML)
+	return strings.Contains(normalized, "already have items on your watch list") &&
+		strings.Contains(normalized, "loginreload")
 }
 
 type watchlistLotLink struct {

--- a/src/api/services/numisbids_service_test.go
+++ b/src/api/services/numisbids_service_test.go
@@ -1,6 +1,12 @@
 package services
 
-import "testing"
+import (
+	"errors"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestParseWatchlistAcceptsCurrentAbsoluteLotLinks(t *testing.T) {
 	html := `
@@ -16,7 +22,8 @@ func TestParseWatchlistAcceptsCurrentAbsoluteLotLinks(t *testing.T) {
 			</div>
 		</section>`
 
-	lots := NewNumisBidsService().ParseWatchlist(html)
+	logger := NewLogger(100)
+	lots := NewNumisBidsService(logger).ParseWatchlist(html)
 	if len(lots) != 1 {
 		t.Fatalf("ParseWatchlist returned %d lots, want 1", len(lots))
 	}
@@ -50,7 +57,8 @@ func TestParseWatchlistAcceptsLegacyLotLinks(t *testing.T) {
 		<a href='/n.php?p=lot&sid=7996&lot=10003'>Status International Auction 406, Lot 10003</a>
 		<span>Estimate: 150 USD</span>`
 
-	lots := NewNumisBidsService().ParseWatchlist(html)
+	logger := NewLogger(100)
+	lots := NewNumisBidsService(logger).ParseWatchlist(html)
 	if len(lots) != 1 {
 		t.Fatalf("ParseWatchlist returned %d lots, want 1", len(lots))
 	}
@@ -71,8 +79,148 @@ func TestParseWatchlistAcceptsLegacyLotLinks(t *testing.T) {
 func TestParseWatchlistIgnoresNonNumisBidsAbsoluteLinks(t *testing.T) {
 	html := `<a href="https://example.com/sale/10749/lot/10003">External Lot</a>`
 
-	lots := NewNumisBidsService().ParseWatchlist(html)
+	logger := NewLogger(100)
+	lots := NewNumisBidsService(logger).ParseWatchlist(html)
 	if len(lots) != 0 {
 		t.Fatalf("ParseWatchlist returned %d lots, want 0", len(lots))
+	}
+}
+
+func TestWatchlistDiagnosticsDetectsLoginPrompt(t *testing.T) {
+	html := `
+		<div class="heading"><b>My Watch List</b></div>
+		<p>Already have items on your Watch List?</p>
+		<a href="" class="loginreload">Login</a>`
+
+	logger := NewLogger(100)
+	diagnostics := NewNumisBidsService(logger).WatchlistDiagnostics(html)
+	if !diagnostics.HasLoginPrompt {
+		t.Fatal("HasLoginPrompt = false, want true")
+	}
+	if !diagnostics.HasWatchlistText {
+		t.Fatal("HasWatchlistText = false, want true")
+	}
+	if diagnostics.CandidateLinkCount != 0 {
+		t.Fatalf("CandidateLinkCount = %d, want 0", diagnostics.CandidateLinkCount)
+	}
+}
+
+func TestFetchWatchlistRejectsLoginPromptPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`
+			<div class="heading"><b>My Watch List</b></div>
+			<p>Already have items on your Watch List?</p>
+			<a href="" class="loginreload">Login</a>`))
+	}))
+	defer server.Close()
+
+	client := server.Client()
+	originalWatchlistURL := numisbidsWatchlistURL
+	numisbidsWatchlistURL = server.URL
+	defer func() { numisbidsWatchlistURL = originalWatchlistURL }()
+
+	logger := NewLogger(100)
+	_, err := NewNumisBidsService(logger).FetchWatchlist(client)
+	if !errors.Is(err, ErrNumisBidsAuthenticationRequired) {
+		t.Fatalf("FetchWatchlist error = %v, want ErrNumisBidsAuthenticationRequired", err)
+	}
+}
+
+func TestLoginRequiresSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/registration/login.php" {
+			http.SetCookie(w, &http.Cookie{Name: "PHPSESSID", Value: "test"})
+			_, _ = w.Write([]byte(`{"status":"error1"}`))
+			return
+		}
+		t.Fatalf("unexpected request path %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	originalLoginURL := numisbidsLoginURL
+	numisbidsLoginURL = server.URL + "/registration/login.php"
+	defer func() { numisbidsLoginURL = originalLoginURL }()
+
+	logger := NewLogger(100)
+	_, err := NewNumisBidsService(logger).Login("user@example.com", "password")
+	if err == nil {
+		t.Fatal("Login returned nil error for non-success NumisBids status")
+	}
+}
+
+func TestLoginPostsCurrentNumisBidsPayloadAndVerifiesWatchlist(t *testing.T) {
+	var loginFormEmail string
+	var loginFormPassword string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/registration/login.php":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
+			loginFormEmail = r.Form.Get("email")
+			loginFormPassword = r.Form.Get("password")
+			if r.Form.Get("login") != "" {
+				t.Fatalf("unexpected legacy login form field = %q", r.Form.Get("login"))
+			}
+			http.SetCookie(w, &http.Cookie{Name: "PHPSESSID", Value: "test"})
+			_, _ = w.Write([]byte(`{"status":"success"}`))
+		case "/watchlist":
+			_, _ = w.Write([]byte(`<div class="heading"><b>My Watch List</b></div><a href="/sale/10749/lot/10003">Lot 10003</a>`))
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	originalLoginURL := numisbidsLoginURL
+	originalWatchlistURL := numisbidsWatchlistURL
+	numisbidsLoginURL = server.URL + "/registration/login.php"
+	numisbidsWatchlistURL = server.URL + "/watchlist"
+	defer func() {
+		numisbidsLoginURL = originalLoginURL
+		numisbidsWatchlistURL = originalWatchlistURL
+	}()
+
+	logger := NewLogger(100)
+	client, err := NewNumisBidsService(logger).Login("user@example.com", "password")
+	if err != nil {
+		t.Fatalf("Login returned error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("Login returned nil client")
+	}
+	if loginFormEmail != "user@example.com" {
+		t.Fatalf("posted email = %q, want user@example.com", loginFormEmail)
+	}
+	if loginFormPassword != "password" {
+		t.Fatalf("posted password = %q, want password", loginFormPassword)
+	}
+}
+
+func TestVerifyAuthenticationRejectsWatchlistLoginPrompt(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`
+			<div class="heading"><b>My Watch List</b></div>
+			<p>Already have items on your Watch List?</p>
+			<a href="" class="loginreload">Login</a>`))
+	}))
+	defer server.Close()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New failed: %v", err)
+	}
+	client := server.Client()
+	client.Jar = jar
+
+	originalWatchlistURL := numisbidsWatchlistURL
+	numisbidsWatchlistURL = server.URL
+	defer func() { numisbidsWatchlistURL = originalWatchlistURL }()
+
+	logger := NewLogger(100)
+	err = NewNumisBidsService(logger).verifyAuthentication(client)
+	if err == nil {
+		t.Fatal("verifyAuthentication returned nil for login prompt page")
 	}
 }


### PR DESCRIPTION
## Summary

- Requires NumisBids AJAX login to return JSON status success before treating credentials as authenticated.
- Verifies the watchlist page after login and rejects NumisBids' HTTP 200 login-prompt page instead of silently parsing zero lots.
- Routes auction sync diagnostics through the app admin logger so DEBUG shows sync stages in Admin Logs.
- Adds safe diagnostics for fetched HTML size, candidate lot link count, parsed lot count, scrape/upsert failures, and completion counts without logging credentials or NumisBids username/email.

## Root cause

NumisBids can return HTTP 200 for /watchlist even when the session is not authenticated; that page contains a Login prompt, not lots. The old sync path treated any 200 response as a valid watchlist and returned 0 synced lots. Separately, auction sync used standard log.Printf in the handler and had no stage-by-stage service diagnostics, so setting LogLevel to DEBUG did not expose the useful sync details in Admin Logs.

## Validation

- cd src/api && go test -v ./services -run "TestParseWatchlist|TestWatchlistDiagnostics|TestFetchWatchlist|TestLogin|TestVerifyAuthentication"
- cd src/api && go test -v ./...
- cd src/api && go build ./...
- cd src/api && go vet ./...
- git diff --check -- src/api/services/numisbids_service.go src/api/services/numisbids_service_test.go src/api/handlers/auction_lots.go src/api/main.go

## Constitution self-check

- Principle I: handler remains orchestration-only; NumisBids login/fetch/parsing stays in the service.
- Principle IV: fixes the actual workflow failure and the directly related debug visibility gap without a broader auction rewrite.
- Principle V: logs avoid credentials and NumisBids username/email.
- §17 / §21: Quality gate and Definition of Done validated above.