### PR TITLE
fix: reposition wishlist detail actions

### DIFF
--- a/src/web/src/components/coin/CoinDetailHeaderActions.vue
+++ b/src/web/src/components/coin/CoinDetailHeaderActions.vue
@@ -5,7 +5,6 @@
       Back to Gallery
     </button>
     <div class="detail-actions">
-      <button v-if="isWishlist" class="btn btn-primary btn-xs" @click="$emit('purchase')">Mark as Purchased</button>
       <button v-if="!isWishlist && !isSold" class="btn btn-secondary btn-xs" @click="$emit('sell')">Sell</button>
       <router-link :to="`/edit/${coinId}`" class="btn btn-secondary btn-xs">Edit</router-link>
       <button class="btn btn-danger btn-xs" @click="$emit('delete')">Delete</button>
@@ -24,7 +23,6 @@ defineProps<{
 }>()
 
 defineEmits<{
-  purchase: []
   sell: []
   delete: []
 }>()
@@ -46,21 +44,23 @@ const router = useRouter()
   justify-content: flex-end;
   flex-wrap: wrap;
   gap: 0.5rem;
+  min-width: 0;
 }
 
 .back-action {
   justify-self: start;
+  white-space: nowrap;
 }
 
 @media (max-width: 768px) {
   .detail-header {
-    grid-template-columns: 1fr;
-    gap: 0.75rem;
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem;
     margin-bottom: 1rem;
   }
 
   .detail-actions {
-    justify-content: flex-start;
+    justify-content: flex-end;
     gap: 0.35rem;
   }
 }

--- a/src/web/src/pages/CoinDetailPage.vue
+++ b/src/web/src/pages/CoinDetailPage.vue
@@ -10,7 +10,6 @@
           :is-wishlist="coin.isWishlist"
           :is-sold="coin.isSold"
           :coin-id="coin.id"
-          @purchase="showPurchaseModal = true"
           @sell="showSellModal = true"
           @delete="handleDelete"
         />
@@ -46,6 +45,11 @@
                 <span class="placeholder-text">No image</span>
               </div>
             </div>
+          </div>
+          <div v-if="coin.isWishlist" class="wishlist-purchase-cta">
+            <button class="btn btn-primary wishlist-purchase-button" @click="showPurchaseModal = true">
+              Mark as Purchased
+            </button>
           </div>
         </div>
 
@@ -237,6 +241,15 @@ async function confirmSell(soldPrice: number | null, soldTo: string) {
 
 .detail-hero-media {
   align-self: start;
+}
+
+.wishlist-purchase-cta {
+  margin-top: 0.75rem;
+}
+
+.wishlist-purchase-button {
+  width: 100%;
+  justify-content: center;
 }
 
 /* T011: Hero media grid for dual-side default display */


### PR DESCRIPTION
## Summary

Updates the wishlist coin detail action layout for the PWA/mobile view:

- Keeps Back to Gallery, Edit, and Delete in the same header row.
- Right-aligns Edit/Delete opposite Back to Gallery.
- Moves Mark as Purchased below the coin images.
- Makes Mark as Purchased a full-width primary CTA across the content area.

## Constitution / spec alignment

- Principle VI: improves mobile/PWA action hierarchy and keeps the page aligned with the elegant museum-quality aesthetic.
- §17 Quality Gate: frontend build/lint were run before merge.

## Validation

- `npm.cmd run build`
- `npm.cmd run lint` (passes with existing unrelated warnings)
