### PR TITLE
fix: avoid coin of day scan error

### DIFF
--- a/src/api/repository/featured_coin_repository.go
+++ b/src/api/repository/featured_coin_repository.go
@@ -79,8 +79,7 @@ func (r *FeaturedCoinRepository) HasBeenFeaturedToday(userID uint, today time.Ti
 // Eligible pool: owned coins that are NOT wishlist and NOT sold.
 func (r *FeaturedCoinRepository) PickNextCoinID(userID uint) (uint, error) {
 	type row struct {
-		ID         uint
-		LastShown  *time.Time
+		ID uint
 	}
 
 	var rows []row

--- a/src/api/repository/featured_coin_repository_test.go
+++ b/src/api/repository/featured_coin_repository_test.go
@@ -1,0 +1,121 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/briandenicola/ancient-coins-api/models"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupFeaturedCoinTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.Coin{}, &models.FeaturedCoin{}); err != nil {
+		t.Fatalf("failed to migrate test db: %v", err)
+	}
+	return db
+}
+
+func createFeaturedCoinTestUser(t *testing.T, db *gorm.DB, username string) models.User {
+	t.Helper()
+
+	user := models.User{
+		Username:     username,
+		Email:        username + "@example.com",
+		PasswordHash: "hash",
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	return user
+}
+
+func createFeaturedCoinTestCoin(t *testing.T, db *gorm.DB, userID uint, name string, wishlist, sold bool) models.Coin {
+	t.Helper()
+
+	coin := models.Coin{
+		Name:       name,
+		Category:   models.CategoryRoman,
+		Material:   models.MaterialSilver,
+		Era:        models.EraAncient,
+		UserID:     userID,
+		IsWishlist: wishlist,
+		IsSold:     sold,
+	}
+	if err := db.Create(&coin).Error; err != nil {
+		t.Fatalf("failed to create coin: %v", err)
+	}
+	return coin
+}
+
+func createFeaturedCoinRecord(t *testing.T, db *gorm.DB, userID, coinID uint, featuredAt time.Time) {
+	t.Helper()
+
+	if err := db.Create(&models.FeaturedCoin{
+		UserID:     userID,
+		CoinID:     coinID,
+		Summary:    "Featured coin",
+		FeaturedAt: featuredAt,
+	}).Error; err != nil {
+		t.Fatalf("failed to create featured coin: %v", err)
+	}
+}
+
+func TestPickNextCoinIDPrefersNeverFeaturedCoin(t *testing.T) {
+	db := setupFeaturedCoinTestDB(t)
+	repo := NewFeaturedCoinRepository(db)
+	user := createFeaturedCoinTestUser(t, db, "never-featured")
+	shown := createFeaturedCoinTestCoin(t, db, user.ID, "Shown", false, false)
+	neverShown := createFeaturedCoinTestCoin(t, db, user.ID, "Never shown", false, false)
+
+	createFeaturedCoinRecord(t, db, user.ID, shown.ID, time.Now().Add(-24*time.Hour))
+
+	got, err := repo.PickNextCoinID(user.ID)
+	if err != nil {
+		t.Fatalf("PickNextCoinID returned error: %v", err)
+	}
+	if got != neverShown.ID {
+		t.Fatalf("PickNextCoinID = %d, want never-shown coin %d", got, neverShown.ID)
+	}
+}
+
+func TestPickNextCoinIDChoosesOldestFeaturedCoinWhenCycleRestarts(t *testing.T) {
+	db := setupFeaturedCoinTestDB(t)
+	repo := NewFeaturedCoinRepository(db)
+	user := createFeaturedCoinTestUser(t, db, "cycle")
+	oldestShown := createFeaturedCoinTestCoin(t, db, user.ID, "Oldest shown", false, false)
+	recentlyShown := createFeaturedCoinTestCoin(t, db, user.ID, "Recently shown", false, false)
+
+	createFeaturedCoinRecord(t, db, user.ID, oldestShown.ID, time.Now().Add(-48*time.Hour))
+	createFeaturedCoinRecord(t, db, user.ID, recentlyShown.ID, time.Now().Add(-24*time.Hour))
+
+	got, err := repo.PickNextCoinID(user.ID)
+	if err != nil {
+		t.Fatalf("PickNextCoinID returned error: %v", err)
+	}
+	if got != oldestShown.ID {
+		t.Fatalf("PickNextCoinID = %d, want oldest featured coin %d", got, oldestShown.ID)
+	}
+}
+
+func TestPickNextCoinIDExcludesWishlistAndSoldCoins(t *testing.T) {
+	db := setupFeaturedCoinTestDB(t)
+	repo := NewFeaturedCoinRepository(db)
+	user := createFeaturedCoinTestUser(t, db, "eligible")
+	createFeaturedCoinTestCoin(t, db, user.ID, "Wishlist", true, false)
+	createFeaturedCoinTestCoin(t, db, user.ID, "Sold", false, true)
+
+	got, err := repo.PickNextCoinID(user.ID)
+	if err != nil {
+		t.Fatalf("PickNextCoinID returned error: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("PickNextCoinID = %d, want 0 when no eligible coins exist", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the manual Coin of the Day run failure shown in the admin logs:

`sql: Scan error on column index 1, name "last_shown": unsupported Scan, storing driver.Value type string into type *time.Time`

The selection query only needs the selected coin id; `last_shown` is used only for SQL ordering. This PR stops scanning the aggregate timestamp into Go, avoiding the SQLite string-to-`time.Time` scan failure while preserving the existing cycle order.

## Details

- Keeps the existing selection semantics:
  - owned coins only
  - excludes wishlist coins
  - excludes sold coins
  - prefers never-featured coins first
  - then cycles by oldest previously featured coin
- Adds repository regression coverage for the manual-run selection path.

## Constitution / spec alignment

- Principle I: keeps selection logic in the repository layer.
- Principle IV: simple proportional fix; remove the unused scanned field rather than adding parsing logic.
- §17 Quality Gate: backend test/build/vet were run locally.

## Validation

- `go test -v ./repository -run TestPickNextCoinID`
- `go test -v ./...`
- `go build ./...`
- `go vet ./...`
