### PR TITLE
fix: accept configured coin eras on update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,8 @@
 - Operational section(s): <!-- e.g., §17 Quality Gate, §21 DoD -->
 - ADR added? <!-- yes/no — required for material design choices, §22 -->
 - Principle IV check: <!-- simple, complete, proportional; note workflow/sibling paths tested -->
+- Workflow contract(s): <!-- user workflow(s), API/UI/config contracts touched -->
+- Blast radius / sibling workflows checked: <!-- e.g., Add Coin, Edit Coin, Admin settings, wishlist -->
 
 ## Linked work
 - Issue: #
@@ -18,16 +20,19 @@
 - [ ] 3. Unit tests pass (`go test ./...`, `pytest tests/`)
 - [ ] 4. Type checks pass (`vue-tsc --build`, Go compile)
 - [ ] 5. Linters clean (`go vet`, `ruff check`)
-- [ ] 6. New service methods have ≥1 unit test
-- [ ] 7. Public handlers have Swagger annotations
-- [ ] 8. If API changed: `task openapi` run and `docs/openapi.json` updated
-- [ ] 9. If material design choice: ADR added in `docs/adr/` *(when Phase 3 lands)*
-- [ ] 10. Active `specs/NNN-*/tasks.md` items checked off
-- [ ] 11. `.squad/decisions/inbox/` written if cross-cutting decision made
-- [ ] 12. Simple Complete Changes self-check complete (Principle IV)
-- [ ] 13. Secrets scan clean (no credentials in diff)
-- [ ] 14. Conventional commit messages
-- [ ] 15. `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer present when AI-assisted
+- [ ] 6. Bug fixes include a targeted regression test for the exact failing user path, or document why automation is deferred
+- [ ] 7. Shared workflow/config/API contract changes list blast radius and sibling workflows checked
+- [ ] 8. User/admin-configured UI values are accepted by every API path the UI can submit them to, or blocked with a clear UI message
+- [ ] 9. New service methods have ≥1 unit test
+- [ ] 10. Public handlers have Swagger annotations
+- [ ] 11. If API changed: `task openapi` run and `docs/openapi.json` updated
+- [ ] 12. If material design choice: ADR added in `docs/adr/` *(when Phase 3 lands)*
+- [ ] 13. Active `specs/NNN-*/tasks.md` items checked off
+- [ ] 14. `.squad/decisions/inbox/` written if cross-cutting decision made
+- [ ] 15. Simple Complete Changes self-check complete (Principle IV)
+- [ ] 16. Secrets scan clean (no credentials in diff)
+- [ ] 17. Conventional commit messages
+- [ ] 18. `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer present when AI-assisted
 
 ## Notes for reviewer
 <!-- Anything reviewer should pay special attention to -->

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,17 +1,15 @@
 <!--
   Sync Impact Report
   ==================
-  Version change: 2.0.0 → 3.0.0 (MAJOR — consolidated and renumbered principles)
-  Modified principles: Consolidated Principles I–XVII into Principles I–IX
-  Added sections:
-    - Principle IV. Simple Complete Changes
-  Removed sections:
-    - Separate standalone principles for DI, architecture enforcement, AI isolation,
-      schema contracts, auth, social/privacy, account lifecycle, and supply chain;
-      their binding content is consolidated into the nine-principle set.
+  Version change: 3.0.0 → 3.1.0 (MINOR — expanded operational gates)
+  Modified principles: None
+  Added sections: None
+  Removed sections: None
+  Modified operational sections:
+    - §17 Quality Gate: added workflow-contract/regression coverage check
+    - §21 Definition of Done: added blast-radius and exact-path regression requirements
   Templates requiring updates:
-    - ✅ .github/copilot-instructions.md — references Principle IV
-    - ✅ .github/pull_request_template.md — adds Principle IV self-check
+    - ✅ .github/pull_request_template.md — adds workflow-contract and blast-radius checks
     - ✅ .specify/templates/plan-template.md — compatible
     - ✅ .specify/templates/spec-template.md — compatible
     - ✅ .specify/templates/tasks-template.md — compatible
@@ -26,9 +24,9 @@
 > Deviations require an explicit, documented waiver (ADR) under §22.
 
 **Project**: Ancient Coins (self-hosted personal collection PWA)
-**Version**: 3.0.0
+**Version**: 3.1.0
 **Ratified**: 2026-04-28
-**Last Amended**: 2026-06-09
+**Last Amended**: 2026-06-11
 
 ## §0. Hierarchy of Authority
 
@@ -334,6 +332,10 @@ relevant tooling lands.
 - [ ] Definition of Done checklist (§21) checked in the PR
 - [ ] Principle IV self-check: change is simple, complete, and
       proportional
+- [ ] Workflow-contract check: PR identifies user workflow(s), shared
+      contracts/configuration touched, and targeted regression or contract
+      tests for the exact failing path. If not automatable, the PR MUST
+      document the manual verification path and why automation is deferred.
 
 **Signed commits are NOT required.** This is a single-developer hobby
 project; the Conventional Commits format and Co-authored-by trailer are
@@ -466,24 +468,35 @@ checklist in the PR description.
    (Principle III).
 5. **Linters clean**: `go vet ./...` and `ruff check app/ tests/` are
    clean.
-6. **Test coverage**: every new service method has ≥ 1 unit test.
-7. **Swagger**: every new or modified public handler has Swagger
+6. **Regression coverage**: every bug fix includes a targeted regression
+   test for the exact failing user path or a documented reason automation
+   is deferred.
+7. **Workflow contracts**: if a change touches shared forms, settings,
+   validation, API DTOs, collection counts, wishlist/sold flags, set
+   membership, AI intake, or other shared workflow surfaces, the PR lists
+   the affected sibling workflows and proves the relevant contract with
+   automated tests where practical.
+8. **Config contracts**: any value a user/admin can configure in the UI
+   MUST be accepted by every API path the UI can submit it to, or the UI
+   MUST prevent the invalid submission with an explicit message.
+9. **Test coverage**: every new service method has ≥ 1 unit test.
+10. **Swagger**: every new or modified public handler has Swagger
    annotations (Principle III).
-8. **API contract sync**: if the API surface changed, `swag` is
+11. **API contract sync**: if the API surface changed, `swag` is
    regenerated AND the root `openapi.yaml` is updated (Phase 3).
-9. **ADR**: if a material design choice was made, an ADR is added in
+12. **ADR**: if a material design choice was made, an ADR is added in
    `docs/adr/`.
-10. **Tasks checked off**: the active `specs/NNN-*/tasks.md` items for
+13. **Tasks checked off**: the active `specs/NNN-*/tasks.md` items for
     this work are checked off.
-11. **Decisions captured**: any cross-cutting decision is written to
+14. **Decisions captured**: any cross-cutting decision is written to
     `.squad/decisions/inbox/`.
-12. **Simple Complete Changes**: the change is simple, complete, and
+15. **Simple Complete Changes**: the change is simple, complete, and
     proportional (Principle IV).
-13. **Secrets scan clean**: no credentials, tokens, or API keys in the
+16. **Secrets scan clean**: no credentials, tokens, or API keys in the
     diff.
-14. **Commit hygiene**: Conventional Commit prefix and (when
+17. **Commit hygiene**: Conventional Commit prefix and (when
     AI-assisted) `Co-authored-by: Copilot` trailer present.
-15. **PR self-check**: PR description cites the relevant Constitution
+18. **PR self-check**: PR description cites the relevant Constitution
     Principle(s) and lists this DoD as a checklist.
 
 ## §22. Amendment Process
@@ -523,5 +536,6 @@ plan's Complexity Tracking table.
 | 1.1.0 | 2026-04-28 | Brian | Gap closure: added Principles XI–XVI (Security Hardening, Authentication & Token Policy, PWA/Mobile Rules, Social & Privacy, Supply Chain & CI, Account Lifecycle). | — |
 | 2.0.0 | 2026-05-28 | Maximus (approved by Brian) | Added §0 Hierarchy of Authority, §17 Quality Gate, §18 AI Agent Operating Rules, §19 Documentation Requirements, §20 Audit & Continuous Improvement, §21 Definition of Done, §22 Amendment Process, §23 Revision History. All 16 Principles (I–XVI) preserved verbatim. | ADR 0001 (to be added in Phase 3) |
 | 3.0.0 | 2026-06-09 | Brian | Consolidated 17 principles into 9 streamlined principles and made Simple Complete Changes Principle IV. | ADR 0005 |
+| 3.1.0 | 2026-06-11 | Brian | Added workflow-contract, blast-radius, configurable-value, and exact regression coverage gates to reduce repeated user-flow regressions. | ADR 0006 |
 
-**Version**: 3.0.0 | **Ratified**: 2026-04-28 | **Last Amended**: 2026-06-09
+**Version**: 3.1.0 | **Ratified**: 2026-04-28 | **Last Amended**: 2026-06-11

--- a/docs/adr/0006-workflow-contract-regression-gates.md
+++ b/docs/adr/0006-workflow-contract-regression-gates.md
@@ -1,0 +1,42 @@
+# ADR 0006: Workflow Contract Regression Gates
+
+## Status
+
+ACCEPTED
+
+## Context
+
+Recent regressions have repeatedly broken user workflows even when unit tests,
+linting, CodeQL, and CI passed. The recurring failure mode is not a static code
+quality issue; it is contract drift between shared surfaces such as Admin
+settings, Vue forms, API DTOs, service validation, and persistence behavior.
+
+The coin Era regression is the concrete trigger: Admin `CoinEras` configured the
+Edit Coin dropdown, but the API update path validated against a different source
+of truth. Each layer looked reasonable in isolation, yet the user workflow
+failed.
+
+## Decision
+
+The constitution and PR template now require workflow-contract checks:
+
+1. Bug fixes must include a targeted regression test for the exact failing user
+   path, or explicitly document why automation is deferred.
+2. PRs touching shared workflow surfaces must list the affected blast radius and
+   sibling workflows checked.
+3. User/admin-configured UI values must be accepted by every API path the UI can
+   submit them to, or the UI must prevent the invalid submission with a clear
+   message.
+4. CI remains a necessary gate, but green CI is not considered proof that the
+   user workflow is safe unless the relevant workflow contract is covered.
+
+## Consequences
+
+- Regression fixes become slightly more expensive up front but harder to repeat.
+- PR descriptions must explain workflow contracts and blast radius instead of
+  only listing build/test commands.
+- Shared surfaces such as Add Coin, Edit Coin, Admin Settings, wishlist flags,
+  collection counts, set membership, and AI intake require sibling workflow
+  checks when touched.
+- CodeQL and static checks remain useful, but they are explicitly not a
+  substitute for workflow-contract coverage.

--- a/src/api/handlers/coin_handler_test.go
+++ b/src/api/handlers/coin_handler_test.go
@@ -30,7 +30,7 @@ func setupCoinHandlerTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to open test db: %v", err)
 	}
 	err = db.AutoMigrate(
-		&models.User{}, &models.StorageLocation{}, &models.Coin{}, &models.CoinImage{}, &models.CoinReference{}, &models.CatalogRegistry{},
+		&models.User{}, &models.StorageLocation{}, &models.Coin{}, &models.CoinImage{}, &models.CoinReference{}, &models.CatalogRegistry{}, &models.AppSetting{},
 		&models.ValueSnapshot{}, &models.CoinJournal{},
 		&models.CoinValueHistory{}, &models.CoinComment{},
 		&models.AvailabilityResult{}, &models.AuctionLot{},
@@ -89,10 +89,13 @@ func setupCoinHandlerRouter(t *testing.T) (*gin.Engine, *gorm.DB) {
 	coinReferenceRepo := repository.NewCoinReferenceRepository(db)
 	coinReferenceSvc := services.NewCoinReferenceService(coinReferenceRepo, catalogRegistryRepo)
 	storageLocationRepo := repository.NewStorageLocationRepository(db)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsSvc := services.NewSettingsService(settingsRepo)
 	coinSvc := services.NewCoinService(coinRepo, nil).
 		WithReferenceSupport(coinReferenceRepo, coinReferenceSvc).
 		WithStorageLocationSupport(storageLocationRepo).
-		WithCatalogRegistrySupport(catalogRegistryRepo)
+		WithCatalogRegistrySupport(catalogRegistryRepo).
+		WithSettingsSupport(settingsSvc)
 	handler := NewCoinHandler(coinRepo, coinSvc, services.NewLogger(100))
 
 	r := gin.New()
@@ -1053,6 +1056,7 @@ func TestCoinHandler_Update_CustomRegistryEraAccepted(t *testing.T) {
 	}).Error; err != nil {
 		t.Fatalf("failed to seed catalog registry: %v", err)
 	}
+
 	coin := models.Coin{Name: "Old Era", Category: models.CategoryRoman, Material: models.MaterialBronze, UserID: 1, Era: models.EraAncient}
 	db.Create(&coin)
 
@@ -1081,6 +1085,44 @@ func TestCoinHandler_Update_CustomRegistryEraAccepted(t *testing.T) {
 	}
 	if found.Era != models.Era("provincial") {
 		t.Fatalf("expected era provincial, got %q", found.Era)
+	}
+}
+
+func TestCoinHandler_Update_AdminConfiguredEraAccepted(t *testing.T) {
+	router, db := setupCoinHandlerRouter(t)
+	createTestUser(t, db, 1, "updater")
+
+	if err := repository.NewSettingsRepository(db).Upsert(services.SettingCoinEras, "Republican Rome\nRoman Empire\n500-480 BC"); err != nil {
+		t.Fatalf("failed to seed coin eras setting: %v", err)
+	}
+	coin := models.Coin{Name: "Old Era", Category: models.CategoryRoman, Material: models.MaterialBronze, UserID: 1, Era: models.EraAncient}
+	db.Create(&coin)
+
+	updates := map[string]interface{}{
+		"name":     "Updated Era",
+		"category": "Roman",
+		"material": "Bronze",
+		"era":      "Roman Empire",
+	}
+	body, _ := json.Marshal(updates)
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/coins/%d", coin.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(1))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for admin-configured era, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found: %v", err)
+	}
+	if found.Era != models.Era("Roman Empire") {
+		t.Fatalf("expected era Roman Empire, got %q", found.Era)
 	}
 }
 

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -219,7 +219,7 @@ func main() {
 		referenceMigrationSvc := services.NewReferenceMigrationService(database.DB, coinReferenceRepo, catalogRegistryRepo, journalRepo)
 		catalogRegistrySvc := services.NewCatalogRegistryService(catalogRegistryRepo)
 		catalogRegistryHandler := handlers.NewCatalogRegistryHandler(catalogRegistrySvc)
-		coinSvc := services.NewCoinService(coinRepo, notifSvc).WithReferenceSupport(coinReferenceRepo, coinReferenceSvc).WithStorageLocationSupport(storageLocationRepo).WithCatalogRegistrySupport(catalogRegistryRepo)
+		coinSvc := services.NewCoinService(coinRepo, notifSvc).WithReferenceSupport(coinReferenceRepo, coinReferenceSvc).WithStorageLocationSupport(storageLocationRepo).WithCatalogRegistrySupport(catalogRegistryRepo).WithSettingsSupport(settingsSvc)
 		coinHandler := handlers.NewCoinHandler(coinRepo, coinSvc, logger)
 		coinReferenceHandler := handlers.NewCoinReferenceHandler(coinReferenceRepo, coinReferenceSvc, referenceMigrationSvc)
 		coinIntakeSvc := services.NewCoinIntakeService(intakeDraftRepo, coinRepo, agentProxy, settingsSvc)

--- a/src/api/services/coin_service.go
+++ b/src/api/services/coin_service.go
@@ -29,6 +29,7 @@ type CoinService struct {
 	refSvc              *CoinReferenceService
 	storageLocationRepo *repository.StorageLocationRepository
 	catalogRegistryRepo *repository.CatalogRegistryRepository
+	settingsSvc         *SettingsService
 }
 
 // NewCoinService creates a new CoinService.
@@ -55,6 +56,12 @@ func (s *CoinService) WithStorageLocationSupport(storageLocationRepo *repository
 // WithCatalogRegistrySupport enables data-driven coin era validation.
 func (s *CoinService) WithCatalogRegistrySupport(catalogRegistryRepo *repository.CatalogRegistryRepository) *CoinService {
 	s.catalogRegistryRepo = catalogRegistryRepo
+	return s
+}
+
+// WithSettingsSupport enables validation against admin-configured coin properties.
+func (s *CoinService) WithSettingsSupport(settingsSvc *SettingsService) *CoinService {
+	s.settingsSvc = settingsSvc
 	return s
 }
 
@@ -291,6 +298,9 @@ func (s *CoinService) validateCoinEra(era models.Era) error {
 	if len(trimmed) > 64 {
 		return ErrCoinInvalidEra
 	}
+	if s.settingsSvc != nil && settingListContains(s.settingsSvc.GetSetting(SettingCoinEras), trimmed) {
+		return nil
+	}
 	if s.catalogRegistryRepo == nil {
 		return ErrCoinInvalidEra
 	}
@@ -302,4 +312,13 @@ func (s *CoinService) validateCoinEra(era models.Era) error {
 		return ErrCoinInvalidEra
 	}
 	return nil
+}
+
+func settingListContains(value, needle string) bool {
+	for _, line := range strings.Split(value, "\n") {
+		if strings.EqualFold(strings.TrimSpace(line), needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/src/api/services/coin_service_test.go
+++ b/src/api/services/coin_service_test.go
@@ -19,7 +19,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to open test db: %v", err)
 	}
 	err = db.AutoMigrate(
-		&models.User{}, &models.Coin{}, &models.CoinImage{}, &models.CoinReference{}, &models.CatalogRegistry{},
+		&models.User{}, &models.Coin{}, &models.CoinImage{}, &models.CoinReference{}, &models.CatalogRegistry{}, &models.AppSetting{},
 		&models.StorageLocation{}, &models.ValueSnapshot{}, &models.CoinJournal{},
 		&models.CoinValueHistory{}, &models.CoinComment{},
 		&models.AvailabilityResult{}, &models.AuctionLot{},
@@ -40,6 +40,12 @@ func newTestCoinServiceWithCatalogRegistry(db *gorm.DB) *CoinService {
 	repo := repository.NewCoinRepository(db)
 	catalogRepo := repository.NewCatalogRegistryRepository(db)
 	return NewCoinService(repo, nil).WithCatalogRegistrySupport(catalogRepo)
+}
+
+func newTestCoinServiceWithSettings(db *gorm.DB) *CoinService {
+	repo := repository.NewCoinRepository(db)
+	settingsRepo := repository.NewSettingsRepository(db)
+	return NewCoinService(repo, nil).WithSettingsSupport(NewSettingsService(settingsRepo))
 }
 
 func newTestCoinServiceWithStorage(db *gorm.DB) *CoinService {
@@ -469,6 +475,33 @@ func TestUpdateCoin_AcceptsCustomEraFromCatalogRegistry(t *testing.T) {
 	}
 	if found.Era != models.Era("provincial") {
 		t.Fatalf("expected era provincial, got %q", found.Era)
+	}
+}
+
+func TestUpdateCoin_AcceptsAdminConfiguredEra(t *testing.T) {
+	db := setupTestDB(t)
+	svc := newTestCoinServiceWithSettings(db)
+	settingsRepo := repository.NewSettingsRepository(db)
+	if err := settingsRepo.Upsert(SettingCoinEras, "Republican Rome\nRoman Empire\n500-480 BC"); err != nil {
+		t.Fatalf("failed to seed coin eras setting: %v", err)
+	}
+
+	coin := &models.Coin{Name: "Imperial Bronze", UserID: 1, Era: models.EraAncient}
+	if err := svc.CreateCoin(coin); err != nil {
+		t.Fatalf("setup: CreateCoin failed: %v", err)
+	}
+
+	updates := &models.Coin{Era: models.Era("Roman Empire")}
+	if err := svc.UpdateCoin(coin, updates, 1, "manual"); err != nil {
+		t.Fatalf("UpdateCoin should accept admin-configured era: %v", err)
+	}
+
+	var found models.Coin
+	if err := db.First(&found, coin.ID).Error; err != nil {
+		t.Fatalf("coin not found: %v", err)
+	}
+	if found.Era != models.Era("Roman Empire") {
+		t.Fatalf("expected era Roman Empire, got %q", found.Era)
 	}
 }
 

--- a/src/web/src/components/admin/AdminCoinPropertiesSection.vue
+++ b/src/web/src/components/admin/AdminCoinPropertiesSection.vue
@@ -1,41 +1,70 @@
 <template>
   <section class="admin-section card">
-    <h2>Coin Properties</h2>
-    <p class="section-description">Configure category and era dropdown values for coin forms. Enter one value per line.</p>
-    
-    <form @submit.prevent="$emit('save')">
-      <div class="form-group">
-        <label class="form-label">Category Options</label>
-        <textarea 
-          v-model="localCategoryOptions" 
-          class="form-textarea property-textarea" 
-          rows="6"
+    <div class="section-heading">
+      <div>
+        <p class="section-label">Collection metadata</p>
+        <h2>Coin Properties</h2>
+      </div>
+      <button type="submit" form="coin-properties-form" class="btn btn-primary btn-sm" :disabled="saving">
+        {{ saving ? 'Saving...' : 'Save Properties' }}
+      </button>
+    </div>
+
+    <p class="section-description">
+      Configure the category and era choices shown on Add Coin and Edit Coin. Enter one value per line.
+    </p>
+
+    <form id="coin-properties-form" class="properties-form" @submit.prevent="$emit('save')">
+      <div class="property-card">
+        <div class="property-card-header">
+          <div>
+            <label class="form-label" for="category-options">Category Options</label>
+            <p class="form-hint">One category per line. Empty lines are ignored.</p>
+          </div>
+          <span class="chip-sm">{{ categoryPreview.length }} options</span>
+        </div>
+        <textarea
+          id="category-options"
+          v-model="localCategoryOptions"
+          class="form-textarea property-textarea"
+          rows="7"
           placeholder="Roman&#10;Greek&#10;Byzantine&#10;Modern&#10;Other"
         />
-        <span class="form-hint">One category per line. Empty lines will be ignored.</span>
+        <div class="option-preview" aria-label="Category option preview">
+          <span v-for="option in categoryPreview" :key="option" class="chip-sm">{{ option }}</span>
+        </div>
       </div>
 
-      <div class="form-group">
-        <label class="form-label">Era Options</label>
-        <textarea 
-          v-model="localEraOptions" 
-          class="form-textarea property-textarea" 
-          rows="4"
+      <div class="property-card">
+        <div class="property-card-header">
+          <div>
+            <label class="form-label" for="era-options">Era Options</label>
+            <p class="form-hint">One era per line. The coin form adds Unspecified automatically.</p>
+          </div>
+          <span class="chip-sm">{{ eraPreview.length }} options</span>
+        </div>
+        <textarea
+          id="era-options"
+          v-model="localEraOptions"
+          class="form-textarea property-textarea"
+          rows="7"
           placeholder="ancient&#10;medieval&#10;modern"
         />
-        <span class="form-hint">One era per line. An "Unspecified" option will be added automatically.</span>
+        <div class="option-preview" aria-label="Era option preview">
+          <span class="chip-sm">Unspecified</span>
+          <span v-for="option in eraPreview" :key="option" class="chip-sm">{{ option }}</span>
+        </div>
       </div>
 
       <p v-if="msg" class="msg" :class="{ error }">{{ msg }}</p>
-      <button type="submit" class="btn btn-primary btn-sm" :disabled="saving">
-        {{ saving ? 'Saving...' : 'Save Coin Properties' }}
-      </button>
     </form>
   </section>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { parseOptionList } from '@/utils/options'
+import { CATEGORIES, COIN_ERAS } from '@/types'
 
 const props = defineProps<{
   categoryOptions: string
@@ -59,18 +88,84 @@ watch(() => props.eraOptions, (v) => { localEraOptions.value = v })
 
 watch(localCategoryOptions, (v) => emit('update:categoryOptions', v))
 watch(localEraOptions, (v) => emit('update:eraOptions', v))
+
+const categoryPreview = computed(() => parseOptionList(localCategoryOptions.value, CATEGORIES))
+const eraPreview = computed(() => parseOptionList(localEraOptions.value, COIN_ERAS))
 </script>
 
 <style scoped>
+.section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+}
+
 .section-description {
   font-size: 0.9rem;
   color: var(--text-secondary);
-  margin: -0.5rem 0 1.5rem;
+  margin: 0 0 1.5rem;
+}
+
+.properties-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.property-card {
+  background: var(--bg-card-hover);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+}
+
+.property-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.form-label {
+  color: var(--text-heading);
+}
+
+.form-hint {
+  display: block;
+  margin: 0.25rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
 }
 
 .property-textarea {
-  font-family: 'Courier New', Courier, monospace;
+  min-height: 11rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: inherit;
   font-size: 0.85rem;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.property-textarea:focus {
+  border-color: var(--accent-gold);
+  box-shadow: var(--shadow-glow);
+  outline: none;
+}
+
+.option-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
 }
 
 .msg {
@@ -81,5 +176,12 @@ watch(localEraOptions, (v) => emit('update:eraOptions', v))
 
 .msg.error {
   color: var(--cat-byzantine);
+}
+
+@media (max-width: 768px) {
+  .section-heading,
+  .property-card-header {
+    flex-direction: column;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary- fix coin update era validation to accept values from the admin-configured `CoinEras` setting- keep catalog-registry era support and legacy unchanged-era behavior intact- add service and handler regression tests for `PUT /coins/:id` with an admin-configured era- refresh Admin → Coin Properties with tokenized cards, preview chips, and a cleaner save affordance## Constitution / Quality Gate- Principle IV: simple complete fix for the exact regression path- §17: local quality gate completed## Validation- `go test -v ./services -run "TestUpdateCoin_AcceptsAdminConfiguredEra|TestUpdateCoin_AcceptsCustomEraFromCatalogRegistry|TestUpdateCoin_RejectsUnsupportedEraWhenCatalogRegistryEnabled"`- `go test -v ./handlers -run "TestCoinHandler_Update_AdminConfiguredEraAccepted|TestCoinHandler_Update_CustomRegistryEraAccepted|TestCoinHandler_Update_PreservesUnchangedLegacyEra"`- `go test ./...`- `go vet ./...`- `go build ./...`- `npm.cmd run build`- `npm.cmd run lint` (passes with existing warnings)
---

## Process hardening follow-up

- Constitution: Principle IV + §17 Quality Gate + §21 Definition of Done
- ADR added: `docs/adr/0006-workflow-contract-regression-gates.md`
- Workflow contract(s): Admin-configured coin properties must round-trip through frontend forms and API update validation; future regressions require exact failing-path regression coverage.
- Blast radius / sibling workflows checked: Edit Coin era update path and Admin Coin Properties configuration contract.