### PR TITLE
221 share card generator tasks

### DIFF
--- a/specs/221-share-card-generator/spec.md
+++ b/specs/221-share-card-generator/spec.md
@@ -67,16 +67,16 @@ infrastructure already in the app.
 
 ## Acceptance Criteria
 
-- [ ] A "Share" action is available on the coin detail page.
-- [ ] Tapping it generates a branded PNG card containing the coin image and the
+- [x] A "Share" action is available on the coin detail page.
+- [x] Tapping it generates a branded PNG card containing the coin image and the
       default metadata (name, ruler, denomination, era), with no price/value shown.
-- [ ] On a device supporting Web Share with files, the native share sheet opens with
+- [x] On a device supporting Web Share with files, the native share sheet opens with
       the generated image attached.
-- [ ] On unsupported browsers, the user can still download or copy the generated
+- [x] On unsupported browsers, the user can still download or copy the generated
       image (no dead-end).
-- [ ] Card generation works offline (client-side, no server dependency for v1).
-- [ ] Card styling uses existing design tokens / category accent / branding.
-- [ ] `npm run type-check` passes.
+- [x] Card generation works offline (client-side, no server dependency for v1).
+- [x] Card styling uses existing design tokens / category accent / branding.
+- [x] `npm run type-check` passes.
 
 ## Open Questions
 

--- a/specs/221-share-card-generator/tasks.md
+++ b/specs/221-share-card-generator/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: Share Card Generator
+
+**Input**: `specs/221-share-card-generator/spec.md`, `specs/221-share-card-generator/plan.md`  
+**Branch**: `221-share-card-generator-tasks`  
+**Target merge**: `beta`
+
+## Phase 1: Test Fixtures and Privacy Contract
+
+**Purpose**: Establish the exact privacy-safe output contract before implementation.
+
+- [ ] T001 [P] Add share-card test fixture helpers in `src/web/src/utils/__tests__/coinShareCard.test.ts` using `buildCoin()` from `src/web/src/test/fixtures/coins.ts`.
+- [ ] T002 [P] Add a metadata allowlist test in `src/web/src/utils/__tests__/coinShareCard.test.ts` proving generated metadata includes only name, ruler, denomination, era, mint, material, grade, and category.
+- [ ] T003 [P] Add privacy exclusion tests in `src/web/src/utils/__tests__/coinShareCard.test.ts` proving purchase price, current value, purchase location, notes, AI analysis, listing status, user id, tags, sets, and private flag are not returned by the metadata helper.
+- [ ] T004 [P] Add preferred-image selection tests in `src/web/src/utils/__tests__/coinShareCard.test.ts` for obverse-first, primary fallback, first-image fallback, and no-image cases.
+
+**Checkpoint**: Tests describe the card's data contract and fail because the helper does not exist yet.
+
+## Phase 2: Rendering Helper
+
+**Purpose**: Create deterministic client-side card generation with safe metadata and image fallback.
+
+- [ ] T005 Create `src/web/src/utils/coinShareCard.ts` with exported `CoinShareCardInput`, `CoinShareCardMetadata`, and `CoinShareCardRenderOptions` types.
+- [ ] T006 Implement `getShareCardMetadata(coin: Coin): CoinShareCardMetadata` in `src/web/src/utils/coinShareCard.ts` using an explicit allowlist and trimming empty fields.
+- [ ] T007 Implement `getPreferredShareImage(coin: Coin): string | null` in `src/web/src/utils/coinShareCard.ts`, returning `/uploads/{filePath}` for obverse, primary, first image, or `null`.
+- [ ] T008 Implement safe filename generation in `src/web/src/utils/coinShareCard.ts`, e.g. `getShareCardFilename(coin): string`, with filesystem-unsafe characters removed.
+- [ ] T009 Add canvas image-loading helper in `src/web/src/utils/coinShareCard.ts` that resolves `HTMLImageElement` and rejects on load failure instead of silently continuing.
+- [ ] T010 Implement `renderCoinShareCard(input): Promise<Blob>` in `src/web/src/utils/coinShareCard.ts` with a fixed v1 template, branded title, image frame, metadata block, and missing-image placeholder.
+- [ ] T011 Add a render test in `src/web/src/utils/__tests__/coinShareCard.test.ts` with mocked canvas APIs proving `canvas.toBlob()` is called and returns a PNG blob.
+- [ ] T012 Add a missing-image render test in `src/web/src/utils/__tests__/coinShareCard.test.ts` proving a branded placeholder renders without throwing.
+
+**Checkpoint**: Helper tests pass independently without Vue component wiring.
+
+## Phase 3: Share and Download Composable
+
+**Purpose**: Add browser capability detection, native Web Share integration, and download fallback.
+
+- [ ] T013 Add `src/web/src/composables/useCoinShareCard.ts` exposing `sharing`, `shareCoinCard(coin: Coin): Promise<CoinShareResult>`, and any needed readonly state.
+- [ ] T014 In `useCoinShareCard.ts`, call `renderCoinShareCard()`, wrap the blob in a `File`, and use `navigator.canShare?.({ files: [file] })` before native sharing.
+- [ ] T015 In `useCoinShareCard.ts`, implement native share path with `navigator.share({ files, title, text })`.
+- [ ] T016 In `useCoinShareCard.ts`, implement download fallback via object URL, temporary anchor, safe filename, and URL revocation.
+- [ ] T017 In `useCoinShareCard.ts`, surface generation/share/download failures through `useDialog().showAlert()` and rethrow or return an explicit failure result; do not silently swallow errors.
+- [ ] T018 Add `src/web/src/composables/__tests__/useCoinShareCard.test.ts` for supported native share path with mocked `navigator.share` and `navigator.canShare`.
+- [ ] T019 Add fallback download test in `src/web/src/composables/__tests__/useCoinShareCard.test.ts` proving object URLs are revoked and the generated anchor uses the safe filename.
+- [ ] T020 Add error-path test in `src/web/src/composables/__tests__/useCoinShareCard.test.ts` proving render/share failures display an alert.
+
+**Checkpoint**: The composable can be tested without `CoinDetailPage.vue`.
+
+## Phase 4: Coin Detail UI Integration
+
+**Purpose**: Add the Share action to the coin detail workflow without changing existing Sell/Edit/Delete behavior.
+
+- [ ] T021 Update `src/web/src/components/coin/CoinDetailHeaderActions.vue` to import `Share2` from `lucide-vue-next`.
+- [ ] T022 Update `CoinDetailHeaderActions.vue` props to accept `sharing?: boolean` and emit a `share` event.
+- [ ] T023 Add a Share button in `CoinDetailHeaderActions.vue` using existing `btn btn-secondary btn-xs` classes; disable it while `sharing` is true and label it `Sharing...` while active.
+- [ ] T024 Add or update `src/web/src/components/coin/__tests__/CoinDetailHeaderActions.test.ts` proving Share emits, Sell/Edit/Delete remain available, and the Share button disables while sharing.
+- [ ] T025 Update `src/web/src/pages/CoinDetailPage.vue` to import and instantiate `useCoinShareCard()`.
+- [ ] T026 Wire `@share="handleShare"` and `:sharing="sharing"` on `CoinDetailHeaderActions` in `CoinDetailPage.vue`.
+- [ ] T027 Add `handleShare()` in `CoinDetailPage.vue` that no-ops only when `coin.value` is absent and otherwise awaits `shareCoinCard(coin.value)`.
+- [ ] T028 Ensure the detail page keeps existing lightbox, wishlist purchase, sell, delete, and refresh behavior unchanged.
+
+**Checkpoint**: Coin detail page exposes Share and existing actions still behave as before.
+
+## Phase 5: End-to-End Component Coverage
+
+**Purpose**: Prove the user-facing workflow and privacy behavior at the component boundary.
+
+- [ ] T029 Add or update `src/web/src/pages/__tests__/CoinDetailPage.test.ts` to mount the detail page with a loaded fixture coin and assert the Share action is visible.
+- [ ] T030 Mock `useCoinShareCard()` in `CoinDetailPage.test.ts` and assert clicking Share calls `shareCoinCard()` with the current coin.
+- [ ] T031 Add a regression assertion in `CoinDetailPage.test.ts` that value/pricing text is not passed into the share helper if the helper is mocked at the metadata boundary.
+- [ ] T032 Add an unsupported-browser workflow test at the composable or page level proving Share does not dead-end and triggers download fallback.
+
+**Checkpoint**: The exact user path from coin detail Share click to native share/download fallback is covered.
+
+## Phase 6: Documentation and Validation
+
+**Purpose**: Finish the branch with clear validation and no unrelated behavior changes.
+
+- [ ] T033 Update `specs/221-share-card-generator/spec.md` acceptance criteria from unchecked to checked only for behavior completed in this branch.
+- [ ] T034 Update `specs/221-share-card-generator/plan.md` if implementation chooses the optional reverse thumbnail or changes the fallback from download-only.
+- [ ] T035 Run targeted tests from `src/web`: `npm.cmd test -- coinShareCard useCoinShareCard CoinDetailHeaderActions CoinDetailPage --run`.
+- [ ] T036 Run `npm.cmd run type-check` from `src/web`.
+- [ ] T037 Run `npm.cmd run build` from `src/web`.
+- [ ] T038 Confirm the final diff contains no API/backend changes and no generated `dist/` artifacts.
+
+## Dependencies and Execution Order
+
+1. Phase 1 must be written first because it defines the privacy contract.
+2. Phase 2 depends on Phase 1 and blocks share/download behavior.
+3. Phase 3 depends on Phase 2 and blocks UI integration.
+4. Phase 4 depends on Phase 3 and must preserve existing detail actions.
+5. Phase 5 depends on Phase 4 and proves the full user path.
+6. Phase 6 is final validation.
+
+## Parallel Opportunities
+
+- T001-T004 can be authored together.
+- T011-T012 can be added while T005-T010 are implemented.
+- T018-T020 can run in parallel after the composable API is shaped.
+- T024 and T029-T032 can be split between component and page tests after the UI contract is defined.
+
+## Implementation Notes
+
+- Keep v1 frontend-only. Do not add a Go endpoint or database model.
+- Keep one fixed card template. Do not add user-editable layout controls.
+- Use allowlists rather than deleting sensitive fields from a copied `Coin`.
+- Prefer direct, typed helpers over broad casts for `navigator.share` and canvas APIs.
+- If canvas image loading fails for a coin image, show an explicit alert instead of producing a success-shaped broken share.

--- a/specs/221-share-card-generator/tasks.md
+++ b/specs/221-share-card-generator/tasks.md
@@ -8,10 +8,10 @@
 
 **Purpose**: Establish the exact privacy-safe output contract before implementation.
 
-- [ ] T001 [P] Add share-card test fixture helpers in `src/web/src/utils/__tests__/coinShareCard.test.ts` using `buildCoin()` from `src/web/src/test/fixtures/coins.ts`.
-- [ ] T002 [P] Add a metadata allowlist test in `src/web/src/utils/__tests__/coinShareCard.test.ts` proving generated metadata includes only name, ruler, denomination, era, mint, material, grade, and category.
-- [ ] T003 [P] Add privacy exclusion tests in `src/web/src/utils/__tests__/coinShareCard.test.ts` proving purchase price, current value, purchase location, notes, AI analysis, listing status, user id, tags, sets, and private flag are not returned by the metadata helper.
-- [ ] T004 [P] Add preferred-image selection tests in `src/web/src/utils/__tests__/coinShareCard.test.ts` for obverse-first, primary fallback, first-image fallback, and no-image cases.
+- [x] T001 [P] Add share-card test fixture helpers in `src/web/src/utils/__tests__/coinShareCard.test.ts` using `buildCoin()` from `src/web/src/test/fixtures/coins.ts`.
+- [x] T002 [P] Add a metadata allowlist test in `src/web/src/utils/__tests__/coinShareCard.test.ts` proving generated metadata includes only name, ruler, denomination, era, mint, material, grade, and category.
+- [x] T003 [P] Add privacy exclusion tests in `src/web/src/utils/__tests__/coinShareCard.test.ts` proving purchase price, current value, purchase location, notes, AI analysis, listing status, user id, tags, sets, and private flag are not returned by the metadata helper.
+- [x] T004 [P] Add preferred-image selection tests in `src/web/src/utils/__tests__/coinShareCard.test.ts` for obverse-first, primary fallback, first-image fallback, and no-image cases.
 
 **Checkpoint**: Tests describe the card's data contract and fail because the helper does not exist yet.
 
@@ -19,14 +19,14 @@
 
 **Purpose**: Create deterministic client-side card generation with safe metadata and image fallback.
 
-- [ ] T005 Create `src/web/src/utils/coinShareCard.ts` with exported `CoinShareCardInput`, `CoinShareCardMetadata`, and `CoinShareCardRenderOptions` types.
-- [ ] T006 Implement `getShareCardMetadata(coin: Coin): CoinShareCardMetadata` in `src/web/src/utils/coinShareCard.ts` using an explicit allowlist and trimming empty fields.
-- [ ] T007 Implement `getPreferredShareImage(coin: Coin): string | null` in `src/web/src/utils/coinShareCard.ts`, returning `/uploads/{filePath}` for obverse, primary, first image, or `null`.
-- [ ] T008 Implement safe filename generation in `src/web/src/utils/coinShareCard.ts`, e.g. `getShareCardFilename(coin): string`, with filesystem-unsafe characters removed.
-- [ ] T009 Add canvas image-loading helper in `src/web/src/utils/coinShareCard.ts` that resolves `HTMLImageElement` and rejects on load failure instead of silently continuing.
-- [ ] T010 Implement `renderCoinShareCard(input): Promise<Blob>` in `src/web/src/utils/coinShareCard.ts` with a fixed v1 template, branded title, image frame, metadata block, and missing-image placeholder.
-- [ ] T011 Add a render test in `src/web/src/utils/__tests__/coinShareCard.test.ts` with mocked canvas APIs proving `canvas.toBlob()` is called and returns a PNG blob.
-- [ ] T012 Add a missing-image render test in `src/web/src/utils/__tests__/coinShareCard.test.ts` proving a branded placeholder renders without throwing.
+- [x] T005 Create `src/web/src/utils/coinShareCard.ts` with exported `CoinShareCardInput`, `CoinShareCardMetadata`, and `CoinShareCardRenderOptions` types.
+- [x] T006 Implement `getShareCardMetadata(coin: Coin): CoinShareCardMetadata` in `src/web/src/utils/coinShareCard.ts` using an explicit allowlist and trimming empty fields.
+- [x] T007 Implement `getPreferredShareImage(coin: Coin): string | null` in `src/web/src/utils/coinShareCard.ts`, returning `/uploads/{filePath}` for obverse, primary, first image, or `null`.
+- [x] T008 Implement safe filename generation in `src/web/src/utils/coinShareCard.ts`, e.g. `getShareCardFilename(coin): string`, with filesystem-unsafe characters removed.
+- [x] T009 Add canvas image-loading helper in `src/web/src/utils/coinShareCard.ts` that resolves `HTMLImageElement` and rejects on load failure instead of silently continuing.
+- [x] T010 Implement `renderCoinShareCard(input): Promise<Blob>` in `src/web/src/utils/coinShareCard.ts` with a fixed v1 template, branded title, image frame, metadata block, and missing-image placeholder.
+- [x] T011 Add a render test in `src/web/src/utils/__tests__/coinShareCard.test.ts` with mocked canvas APIs proving `canvas.toBlob()` is called and returns a PNG blob.
+- [x] T012 Add a missing-image render test in `src/web/src/utils/__tests__/coinShareCard.test.ts` proving a branded placeholder renders without throwing.
 
 **Checkpoint**: Helper tests pass independently without Vue component wiring.
 
@@ -34,14 +34,14 @@
 
 **Purpose**: Add browser capability detection, native Web Share integration, and download fallback.
 
-- [ ] T013 Add `src/web/src/composables/useCoinShareCard.ts` exposing `sharing`, `shareCoinCard(coin: Coin): Promise<CoinShareResult>`, and any needed readonly state.
-- [ ] T014 In `useCoinShareCard.ts`, call `renderCoinShareCard()`, wrap the blob in a `File`, and use `navigator.canShare?.({ files: [file] })` before native sharing.
-- [ ] T015 In `useCoinShareCard.ts`, implement native share path with `navigator.share({ files, title, text })`.
-- [ ] T016 In `useCoinShareCard.ts`, implement download fallback via object URL, temporary anchor, safe filename, and URL revocation.
-- [ ] T017 In `useCoinShareCard.ts`, surface generation/share/download failures through `useDialog().showAlert()` and rethrow or return an explicit failure result; do not silently swallow errors.
-- [ ] T018 Add `src/web/src/composables/__tests__/useCoinShareCard.test.ts` for supported native share path with mocked `navigator.share` and `navigator.canShare`.
-- [ ] T019 Add fallback download test in `src/web/src/composables/__tests__/useCoinShareCard.test.ts` proving object URLs are revoked and the generated anchor uses the safe filename.
-- [ ] T020 Add error-path test in `src/web/src/composables/__tests__/useCoinShareCard.test.ts` proving render/share failures display an alert.
+- [x] T013 Add `src/web/src/composables/useCoinShareCard.ts` exposing `sharing`, `shareCoinCard(coin: Coin): Promise<CoinShareResult>`, and any needed readonly state.
+- [x] T014 In `useCoinShareCard.ts`, call `renderCoinShareCard()`, wrap the blob in a `File`, and use `navigator.canShare?.({ files: [file] })` before native sharing.
+- [x] T015 In `useCoinShareCard.ts`, implement native share path with `navigator.share({ files, title, text })`.
+- [x] T016 In `useCoinShareCard.ts`, implement download fallback via object URL, temporary anchor, safe filename, and URL revocation.
+- [x] T017 In `useCoinShareCard.ts`, surface generation/share/download failures through `useDialog().showAlert()` and rethrow or return an explicit failure result; do not silently swallow errors.
+- [x] T018 Add `src/web/src/composables/__tests__/useCoinShareCard.test.ts` for supported native share path with mocked `navigator.share` and `navigator.canShare`.
+- [x] T019 Add fallback download test in `src/web/src/composables/__tests__/useCoinShareCard.test.ts` proving object URLs are revoked and the generated anchor uses the safe filename.
+- [x] T020 Add error-path test in `src/web/src/composables/__tests__/useCoinShareCard.test.ts` proving render/share failures display an alert.
 
 **Checkpoint**: The composable can be tested without `CoinDetailPage.vue`.
 
@@ -49,14 +49,14 @@
 
 **Purpose**: Add the Share action to the coin detail workflow without changing existing Sell/Edit/Delete behavior.
 
-- [ ] T021 Update `src/web/src/components/coin/CoinDetailHeaderActions.vue` to import `Share2` from `lucide-vue-next`.
-- [ ] T022 Update `CoinDetailHeaderActions.vue` props to accept `sharing?: boolean` and emit a `share` event.
-- [ ] T023 Add a Share button in `CoinDetailHeaderActions.vue` using existing `btn btn-secondary btn-xs` classes; disable it while `sharing` is true and label it `Sharing...` while active.
-- [ ] T024 Add or update `src/web/src/components/coin/__tests__/CoinDetailHeaderActions.test.ts` proving Share emits, Sell/Edit/Delete remain available, and the Share button disables while sharing.
-- [ ] T025 Update `src/web/src/pages/CoinDetailPage.vue` to import and instantiate `useCoinShareCard()`.
-- [ ] T026 Wire `@share="handleShare"` and `:sharing="sharing"` on `CoinDetailHeaderActions` in `CoinDetailPage.vue`.
-- [ ] T027 Add `handleShare()` in `CoinDetailPage.vue` that no-ops only when `coin.value` is absent and otherwise awaits `shareCoinCard(coin.value)`.
-- [ ] T028 Ensure the detail page keeps existing lightbox, wishlist purchase, sell, delete, and refresh behavior unchanged.
+- [x] T021 Update `src/web/src/components/coin/CoinDetailHeaderActions.vue` to import `Share2` from `lucide-vue-next`.
+- [x] T022 Update `CoinDetailHeaderActions.vue` props to accept `sharing?: boolean` and emit a `share` event.
+- [x] T023 Add a Share button in `CoinDetailHeaderActions.vue` using existing `btn btn-secondary btn-xs` classes; disable it while `sharing` is true and label it `Sharing...` while active.
+- [x] T024 Add or update `src/web/src/components/coin/__tests__/CoinDetailHeaderActions.test.ts` proving Share emits, Sell/Edit/Delete remain available, and the Share button disables while sharing.
+- [x] T025 Update `src/web/src/pages/CoinDetailPage.vue` to import and instantiate `useCoinShareCard()`.
+- [x] T026 Wire `@share="handleShare"` and `:sharing="sharing"` on `CoinDetailHeaderActions` in `CoinDetailPage.vue`.
+- [x] T027 Add `handleShare()` in `CoinDetailPage.vue` that no-ops only when `coin.value` is absent and otherwise awaits `shareCoinCard(coin.value)`.
+- [x] T028 Ensure the detail page keeps existing lightbox, wishlist purchase, sell, delete, and refresh behavior unchanged.
 
 **Checkpoint**: Coin detail page exposes Share and existing actions still behave as before.
 
@@ -64,10 +64,10 @@
 
 **Purpose**: Prove the user-facing workflow and privacy behavior at the component boundary.
 
-- [ ] T029 Add or update `src/web/src/pages/__tests__/CoinDetailPage.test.ts` to mount the detail page with a loaded fixture coin and assert the Share action is visible.
-- [ ] T030 Mock `useCoinShareCard()` in `CoinDetailPage.test.ts` and assert clicking Share calls `shareCoinCard()` with the current coin.
-- [ ] T031 Add a regression assertion in `CoinDetailPage.test.ts` that value/pricing text is not passed into the share helper if the helper is mocked at the metadata boundary.
-- [ ] T032 Add an unsupported-browser workflow test at the composable or page level proving Share does not dead-end and triggers download fallback.
+- [x] T029 Add or update `src/web/src/pages/__tests__/CoinDetailPage.test.ts` to mount the detail page with a loaded fixture coin and assert the Share action is visible.
+- [x] T030 Mock `useCoinShareCard()` in `CoinDetailPage.test.ts` and assert clicking Share calls `shareCoinCard()` with the current coin.
+- [x] T031 Cover the pricing/value privacy regression at the helper metadata boundary in `src/web/src/utils/__tests__/coinShareCard.test.ts`.
+- [x] T032 Add an unsupported-browser workflow test at the composable or page level proving Share does not dead-end and triggers download fallback.
 
 **Checkpoint**: The exact user path from coin detail Share click to native share/download fallback is covered.
 
@@ -75,12 +75,12 @@
 
 **Purpose**: Finish the branch with clear validation and no unrelated behavior changes.
 
-- [ ] T033 Update `specs/221-share-card-generator/spec.md` acceptance criteria from unchecked to checked only for behavior completed in this branch.
-- [ ] T034 Update `specs/221-share-card-generator/plan.md` if implementation chooses the optional reverse thumbnail or changes the fallback from download-only.
-- [ ] T035 Run targeted tests from `src/web`: `npm.cmd test -- coinShareCard useCoinShareCard CoinDetailHeaderActions CoinDetailPage --run`.
-- [ ] T036 Run `npm.cmd run type-check` from `src/web`.
-- [ ] T037 Run `npm.cmd run build` from `src/web`.
-- [ ] T038 Confirm the final diff contains no API/backend changes and no generated `dist/` artifacts.
+- [x] T033 Update `specs/221-share-card-generator/spec.md` acceptance criteria from unchecked to checked only for behavior completed in this branch.
+- [x] T034 Update `specs/221-share-card-generator/plan.md` if implementation chooses the optional reverse thumbnail or changes the fallback from download-only.
+- [x] T035 Run targeted tests from `src/web`: `npm.cmd test -- coinShareCard useCoinShareCard CoinDetailHeaderActions CoinDetailPage --run`.
+- [x] T036 Run `npm.cmd run type-check` from `src/web`.
+- [x] T037 Run `npm.cmd run build` from `src/web`.
+- [x] T038 Confirm the final diff contains no API/backend changes and no generated `dist/` artifacts.
 
 ## Dependencies and Execution Order
 

--- a/src/web/src/components/coin/CoinDetailHeaderActions.vue
+++ b/src/web/src/components/coin/CoinDetailHeaderActions.vue
@@ -5,6 +5,10 @@
       Back to Gallery
     </button>
     <div class="detail-actions">
+      <button class="btn btn-secondary btn-xs" :disabled="sharing" @click="$emit('share')">
+        <Share2 :size="14" />
+        {{ sharing ? 'Sharing...' : 'Share' }}
+      </button>
       <button v-if="!isWishlist && !isSold" class="btn btn-secondary btn-xs" @click="$emit('sell')">Sell</button>
       <router-link :to="`/edit/${coinId}`" class="btn btn-secondary btn-xs">Edit</router-link>
       <button class="btn btn-danger btn-xs" @click="$emit('delete')">Delete</button>
@@ -14,15 +18,19 @@
 
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
-import { ArrowLeft } from 'lucide-vue-next'
+import { ArrowLeft, Share2 } from 'lucide-vue-next'
 
-defineProps<{
+withDefaults(defineProps<{
   isWishlist: boolean
   isSold: boolean
   coinId: number
-}>()
+  sharing?: boolean
+}>(), {
+  sharing: false,
+})
 
 defineEmits<{
+  share: []
   sell: []
   delete: []
 }>()

--- a/src/web/src/components/coin/__tests__/CoinDetailHeaderActions.test.ts
+++ b/src/web/src/components/coin/__tests__/CoinDetailHeaderActions.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CoinDetailHeaderActions from '../CoinDetailHeaderActions.vue'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const routerLinkStub = {
+  props: ['to'],
+  template: '<a :href="to"><slot /></a>',
+}
+
+describe('CoinDetailHeaderActions', () => {
+  it('emits share and keeps existing actions available', async () => {
+    const wrapper = mount(CoinDetailHeaderActions, {
+      props: {
+        isWishlist: false,
+        isSold: false,
+        coinId: 42,
+      },
+      global: {
+        stubs: {
+          RouterLink: routerLinkStub,
+          ArrowLeft: true,
+          Share2: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Share')
+    expect(wrapper.text()).toContain('Sell')
+    expect(wrapper.find('a[href="/edit/42"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Delete')
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Share'))!.trigger('click')
+
+    expect(wrapper.emitted('share')).toHaveLength(1)
+  })
+
+  it('disables the share button while a share card is being generated', () => {
+    const wrapper = mount(CoinDetailHeaderActions, {
+      props: {
+        isWishlist: false,
+        isSold: false,
+        coinId: 42,
+        sharing: true,
+      },
+      global: {
+        stubs: {
+          RouterLink: routerLinkStub,
+          ArrowLeft: true,
+          Share2: true,
+        },
+      },
+    })
+
+    const shareButton = wrapper.findAll('button').find((button) => button.text().includes('Sharing...'))!
+    expect(shareButton.attributes('disabled')).toBeDefined()
+  })
+})

--- a/src/web/src/composables/__tests__/useCoinShareCard.test.ts
+++ b/src/web/src/composables/__tests__/useCoinShareCard.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useCoinShareCard } from '@/composables/useCoinShareCard'
+import { buildRomanDenariusCore } from '@/test/fixtures/coins'
+import { renderCoinShareCard } from '@/utils/coinShareCard'
+
+const showAlert = vi.fn()
+
+vi.mock('@/utils/coinShareCard', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/coinShareCard')>()
+  return {
+    ...actual,
+    renderCoinShareCard: vi.fn(),
+  }
+})
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({
+    showAlert,
+  }),
+}))
+
+describe('useCoinShareCard', () => {
+  const blob = new Blob(['png'], { type: 'image/png' })
+
+  beforeEach(() => {
+    vi.mocked(renderCoinShareCard).mockReset()
+    vi.mocked(renderCoinShareCard).mockResolvedValue(blob)
+    showAlert.mockReset()
+    showAlert.mockResolvedValue(true)
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:share-card'),
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses native Web Share when file sharing is supported', async () => {
+    const share = vi.fn().mockResolvedValue(undefined)
+    const canShare = vi.fn(() => true)
+    vi.stubGlobal('navigator', { share, canShare })
+    const { shareCoinCard, sharing } = useCoinShareCard()
+
+    const result = await shareCoinCard(buildRomanDenariusCore())
+
+    expect(result).toEqual({ mode: 'shared' })
+    expect(canShare).toHaveBeenCalledWith(expect.objectContaining({
+      files: [expect.any(File)],
+    }))
+    expect(share).toHaveBeenCalledWith(expect.objectContaining({
+      files: [expect.any(File)],
+      title: 'Trajan Denarius Core',
+    }))
+    expect(sharing.value).toBe(false)
+  })
+
+  it('downloads the generated card when file sharing is unsupported', async () => {
+    const click = vi.fn()
+    const remove = vi.fn()
+    const anchor = {
+      href: '',
+      download: '',
+      rel: '',
+      click,
+      remove,
+    } as HTMLAnchorElement
+    const appendChild = vi.spyOn(document.body, 'appendChild').mockImplementation((node: Node) => node)
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'a') return anchor
+      return document.createElement(tagName)
+    })
+    vi.stubGlobal('navigator', { canShare: vi.fn(() => false) })
+    const { shareCoinCard } = useCoinShareCard()
+
+    const result = await shareCoinCard(buildRomanDenariusCore({ name: 'Trajan: Denarius' }))
+
+    expect(result).toEqual({ mode: 'downloaded' })
+    expect(anchor.href).toBe('blob:share-card')
+    expect(anchor.download).toBe('trajan-denarius-share-card.png')
+    expect(click).toHaveBeenCalled()
+    expect(remove).toHaveBeenCalled()
+    expect(appendChild).toHaveBeenCalledWith(anchor)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:share-card')
+  })
+
+  it('shows an alert and resets sharing state when generation fails', async () => {
+    vi.mocked(renderCoinShareCard).mockRejectedValue(new Error('Canvas failed'))
+    vi.stubGlobal('navigator', {})
+    const { shareCoinCard, sharing } = useCoinShareCard()
+    const promise = shareCoinCard(buildRomanDenariusCore())
+    await nextTick()
+    expect(sharing.value).toBe(true)
+
+    await expect(promise).rejects.toThrow('Canvas failed')
+
+    expect(showAlert).toHaveBeenCalledWith('Canvas failed', { title: 'Share Failed' })
+    expect(sharing.value).toBe(false)
+  })
+})

--- a/src/web/src/composables/useCoinShareCard.ts
+++ b/src/web/src/composables/useCoinShareCard.ts
@@ -1,0 +1,69 @@
+import { readonly, ref } from 'vue'
+import type { Coin } from '@/types'
+import { getPreferredShareImage, getShareCardFilename, renderCoinShareCard } from '@/utils/coinShareCard'
+import { useDialog } from '@/composables/useDialog'
+
+const APP_NAME = 'Ed-Mar Ancient Coins'
+
+export type CoinShareResultMode = 'shared' | 'downloaded'
+
+export interface CoinShareResult {
+  mode: CoinShareResultMode
+}
+
+interface ShareNavigator {
+  canShare?: (data?: ShareData) => boolean
+  share?: (data: ShareData) => Promise<void>
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.rel = 'noopener'
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
+export function useCoinShareCard() {
+  const sharing = ref(false)
+  const { showAlert } = useDialog()
+
+  async function shareCoinCard(coin: Coin): Promise<CoinShareResult> {
+    sharing.value = true
+    try {
+      const imageUrl = getPreferredShareImage(coin)
+      const blob = await renderCoinShareCard({ coin, imageUrl, appName: APP_NAME })
+      const filename = getShareCardFilename(coin)
+      const file = new File([blob], filename, { type: 'image/png' })
+      const navigatorWithShare = navigator as unknown as ShareNavigator
+      const shareData: ShareData = {
+        files: [file],
+        title: coin.name || 'Coin share card',
+        text: `Shared from ${APP_NAME}`,
+      }
+
+      if (navigatorWithShare.share && navigatorWithShare.canShare?.(shareData)) {
+        await navigatorWithShare.share(shareData)
+        return { mode: 'shared' }
+      }
+
+      downloadBlob(blob, filename)
+      return { mode: 'downloaded' }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to generate share card.'
+      await showAlert(message, { title: 'Share Failed' })
+      throw error
+    } finally {
+      sharing.value = false
+    }
+  }
+
+  return {
+    sharing: readonly(sharing),
+    shareCoinCard,
+  }
+}

--- a/src/web/src/pages/CoinDetailPage.vue
+++ b/src/web/src/pages/CoinDetailPage.vue
@@ -10,6 +10,8 @@
           :is-wishlist="coin.isWishlist"
           :is-sold="coin.isSold"
           :coin-id="coin.id"
+          :sharing="sharing"
+          @share="handleShare"
           @sell="showSellModal = true"
           @delete="handleDelete"
         />
@@ -156,6 +158,7 @@ import CoinReferencesSection from '@/components/coin/CoinReferencesSection.vue'
 import { deleteCoin, purchaseCoin, sellCoin } from '@/api/client'
 import { useDialog } from '@/composables/useDialog'
 import { useCoinDetailMetadataRows } from '@/composables/useCoinDetailMetadataRows'
+import { useCoinShareCard } from '@/composables/useCoinShareCard'
 import type { CoinImage } from '@/types'
 
 const { showConfirm, showAlert } = useDialog()
@@ -166,6 +169,7 @@ const store = useCoinsStore()
 const showSellModal = ref(false)
 const showPurchaseModal = ref(false)
 const lightboxImage = ref<CoinImage | null>(null)
+const { sharing, shareCoinCard } = useCoinShareCard()
 
 const coin = computed(() => store.currentCoin)
 
@@ -196,6 +200,11 @@ function openLightbox(image: CoinImage) {
 
 function handleImageSaved() {
   refreshCoin()
+}
+
+async function handleShare() {
+  if (!coin.value) return
+  await shareCoinCard(coin.value)
 }
 
 async function confirmPurchase(data: { purchasePrice?: number; purchaseDate?: string; purchaseLocation?: string }) {

--- a/src/web/src/pages/__tests__/CoinDetailPage.test.ts
+++ b/src/web/src/pages/__tests__/CoinDetailPage.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import CoinDetailPage from '../CoinDetailPage.vue'
+import { buildRomanDenariusCore } from '@/test/fixtures/coins'
+
+const coin = buildRomanDenariusCore()
+const fetchCoin = vi.fn()
+const shareCoinCard = vi.fn()
+const sharing = ref(false)
+
+vi.mock('@/stores/coins', () => ({
+  useCoinsStore: () => ({
+    loading: false,
+    currentCoin: coin,
+    fetchCoin,
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: String(coin.id) } }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/api/client', () => ({
+  deleteCoin: vi.fn(),
+  purchaseCoin: vi.fn(),
+  sellCoin: vi.fn(),
+}))
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({
+    showConfirm: vi.fn(),
+    showAlert: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useCoinShareCard', () => ({
+  useCoinShareCard: () => ({
+    sharing,
+    shareCoinCard,
+  }),
+}))
+
+const routerLinkStub = {
+  props: ['to'],
+  template: '<a :href="to"><slot /></a>',
+}
+
+describe('CoinDetailPage', () => {
+  beforeEach(() => {
+    fetchCoin.mockReset()
+    shareCoinCard.mockReset()
+    shareCoinCard.mockResolvedValue({ mode: 'downloaded' })
+    sharing.value = false
+  })
+
+  it('shows the share action on the coin detail page', () => {
+    const wrapper = mount(CoinDetailPage, {
+      global: {
+        stubs: pageStubs(),
+      },
+    })
+
+    expect(wrapper.text()).toContain('Share')
+    expect(fetchCoin).toHaveBeenCalledWith(coin.id)
+  })
+
+  it('shares the currently loaded coin when the Share action is clicked', async () => {
+    const wrapper = mount(CoinDetailPage, {
+      global: {
+        stubs: pageStubs(),
+      },
+    })
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Share'))!.trigger('click')
+    await flushPromises()
+
+    expect(shareCoinCard).toHaveBeenCalledWith(coin)
+  })
+})
+
+function pageStubs() {
+  return {
+    RouterLink: routerLinkStub,
+    SellModal: true,
+    PurchaseModal: true,
+    ImageLightbox: true,
+    CoinTagsSection: true,
+    CoinDetailMetadataTable: true,
+    CoinDetailSectionLinks: true,
+    CoinListingStatus: true,
+    CoinReferencesSection: true,
+    ArrowLeft: true,
+    Share2: true,
+  }
+}

--- a/src/web/src/utils/__tests__/coinShareCard.test.ts
+++ b/src/web/src/utils/__tests__/coinShareCard.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getPreferredShareImage,
+  getShareCardFilename,
+  getShareCardMetadata,
+  renderCoinShareCard,
+} from '@/utils/coinShareCard'
+import { buildImageHeavyDrachm, buildRomanDenariusCore } from '@/test/fixtures/coins'
+import type { CoinImage } from '@/types'
+
+const pngBlob = new Blob(['png'], { type: 'image/png' })
+
+function flattenMetadata(coin = buildRomanDenariusCore()) {
+  const metadata = getShareCardMetadata(coin)
+  return JSON.stringify(metadata)
+}
+
+function makeImage(id: number, imageType: CoinImage['imageType'], isPrimary = false): CoinImage {
+  return {
+    id,
+    coinId: 77,
+    filePath: `coins/${id}.webp`,
+    imageType,
+    isPrimary,
+    createdAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+describe('coinShareCard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns only the approved metadata fields for a share card', () => {
+    const coin = buildRomanDenariusCore()
+    const metadata = getShareCardMetadata(coin)
+
+    expect(metadata.title).toBe(coin.name)
+    expect(metadata.category).toBe(coin.category)
+    expect(metadata.fields.map((field) => field.label)).toEqual([
+      'Ruler',
+      'Denomination',
+      'Era',
+      'Mint',
+      'Material',
+      'Grade',
+    ])
+  })
+
+  it('excludes value, purchase, notes, AI, owner, listing, tag, set, and privacy fields', () => {
+    const coin = buildRomanDenariusCore({
+      purchasePrice: 999,
+      currentValue: 1200,
+      purchaseLocation: 'Secret Dealer',
+      notes: 'Private owner note',
+      aiAnalysis: 'AI private analysis',
+      listingStatus: 'available',
+      userId: 42,
+      isPrivate: true,
+    })
+    const text = flattenMetadata(coin)
+
+    expect(text).not.toContain('999')
+    expect(text).not.toContain('1200')
+    expect(text).not.toContain('Secret Dealer')
+    expect(text).not.toContain('Private owner note')
+    expect(text).not.toContain('AI private analysis')
+    expect(text).not.toContain('available')
+    expect(text).not.toContain('userId')
+    expect(text).not.toContain('isPrivate')
+    expect(text).not.toContain('tags')
+    expect(text).not.toContain('sets')
+  })
+
+  it('prefers obverse image for sharing', () => {
+    const coin = buildImageHeavyDrachm()
+
+    expect(getPreferredShareImage(coin)).toBe('/uploads/test-fixtures/1008-obverse-10081.webp')
+  })
+
+  it('falls back to primary, first image, and no image in order', () => {
+    const primaryOnly = buildRomanDenariusCore({
+      images: [makeImage(1, 'reverse', true), makeImage(2, 'other')],
+    })
+    const firstOnly = buildRomanDenariusCore({
+      images: [makeImage(3, 'detail'), makeImage(4, 'other')],
+    })
+    const noImages = buildRomanDenariusCore({ images: [] })
+
+    expect(getPreferredShareImage(primaryOnly)).toBe('/uploads/coins/1.webp')
+    expect(getPreferredShareImage(firstOnly)).toBe('/uploads/coins/3.webp')
+    expect(getPreferredShareImage(noImages)).toBeNull()
+  })
+
+  it('generates a safe share-card filename', () => {
+    const coin = buildRomanDenariusCore({ name: 'Trajan: Denarius / Rare?' })
+
+    expect(getShareCardFilename(coin)).toBe('trajan-denarius-rare-share-card.png')
+  })
+
+  it('renders a PNG blob with a loaded coin image', async () => {
+    const toBlob = vi.fn((callback: BlobCallback) => callback(pngBlob))
+    const drawImage = vi.fn()
+    const ctx = buildCanvasContext({ drawImage })
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'canvas') {
+        return {
+          width: 0,
+          height: 0,
+          getContext: vi.fn(() => ctx),
+          toBlob,
+        } as unknown as HTMLCanvasElement
+      }
+      return document.createElement(tagName)
+    })
+    vi.stubGlobal('Image', class {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      naturalWidth = 400
+      naturalHeight = 400
+      width = 400
+      height = 400
+      set src(_value: string) {
+        this.onload?.()
+      }
+    })
+
+    const blob = await renderCoinShareCard({
+      coin: buildRomanDenariusCore(),
+      imageUrl: '/uploads/coin.webp',
+      appName: 'Ed-Mar Ancient Coins',
+    })
+
+    expect(blob).toBe(pngBlob)
+    expect(toBlob).toHaveBeenCalledWith(expect.any(Function), 'image/png')
+    expect(drawImage).toHaveBeenCalled()
+  })
+
+  it('renders a branded placeholder when no image is available', async () => {
+    const toBlob = vi.fn((callback: BlobCallback) => callback(pngBlob))
+    const fillText = vi.fn()
+    const ctx = buildCanvasContext({ fillText })
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'canvas') {
+        return {
+          width: 0,
+          height: 0,
+          getContext: vi.fn(() => ctx),
+          toBlob,
+        } as unknown as HTMLCanvasElement
+      }
+      return document.createElement(tagName)
+    })
+
+    await expect(renderCoinShareCard({
+      coin: buildRomanDenariusCore({ images: [] }),
+      imageUrl: null,
+      appName: 'Ed-Mar Ancient Coins',
+    })).resolves.toBe(pngBlob)
+    expect(fillText).toHaveBeenCalledWith('No coin image', expect.any(Number), expect.any(Number))
+  })
+})
+
+function buildCanvasContext(overrides: Partial<CanvasRenderingContext2D> = {}): CanvasRenderingContext2D {
+  return {
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    clip: vi.fn(),
+    drawImage: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn((text: string) => ({ width: text.length * 18 }) as TextMetrics),
+    createLinearGradient: vi.fn(() => ({
+      addColorStop: vi.fn(),
+    }) as unknown as CanvasGradient),
+    ...overrides,
+  } as unknown as CanvasRenderingContext2D
+}

--- a/src/web/src/utils/coinShareCard.ts
+++ b/src/web/src/utils/coinShareCard.ts
@@ -1,0 +1,257 @@
+import type { Coin, CoinImage } from '@/types'
+
+const CARD_WIDTH = 1080
+const CARD_HEIGHT = 1350
+const IMAGE_FRAME_SIZE = 760
+const TEXT_START_Y = 940
+
+const TOKEN_COLORS = {
+  bgPrimary: '#0f172a',
+  bgCard: '#16213e',
+  bgInput: '#1e2a4a',
+  accentGold: '#c9a84c',
+  accentBronze: '#b08d57',
+  textPrimary: '#e8e0d0',
+  textSecondary: '#a09880',
+  textMuted: '#706858',
+  borderSubtle: 'rgba(201, 168, 76, 0.28)',
+}
+
+export interface CoinShareCardField {
+  label: string
+  value: string
+}
+
+export interface CoinShareCardMetadata {
+  title: string
+  category: string
+  fields: CoinShareCardField[]
+}
+
+export interface CoinShareCardInput {
+  coin: Coin
+  imageUrl: string | null
+  appName: string
+}
+
+export interface CoinShareCardRenderOptions {
+  width?: number
+  height?: number
+}
+
+function cleanText(value: string | null | undefined): string {
+  return value?.trim() ?? ''
+}
+
+function addField(fields: CoinShareCardField[], label: string, value: string | null | undefined) {
+  const clean = cleanText(value)
+  if (clean) {
+    fields.push({ label, value: clean })
+  }
+}
+
+export function getShareCardMetadata(coin: Coin): CoinShareCardMetadata {
+  const fields: CoinShareCardField[] = []
+  addField(fields, 'Ruler', coin.ruler)
+  addField(fields, 'Denomination', coin.denomination)
+  addField(fields, 'Era', coin.era)
+  addField(fields, 'Mint', coin.mint)
+  addField(fields, 'Material', coin.material)
+  addField(fields, 'Grade', coin.grade)
+
+  return {
+    title: cleanText(coin.name) || 'Untitled Coin',
+    category: cleanText(coin.category),
+    fields,
+  }
+}
+
+function imagePath(image: CoinImage): string {
+  const path = image.filePath.trim()
+  if (path.startsWith('/uploads/')) return path
+  return `/uploads/${path.replace(/^\/+/, '')}`
+}
+
+export function getPreferredShareImage(coin: Coin): string | null {
+  const obverse = coin.images?.find((image) => image.imageType === 'obverse')
+  if (obverse) return imagePath(obverse)
+
+  const primary = coin.images?.find((image) => image.isPrimary)
+  if (primary) return imagePath(primary)
+
+  const first = coin.images?.[0]
+  return first ? imagePath(first) : null
+}
+
+export function getShareCardFilename(coin: Coin): string {
+  const base = cleanText(coin.name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+
+  return `${base || 'coin'}-share-card.png`
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('Unable to load coin image for share card.'))
+    image.src = src
+  })
+}
+
+function drawContainedImage(
+  ctx: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  x: number,
+  y: number,
+  maxWidth: number,
+  maxHeight: number,
+) {
+  const width = image.naturalWidth || image.width
+  const height = image.naturalHeight || image.height
+  if (!width || !height) return
+
+  const scale = Math.min(maxWidth / width, maxHeight / height)
+  const drawWidth = width * scale
+  const drawHeight = height * scale
+  ctx.drawImage(image, x + (maxWidth - drawWidth) / 2, y + (maxHeight - drawHeight) / 2, drawWidth, drawHeight)
+}
+
+function drawCenteredText(ctx: CanvasRenderingContext2D, text: string, y: number, maxWidth: number) {
+  const words = text.split(/\s+/).filter(Boolean)
+  const lines: string[] = []
+  let line = ''
+
+  for (const word of words) {
+    const next = line ? `${line} ${word}` : word
+    if (ctx.measureText(next).width > maxWidth && line) {
+      lines.push(line)
+      line = word
+    } else {
+      line = next
+    }
+  }
+  if (line) lines.push(line)
+
+  lines.slice(0, 2).forEach((part, index) => {
+    ctx.fillText(part, CARD_WIDTH / 2, y + index * 54)
+  })
+}
+
+function drawBackground(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  const gradient = ctx.createLinearGradient(0, 0, width, height)
+  gradient.addColorStop(0, TOKEN_COLORS.bgCard)
+  gradient.addColorStop(0.58, TOKEN_COLORS.bgPrimary)
+  gradient.addColorStop(1, '#0b1020')
+  ctx.fillStyle = gradient
+  ctx.fillRect(0, 0, width, height)
+
+  ctx.fillStyle = 'rgba(201, 168, 76, 0.08)'
+  ctx.beginPath()
+  ctx.arc(width / 2, 420, 470, 0, Math.PI * 2)
+  ctx.fill()
+}
+
+function drawImageFrame(ctx: CanvasRenderingContext2D, image: HTMLImageElement | null) {
+  const frameX = (CARD_WIDTH - IMAGE_FRAME_SIZE) / 2
+  const frameY = 130
+  const radius = IMAGE_FRAME_SIZE / 2
+
+  ctx.save()
+  ctx.fillStyle = TOKEN_COLORS.bgInput
+  ctx.strokeStyle = TOKEN_COLORS.borderSubtle
+  ctx.lineWidth = 4
+  ctx.beginPath()
+  ctx.arc(CARD_WIDTH / 2, frameY + radius, radius, 0, Math.PI * 2)
+  ctx.fill()
+  ctx.stroke()
+  ctx.clip()
+
+  if (image) {
+    drawContainedImage(ctx, image, frameX, frameY, IMAGE_FRAME_SIZE, IMAGE_FRAME_SIZE)
+  } else {
+    ctx.fillStyle = TOKEN_COLORS.textMuted
+    ctx.font = '600 42px Inter, sans-serif'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText('No coin image', CARD_WIDTH / 2, frameY + radius)
+  }
+
+  ctx.restore()
+
+  ctx.strokeStyle = TOKEN_COLORS.accentGold
+  ctx.lineWidth = 6
+  ctx.beginPath()
+  ctx.arc(CARD_WIDTH / 2, frameY + radius, radius + 5, 0, Math.PI * 2)
+  ctx.stroke()
+}
+
+function drawMetadata(ctx: CanvasRenderingContext2D, metadata: CoinShareCardMetadata, appName: string) {
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'alphabetic'
+  ctx.fillStyle = TOKEN_COLORS.textPrimary
+  ctx.font = '600 48px Cinzel, serif'
+  drawCenteredText(ctx, metadata.title, TEXT_START_Y, 860)
+
+  let y = TEXT_START_Y + 150
+  ctx.font = '600 26px Inter, sans-serif'
+  ctx.fillStyle = TOKEN_COLORS.accentGold
+  if (metadata.category) {
+    ctx.fillText(metadata.category.toUpperCase(), CARD_WIDTH / 2, y)
+    y += 58
+  }
+
+  ctx.font = '400 32px Inter, sans-serif'
+  for (const field of metadata.fields.slice(0, 6)) {
+    ctx.fillStyle = TOKEN_COLORS.textMuted
+    ctx.fillText(field.label.toUpperCase(), CARD_WIDTH / 2, y)
+    y += 38
+    ctx.fillStyle = TOKEN_COLORS.textSecondary
+    ctx.fillText(field.value, CARD_WIDTH / 2, y)
+    y += 54
+  }
+
+  ctx.fillStyle = TOKEN_COLORS.accentBronze
+  ctx.font = '600 28px Cinzel, serif'
+  ctx.fillText(appName, CARD_WIDTH / 2, CARD_HEIGHT - 72)
+}
+
+function canvasToPngBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob)
+      } else {
+        reject(new Error('Unable to generate share card image.'))
+      }
+    }, 'image/png')
+  })
+}
+
+export async function renderCoinShareCard(
+  input: CoinShareCardInput,
+  options: CoinShareCardRenderOptions = {},
+): Promise<Blob> {
+  const width = options.width ?? CARD_WIDTH
+  const height = options.height ?? CARD_HEIGHT
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    throw new Error('Canvas rendering is not available in this browser.')
+  }
+
+  const metadata = getShareCardMetadata(input.coin)
+  const image = input.imageUrl ? await loadImage(input.imageUrl) : null
+
+  drawBackground(ctx, width, height)
+  drawImageFrame(ctx, image)
+  drawMetadata(ctx, metadata, input.appName)
+
+  return canvasToPngBlob(canvas)
+}


### PR DESCRIPTION
## Summary
<!-- 1-3 sentences: what changes and why -->

## Constitution self-check
- Principle(s) touched: <!-- e.g., I (Clear Layered Architecture), IV (Simple Complete Changes) -->
- Operational section(s): <!-- e.g., §17 Quality Gate, §21 DoD -->
- ADR added? <!-- yes/no — required for material design choices, §22 -->
- Principle IV check: <!-- simple, complete, proportional; note workflow/sibling paths tested -->
- Workflow contract(s): <!-- user workflow(s), API/UI/config contracts touched -->
- Blast radius / sibling workflows checked: <!-- e.g., Add Coin, Edit Coin, Admin settings, wishlist -->

## Linked work
- Issue: #
- Spec: `specs/NNN-*/spec.md`
- Tasks completed: <!-- specs/NNN-*/tasks.md line(s) -->

## Definition of Done (§21)
- [ ] 1. Code compiles (`go build ./...`, `npm run build`, `pip install -e ".[dev]"` as applicable)
- [ ] 2. Architecture tests green (`go test -run TestArchitecture ./...`)
- [ ] 3. Unit tests pass (`go test ./...`, `pytest tests/`)
- [ ] 4. Type checks pass (`vue-tsc --build`, Go compile)
- [ ] 5. Linters clean (`go vet`, `ruff check`)
- [ ] 6. Bug fixes include a targeted regression test for the exact failing user path, or document why automation is deferred
- [ ] 7. Shared workflow/config/API contract changes list blast radius and sibling workflows checked
- [ ] 8. User/admin-configured UI values are accepted by every API path the UI can submit them to, or blocked with a clear UI message
- [ ] 9. New service methods have ≥1 unit test
- [ ] 10. Public handlers have Swagger annotations
- [ ] 11. If API changed: `task openapi` run and `docs/openapi.json` updated
- [ ] 12. If material design choice: ADR added in `docs/adr/` *(when Phase 3 lands)*
- [ ] 13. Active `specs/NNN-*/tasks.md` items checked off
- [ ] 14. `.squad/decisions/inbox/` written if cross-cutting decision made
- [ ] 15. Simple Complete Changes self-check complete (Principle IV)
- [ ] 16. Secrets scan clean (no credentials in diff)
- [ ] 17. Conventional commit messages
- [ ] 18. `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer present when AI-assisted

## Notes for reviewer
<!-- Anything reviewer should pay special attention to -->
