### PR TITLE
feat: add showcase present mode

### DIFF
--- a/specs/223-showcase-lightbox-mode/spec.md
+++ b/specs/223-showcase-lightbox-mode/spec.md
@@ -63,16 +63,16 @@ mode makes the coins the entire focus.
 
 ## Acceptance Criteria
 
-- [ ] A Present/Showcase mode can be launched from the gallery and fills the screen
+- [x] A Present/Showcase mode can be launched from the gallery and fills the screen
       with one coin at a time on the dark theme.
-- [ ] Swiping (touch) and arrow keys (desktop) move between coins in the current set.
-- [ ] Tapping toggles a minimal metadata overlay; pricing/value is not shown.
-- [ ] Obverse and reverse are both viewable in this mode.
-- [ ] On supported browsers the view goes fullscreen and the screen does not dim
+- [x] Swiping (touch) and arrow keys (desktop) move between coins in the current set.
+- [x] Tapping toggles a minimal metadata overlay; pricing/value is not shown.
+- [x] Obverse and reverse are both viewable in this mode.
+- [x] On supported browsers the view goes fullscreen and the screen does not dim
       while the mode is active (Wake Lock), releasing correctly on exit.
-- [ ] Exiting returns to the previous gallery state (scroll/filter preserved).
-- [ ] `prefers-reduced-motion` is respected for coin-to-coin transitions.
-- [ ] `npm run type-check` passes; uses existing design tokens.
+- [x] Exiting returns to the previous gallery state (scroll/filter preserved).
+- [x] `prefers-reduced-motion` is respected for coin-to-coin transitions.
+- [x] `npm run type-check` passes; uses existing design tokens.
 
 ## Open Questions
 

--- a/specs/223-showcase-lightbox-mode/tasks.md
+++ b/specs/223-showcase-lightbox-mode/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Table / Lightbox Showcase Mode
+
+## Phase 1: Browser API lifecycle
+
+- [x] T001 Add `useReducedMotion()` for `prefers-reduced-motion` with listener cleanup.
+- [x] T002 Add `useFullscreen()` for target fullscreen entry/exit, state sync, and cleanup.
+- [x] T003 Add `useWakeLock()` for progressive screen wake lock, release, visibility reacquire, and cleanup.
+- [x] T004 Add composable regression tests for unsupported/supported lifecycle paths.
+
+## Phase 2: Presentation viewer
+
+- [x] T005 Add reusable `PresentCoinViewer.vue` for one-coin immersive presentation.
+- [x] T006 Render dark full-bleed edge-lit stage with a single maximized image.
+- [x] T007 Add tap-to-toggle metadata overlay using only name, ruler, denomination, era, material, and grade.
+- [x] T008 Add obverse/reverse controls without pricing, value, notes, AI analysis, or owner fields.
+- [x] T009 Add swipe and keyboard navigation events plus accessible exit/prev/next controls.
+- [x] T010 Respect reduced motion for image and overlay transitions.
+
+## Phase 3: Route and gallery launch
+
+- [x] T011 Add authenticated `/present` route.
+- [x] T012 Add `PresentModePage.vue` using current `store.coins` and `store.galleryIndex` as the source set.
+- [x] T013 Add desktop collection header Present button.
+- [x] T014 Add PWA collection menu Present action.
+- [x] T015 Ensure exit returns to the collection route with existing filter/scroll state preserved by current route/store behavior.
+
+## Phase 4: Tests and validation
+
+- [x] T016 Test metadata allowlist and overlay toggle.
+- [x] T017 Test swipe/keyboard navigation and obverse/reverse behavior.
+- [x] T018 Test fullscreen/wake-lock cleanup on page exit/unmount.
+- [x] T019 Test collection header launch wiring.
+- [x] T020 Run targeted tests: `npm.cmd test -- PresentCoinViewer PresentMode useWakeLock useFullscreen CollectionPage PwaCollectionHeader --run`.
+- [x] T021 Run full frontend tests: `npm.cmd test`.
+- [x] T022 Run `npm.cmd run type-check`.
+- [x] T023 Run `npm.cmd run build`.
+- [x] T024 Run `npm.cmd run lint`.
+- [x] T025 Confirm no backend/API changes or generated `dist/` artifacts are in the final diff.

--- a/src/web/src/components/__tests__/PwaCollectionHeader.test.ts
+++ b/src/web/src/components/__tests__/PwaCollectionHeader.test.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+import PwaCollectionHeader from '../collection/PwaCollectionHeader.vue'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -14,5 +16,39 @@ describe('PwaCollectionHeader', () => {
     expect(source).not.toContain('class="pwa-icon-btn"')
     expect(source).toContain('<span class="pwa-menu-label">Selection</span>')
     expect(source).toContain("{{ selectMode ? 'Exit Selection Mode' : 'Enable Selection Mode' }}")
+  })
+
+  it('emits present from the PWA menu and closes the menu', async () => {
+    const wrapper = mount(PwaCollectionHeader, {
+      props: {
+        search: '',
+        selectMode: false,
+        menuOpen: true,
+        selectedCategory: '',
+        selectedEra: '',
+        selectedTag: '',
+        userTags: [],
+        sortKey: 'updated_at_desc',
+        viewMode: 'swipe',
+        gridSide: null,
+      },
+      global: {
+        stubs: {
+          SearchBar: true,
+          CategoryFilter: true,
+          EraFilter: true,
+          SortSelect: true,
+          Layers: true,
+          LayoutGrid: true,
+          MonitorPlay: true,
+          SlidersHorizontal: true,
+        },
+      },
+    })
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Present Collection'))!.trigger('click')
+
+    expect(wrapper.emitted('present')).toHaveLength(1)
+    expect(wrapper.emitted('update:menuOpen')).toEqual([[false]])
   })
 })

--- a/src/web/src/components/collection/DesktopCollectionHeader.vue
+++ b/src/web/src/components/collection/DesktopCollectionHeader.vue
@@ -28,6 +28,9 @@
             Reverse
           </button>
         </div>
+        <button class="btn btn-secondary" type="button" @click="$emit('present')">
+          <MonitorPlay :size="16" /> Present
+        </button>
         <router-link to="/add" class="btn btn-primary"><CirclePlus :size="16" /> Add Coin</router-link>
       </div>
     </div>
@@ -39,7 +42,7 @@ import type { CollectionSetOption, ImageType } from '@/types'
 import CategoryFilter from '@/components/CategoryFilter.vue'
 import SearchBar from '@/components/SearchBar.vue'
 import SortSelect from '@/components/SortSelect.vue'
-import { CirclePlus, CheckSquare } from 'lucide-vue-next'
+import { CirclePlus, CheckSquare, MonitorPlay } from 'lucide-vue-next'
 
 defineProps<{
   search: string
@@ -58,6 +61,7 @@ defineEmits<{
   'update:sortKey': [value: string]
   'update:gridSide': [value: ImageType | null]
   'toggle-select-mode': []
+  present: []
 }>()
 </script>
 

--- a/src/web/src/components/collection/PwaCollectionHeader.vue
+++ b/src/web/src/components/collection/PwaCollectionHeader.vue
@@ -14,6 +14,13 @@
             </button>
           </div>
           <div class="pwa-menu-section">
+            <span class="pwa-menu-label">Presentation</span>
+            <button class="menu-toggle-btn" @click="emitPresent">
+              <MonitorPlay :size="16" />
+              Present Collection
+            </button>
+          </div>
+          <div class="pwa-menu-section">
             <span class="pwa-menu-label">Category</span>
             <CategoryFilter :model-value="selectedCategory" @update:model-value="$emit('update:selectedCategory', $event)" />
           </div>
@@ -65,7 +72,7 @@ import CategoryFilter from '@/components/CategoryFilter.vue'
 import EraFilter from '@/components/collection/EraFilter.vue'
 import SearchBar from '@/components/SearchBar.vue'
 import SortSelect from '@/components/SortSelect.vue'
-import { Layers, LayoutGrid, SlidersHorizontal } from 'lucide-vue-next'
+import { Layers, LayoutGrid, MonitorPlay, SlidersHorizontal } from 'lucide-vue-next'
 
 defineProps<{
   search: string
@@ -80,7 +87,7 @@ defineProps<{
   gridSide: ImageType | null
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   'update:search': [value: string]
   'update:menuOpen': [value: boolean]
   'update:selectedCategory': [value: string]
@@ -90,7 +97,13 @@ defineEmits<{
   'update:viewMode': [value: 'grid' | 'swipe']
   'update:gridSide': [value: ImageType | null]
   'toggle-select-mode': []
+  present: []
 }>()
+
+function emitPresent() {
+  emit('update:menuOpen', false)
+  emit('present')
+}
 </script>
 
 <style scoped>

--- a/src/web/src/components/presentation/PresentCoinViewer.vue
+++ b/src/web/src/components/presentation/PresentCoinViewer.vue
@@ -1,0 +1,336 @@
+<template>
+  <section
+    class="present-viewer"
+    :class="{ 'reduced-motion': reducedMotion, 'metadata-visible': metadataVisible }"
+    tabindex="0"
+    aria-label="Coin presentation viewer"
+    @keydown.left.prevent="$emit('prev')"
+    @keydown.right.prevent="$emit('next')"
+    @keydown.esc.prevent="$emit('exit')"
+  >
+    <div class="present-topbar">
+      <button class="btn btn-ghost btn-sm" type="button" @click="$emit('exit')">
+        <X :size="16" />
+        Exit
+      </button>
+      <span class="section-label">{{ index + 1 }} / {{ total }}</span>
+    </div>
+
+    <button class="present-nav present-nav-prev btn btn-ghost" type="button" aria-label="Previous coin" @click="$emit('prev')">
+      <ChevronLeft :size="24" />
+    </button>
+
+    <div class="present-stage" @pointerdown="handlePointerDown" @click="toggleMetadata">
+      <div class="present-spotlight"></div>
+      <img v-if="imageSrc" class="present-image" :src="imageSrc" :alt="imageAlt" draggable="false" />
+      <div v-else class="present-empty">
+        <Coins :size="80" :stroke-width="1" />
+        <p>No image available</p>
+      </div>
+      <Transition name="metadata-fade">
+        <div v-if="metadataVisible && coin" class="metadata-overlay" @click.stop>
+          <h1>{{ coin.name }}</h1>
+          <div class="metadata-grid">
+            <div v-for="item in metadataItems" :key="item.label" class="metadata-item">
+              <span class="info-label">{{ item.label }}</span>
+              <span>{{ item.value }}</span>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </div>
+
+    <button class="present-nav present-nav-next btn btn-ghost" type="button" aria-label="Next coin" @click="$emit('next')">
+      <ChevronRight :size="24" />
+    </button>
+
+    <div class="present-controls" @click.stop>
+      <button
+        class="chip"
+        type="button"
+        :class="{ active: activeSide === 'obverse' }"
+        :disabled="!hasObverse"
+        @click="activeSide = 'obverse'"
+      >
+        Obverse
+      </button>
+      <button
+        class="chip"
+        type="button"
+        :class="{ active: activeSide === 'reverse' }"
+        :disabled="!hasReverse"
+        @click="activeSide = 'reverse'"
+      >
+        Reverse
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { ChevronLeft, ChevronRight, Coins, X } from 'lucide-vue-next'
+import type { Coin, CoinImage, ImageType } from '@/types'
+
+type PresentCoin = Pick<Coin, 'id' | 'name' | 'ruler' | 'denomination' | 'era' | 'material' | 'grade' | 'images'>
+
+const props = defineProps<{
+  coin: PresentCoin | null
+  index: number
+  total: number
+  reducedMotion?: boolean
+}>()
+
+const emit = defineEmits<{
+  next: []
+  prev: []
+  exit: []
+}>()
+
+const metadataVisible = ref(false)
+const activeSide = ref<ImageType>('obverse')
+let pointerStartX = 0
+let pointerStartY = 0
+let dragged = false
+
+const hasObverse = computed(() => Boolean(findImage('obverse')))
+const hasReverse = computed(() => Boolean(findImage('reverse')))
+
+const activeImage = computed(() => {
+  if (!props.coin) return null
+  return findImage(activeSide.value)
+    ?? props.coin.images?.find((image) => image.isPrimary)
+    ?? props.coin.images?.[0]
+    ?? null
+})
+
+const imageSrc = computed(() => activeImage.value ? `/uploads/${activeImage.value.filePath}` : null)
+const imageAlt = computed(() => props.coin ? `${props.coin.name} ${activeSide.value}` : 'Presented coin')
+
+const metadataItems = computed(() => {
+  if (!props.coin) return []
+  return [
+    { label: 'Ruler', value: props.coin.ruler },
+    { label: 'Denomination', value: props.coin.denomination },
+    { label: 'Era', value: props.coin.era },
+    { label: 'Material', value: props.coin.material },
+    { label: 'Grade', value: props.coin.grade },
+  ].filter((item): item is { label: string; value: string } => Boolean(item.value))
+})
+
+watch(() => props.coin?.id, () => {
+  metadataVisible.value = false
+  activeSide.value = hasObverse.value || !hasReverse.value ? 'obverse' : 'reverse'
+})
+
+function findImage(side: ImageType): CoinImage | undefined {
+  return props.coin?.images?.find((image) => image.imageType === side)
+}
+
+function toggleMetadata() {
+  if (dragged) {
+    dragged = false
+    return
+  }
+  metadataVisible.value = !metadataVisible.value
+}
+
+function handlePointerDown(event: PointerEvent) {
+  pointerStartX = event.clientX
+  pointerStartY = event.clientY
+  dragged = false
+  window.addEventListener('pointerup', handlePointerUp, { once: true })
+}
+
+function handlePointerUp(event: PointerEvent) {
+  const deltaX = event.clientX - pointerStartX
+  const deltaY = event.clientY - pointerStartY
+  if (Math.abs(deltaX) < 55 || Math.abs(deltaX) < Math.abs(deltaY)) return
+  dragged = true
+  if (deltaX < 0) {
+    emit('next')
+  } else {
+    emit('prev')
+  }
+}
+</script>
+
+<style scoped>
+.present-viewer {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template: auto 1fr auto / auto 1fr auto;
+  gap: 1rem;
+  padding: calc(1rem + env(safe-area-inset-top)) calc(1rem + env(safe-area-inset-right)) calc(1rem + env(safe-area-inset-bottom)) calc(1rem + env(safe-area-inset-left));
+  background:
+    radial-gradient(circle at center, var(--bg-card-hover) 0%, var(--bg-secondary) 36%, var(--bg-primary) 72%),
+    var(--bg-primary);
+  color: var(--text-primary);
+  z-index: 1000;
+  overflow: hidden;
+}
+
+.present-topbar {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  opacity: 0.82;
+}
+
+.present-stage {
+  position: relative;
+  grid-column: 2;
+  grid-row: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  min-height: 0;
+  touch-action: none;
+  cursor: pointer;
+}
+
+.present-spotlight {
+  position: absolute;
+  width: min(82vw, 82vh);
+  aspect-ratio: 1;
+  background: radial-gradient(circle, var(--accent-gold-glow) 0%, transparent 66%);
+  filter: blur(18px);
+  pointer-events: none;
+}
+
+.present-image {
+  position: relative;
+  max-width: min(92vw, 58rem);
+  max-height: 76vh;
+  object-fit: contain;
+  filter: drop-shadow(0 1.5rem 2.5rem var(--overlay-dark));
+  user-select: none;
+  transition: opacity var(--transition-med), transform var(--transition-med);
+}
+
+.present-empty {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text-muted);
+}
+
+.metadata-overlay {
+  position: absolute;
+  left: 50%;
+  bottom: 2rem;
+  width: min(40rem, calc(100vw - 2rem));
+  transform: translateX(-50%);
+  padding: 1.5rem;
+  background: var(--overlay-full);
+  border: 1px solid var(--border-accent);
+  box-shadow: var(--shadow-card);
+}
+
+.metadata-overlay h1 {
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.metadata-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: 0.75rem;
+}
+
+.metadata-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.metadata-item span:last-child {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.present-nav {
+  align-self: center;
+  justify-self: center;
+  padding: 0.6rem;
+  opacity: 0.72;
+}
+
+.present-nav-prev {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.present-nav-next {
+  grid-column: 3;
+  grid-row: 2;
+}
+
+.present-controls {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: center;
+  gap: 0.35rem;
+  opacity: 0.86;
+}
+
+.present-controls .chip:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+.metadata-fade-enter-active,
+.metadata-fade-leave-active {
+  transition: opacity var(--transition-med), transform var(--transition-med);
+}
+
+.metadata-fade-enter-from,
+.metadata-fade-leave-to {
+  opacity: 0;
+  transform: translate(-50%, 0.75rem);
+}
+
+.reduced-motion .present-image,
+.reduced-motion .metadata-fade-enter-active,
+.reduced-motion .metadata-fade-leave-active {
+  transition: none;
+}
+
+@media (max-width: 768px) {
+  .present-viewer {
+    grid-template: auto 1fr auto / 1fr 1fr;
+    gap: 0.75rem;
+  }
+
+  .present-stage {
+    grid-column: 1 / -1;
+  }
+
+  .present-nav {
+    grid-row: 3;
+  }
+
+  .present-nav-prev {
+    grid-column: 1;
+  }
+
+  .present-nav-next {
+    grid-column: 2;
+  }
+
+  .present-controls {
+    grid-row: 4;
+  }
+
+  .metadata-overlay {
+    bottom: 1rem;
+    padding: 1rem;
+  }
+}
+</style>

--- a/src/web/src/components/presentation/__tests__/PresentCoinViewer.test.ts
+++ b/src/web/src/components/presentation/__tests__/PresentCoinViewer.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PresentCoinViewer from '../PresentCoinViewer.vue'
+import { buildRomanDenariusCore } from '@/test/fixtures/coins'
+
+const coin = buildRomanDenariusCore({
+  purchasePrice: 200,
+  currentValue: 250,
+  notes: 'Private note',
+  aiAnalysis: 'Private analysis',
+  images: [
+    { id: 1, coinId: 1, filePath: 'obverse.webp', imageType: 'obverse', isPrimary: true, createdAt: '2026-01-01T00:00:00Z' },
+    { id: 2, coinId: 1, filePath: 'reverse.webp', imageType: 'reverse', isPrimary: false, createdAt: '2026-01-01T00:00:00Z' },
+  ],
+})
+
+function mountViewer() {
+  return mount(PresentCoinViewer, {
+    props: { coin, index: 0, total: 2 },
+    global: {
+      stubs: {
+        ChevronLeft: true,
+        ChevronRight: true,
+        Coins: true,
+        X: true,
+      },
+    },
+  })
+}
+
+describe('PresentCoinViewer', () => {
+  it('toggles a metadata overlay without price, value, notes, or analysis fields', async () => {
+    const wrapper = mountViewer()
+
+    await wrapper.find('.present-stage').trigger('click')
+
+    expect(wrapper.text()).toContain(coin.name)
+    expect(wrapper.text()).toContain(coin.ruler)
+    expect(wrapper.text()).toContain(coin.denomination)
+    expect(wrapper.text()).not.toContain('200')
+    expect(wrapper.text()).not.toContain('250')
+    expect(wrapper.text()).not.toContain('Private note')
+    expect(wrapper.text()).not.toContain('Private analysis')
+
+    await wrapper.find('.present-stage').trigger('click')
+
+    expect(wrapper.find('.metadata-overlay').exists()).toBe(false)
+  })
+
+  it('switches between obverse and reverse images', async () => {
+    const wrapper = mountViewer()
+
+    expect(wrapper.find('.present-image').attributes('src')).toBe('/uploads/obverse.webp')
+
+    await wrapper.findAll('.chip')[1]!.trigger('click')
+
+    expect(wrapper.find('.present-image').attributes('src')).toBe('/uploads/reverse.webp')
+  })
+
+  it('emits keyboard and swipe navigation events', async () => {
+    const wrapper = mountViewer()
+
+    await wrapper.find('.present-viewer').trigger('keydown', { key: 'ArrowRight' })
+    await wrapper.find('.present-viewer').trigger('keydown', { key: 'ArrowLeft' })
+    wrapper.find('.present-stage').element.dispatchEvent(new MouseEvent('pointerdown', { clientX: 200, clientY: 20 }))
+    window.dispatchEvent(new MouseEvent('pointerup', { clientX: 100, clientY: 24 }))
+
+    expect(wrapper.emitted('next')).toHaveLength(2)
+    expect(wrapper.emitted('prev')).toHaveLength(1)
+  })
+
+  it('marks reduced-motion mode when requested', () => {
+    const wrapper = mount(PresentCoinViewer, {
+      props: { coin, index: 0, total: 1, reducedMotion: true },
+      global: {
+        stubs: { ChevronLeft: true, ChevronRight: true, Coins: true, X: true },
+      },
+    })
+
+    expect(wrapper.find('.present-viewer').classes()).toContain('reduced-motion')
+  })
+})

--- a/src/web/src/composables/__tests__/useFullscreen.test.ts
+++ b/src/web/src/composables/__tests__/useFullscreen.test.ts
@@ -1,0 +1,72 @@
+import { defineComponent, ref } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFullscreen } from '../useFullscreen'
+
+let fullscreenElement: Element | null
+const originalRequestFullscreen = HTMLElement.prototype.requestFullscreen
+const originalExitFullscreen = document.exitFullscreen
+
+const Harness = defineComponent({
+  setup() {
+    const target = ref<HTMLElement | null>(null)
+    return { api: useFullscreen(target), target }
+  },
+  template: '<div ref="target" data-fullscreen-target>Target</div>',
+})
+
+describe('useFullscreen', () => {
+  beforeEach(() => {
+    fullscreenElement = null
+    Object.defineProperty(document, 'fullscreenElement', {
+      get: () => fullscreenElement,
+      configurable: true,
+    })
+    HTMLElement.prototype.requestFullscreen = vi.fn(() => {
+      fullscreenElement = document.querySelector('[data-fullscreen-target]')
+      document.dispatchEvent(new Event('fullscreenchange'))
+      return Promise.resolve()
+    })
+    Object.defineProperty(document, 'exitFullscreen', {
+      value: vi.fn(() => {
+        fullscreenElement = null
+        document.dispatchEvent(new Event('fullscreenchange'))
+        return Promise.resolve()
+      }),
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    HTMLElement.prototype.requestFullscreen = originalRequestFullscreen
+    Object.defineProperty(document, 'exitFullscreen', {
+      value: originalExitFullscreen,
+      configurable: true,
+    })
+    document.body.innerHTML = ''
+  })
+
+  it('enters and exits fullscreen for the target element', async () => {
+    const wrapper = mount(Harness, { attachTo: document.body })
+
+    await wrapper.vm.api.enter()
+    await flushPromises()
+
+    expect(wrapper.vm.api.isFullscreen.value).toBe(true)
+
+    await wrapper.vm.api.exit()
+    await flushPromises()
+
+    expect(wrapper.vm.api.isFullscreen.value).toBe(false)
+    expect(document.exitFullscreen).toHaveBeenCalled()
+  })
+
+  it('does not exit fullscreen owned by another element', async () => {
+    const wrapper = mount(Harness, { attachTo: document.body })
+    fullscreenElement = document.createElement('section')
+
+    await wrapper.vm.api.exit()
+
+    expect(document.exitFullscreen).not.toHaveBeenCalled()
+  })
+})

--- a/src/web/src/composables/__tests__/useWakeLock.test.ts
+++ b/src/web/src/composables/__tests__/useWakeLock.test.ts
@@ -1,0 +1,77 @@
+import { defineComponent } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useWakeLock } from '../useWakeLock'
+
+class TestWakeLockSentinel extends EventTarget {
+  released = false
+  readonly type = 'screen'
+  release = vi.fn(async () => {
+    this.released = true
+    this.dispatchEvent(new Event('release'))
+  })
+}
+
+const Harness = defineComponent({
+  setup() {
+    return { api: useWakeLock() }
+  },
+  template: '<div />',
+})
+
+describe('useWakeLock', () => {
+  let sentinel: TestWakeLockSentinel
+  let request: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    sentinel = new TestWakeLockSentinel()
+    request = vi.fn(async () => sentinel)
+    Object.defineProperty(navigator, 'wakeLock', {
+      value: { request },
+      configurable: true,
+    })
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    delete (navigator as Navigator & { wakeLock?: unknown }).wakeLock
+  })
+
+  it('requests and releases a screen wake lock', async () => {
+    const wrapper = mount(Harness)
+
+    await wrapper.vm.api.request()
+    await flushPromises()
+
+    expect(request).toHaveBeenCalledWith('screen')
+    expect(wrapper.vm.api.active.value).toBe(true)
+
+    await wrapper.vm.api.release()
+    await flushPromises()
+
+    expect(sentinel.release).toHaveBeenCalled()
+    expect(wrapper.vm.api.active.value).toBe(false)
+  })
+
+  it('releases an active wake lock on unmount', async () => {
+    const wrapper = mount(Harness)
+
+    await wrapper.vm.api.request()
+    wrapper.unmount()
+    await flushPromises()
+
+    expect(sentinel.release).toHaveBeenCalled()
+  })
+
+  it('treats unsupported wake lock as a non-blocking false result', async () => {
+    delete (navigator as Navigator & { wakeLock?: unknown }).wakeLock
+    const wrapper = mount(Harness)
+
+    await expect(wrapper.vm.api.request()).resolves.toBe(false)
+
+    expect(wrapper.vm.api.supported.value).toBe(false)
+  })
+})

--- a/src/web/src/composables/useFullscreen.ts
+++ b/src/web/src/composables/useFullscreen.ts
@@ -1,0 +1,59 @@
+import type { Ref } from 'vue'
+import { onMounted, onUnmounted, readonly, ref } from 'vue'
+
+export function useFullscreen(target: Ref<HTMLElement | null>) {
+  const isFullscreen = ref(false)
+  const error = ref<unknown>(null)
+
+  function syncState() {
+    isFullscreen.value = document.fullscreenElement === target.value
+  }
+
+  async function enter(): Promise<boolean> {
+    error.value = null
+    const element = target.value
+    if (!element || typeof element.requestFullscreen !== 'function') return false
+
+    try {
+      await element.requestFullscreen()
+      syncState()
+      return true
+    } catch (err) {
+      error.value = err
+      return false
+    }
+  }
+
+  async function exit(): Promise<boolean> {
+    error.value = null
+    if (document.fullscreenElement !== target.value || typeof document.exitFullscreen !== 'function') {
+      syncState()
+      return false
+    }
+
+    try {
+      await document.exitFullscreen()
+      syncState()
+      return true
+    } catch (err) {
+      error.value = err
+      return false
+    }
+  }
+
+  onMounted(() => {
+    document.addEventListener('fullscreenchange', syncState)
+    syncState()
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('fullscreenchange', syncState)
+  })
+
+  return {
+    isFullscreen: readonly(isFullscreen),
+    error: readonly(error),
+    enter,
+    exit,
+  }
+}

--- a/src/web/src/composables/useWakeLock.ts
+++ b/src/web/src/composables/useWakeLock.ts
@@ -1,0 +1,100 @@
+import { onMounted, onUnmounted, readonly, ref } from 'vue'
+
+interface WakeLockSentinelLike extends EventTarget {
+  readonly released: boolean
+  readonly type: 'screen'
+  release: () => Promise<void>
+}
+
+interface WakeLockLike {
+  request: (type: 'screen') => Promise<WakeLockSentinelLike>
+}
+
+type NavigatorWithWakeLock = Navigator & {
+  wakeLock?: WakeLockLike
+}
+
+function getWakeLock(): WakeLockLike | null {
+  if (typeof navigator === 'undefined') return null
+  return (navigator as NavigatorWithWakeLock).wakeLock ?? null
+}
+
+export function useWakeLock() {
+  const active = ref(false)
+  const supported = ref(false)
+  const error = ref<unknown>(null)
+  let sentinel: WakeLockSentinelLike | null = null
+  let requested = false
+
+  function handleRelease() {
+    active.value = false
+    sentinel?.removeEventListener('release', handleRelease)
+    sentinel = null
+  }
+
+  async function request(): Promise<boolean> {
+    error.value = null
+    requested = true
+    const wakeLock = getWakeLock()
+    supported.value = Boolean(wakeLock)
+    if (!wakeLock) return false
+
+    try {
+      sentinel?.removeEventListener('release', handleRelease)
+      sentinel = await wakeLock.request('screen')
+      sentinel.addEventListener('release', handleRelease)
+      active.value = !sentinel.released
+      return active.value
+    } catch (err) {
+      error.value = err
+      active.value = false
+      sentinel = null
+      return false
+    }
+  }
+
+  async function release(): Promise<boolean> {
+    error.value = null
+    requested = false
+    if (!sentinel) {
+      active.value = false
+      return false
+    }
+
+    try {
+      const current = sentinel
+      current.removeEventListener('release', handleRelease)
+      sentinel = null
+      await current.release()
+      active.value = false
+      return true
+    } catch (err) {
+      error.value = err
+      return false
+    }
+  }
+
+  function handleVisibilityChange() {
+    if (document.visibilityState === 'visible' && requested && !active.value) {
+      void request()
+    }
+  }
+
+  onMounted(() => {
+    supported.value = Boolean(getWakeLock())
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
+    void release()
+  })
+
+  return {
+    active: readonly(active),
+    supported: readonly(supported),
+    error: readonly(error),
+    request,
+    release,
+  }
+}

--- a/src/web/src/pages/CollectionPage.vue
+++ b/src/web/src/pages/CollectionPage.vue
@@ -18,6 +18,7 @@
       :select-mode="selectMode"
       :user-tags="userTags"
       @toggle-select-mode="toggleSelectMode"
+      @present="openPresentMode"
     />
 
     <DesktopCollectionHeader
@@ -30,6 +31,7 @@
       :select-mode="selectMode"
       :user-tags="userTags"
       @toggle-select-mode="toggleSelectMode"
+      @present="openPresentMode"
     />
 
     <!-- Needs Attention Queue (when filter is active) -->
@@ -304,6 +306,10 @@ async function bulkAssignLocation(locationId: number | null) {
 
 function handlePageChange(newPage: number) {
   page.value = newPage
+}
+
+function openPresentMode() {
+  router.push({ name: 'present', query: { start: String(store.galleryIndex) } })
 }
 
 onUnmounted(() => {

--- a/src/web/src/pages/PresentModePage.vue
+++ b/src/web/src/pages/PresentModePage.vue
@@ -1,0 +1,100 @@
+<template>
+  <main ref="presentRoot" class="present-mode-page">
+    <PresentCoinViewer
+      v-if="currentCoin"
+      :coin="currentCoin"
+      :index="currentIndex"
+      :total="coins.length"
+      :reduced-motion="prefersReducedMotion"
+      @next="goNext"
+      @prev="goPrev"
+      @exit="exitPresentMode"
+    />
+    <section v-else class="present-empty-page">
+      <h1>No coins to present</h1>
+      <p>Return to the collection and load a gallery before starting Present mode.</p>
+      <button class="btn btn-primary" type="button" @click="exitPresentMode">Back to Collection</button>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import PresentCoinViewer from '@/components/presentation/PresentCoinViewer.vue'
+import { useFullscreen } from '@/composables/useFullscreen'
+import { useReducedMotion } from '@/composables/useReducedMotion'
+import { useWakeLock } from '@/composables/useWakeLock'
+import { useCoinsStore } from '@/stores/coins'
+
+const store = useCoinsStore()
+const route = useRoute()
+const router = useRouter()
+const presentRoot = ref<HTMLElement | null>(null)
+const { prefersReducedMotion } = useReducedMotion()
+const fullscreen = useFullscreen(presentRoot)
+const wakeLock = useWakeLock()
+
+const requestedStart = Number(route.query.start ?? store.galleryIndex ?? 0)
+const currentIndex = ref(Number.isFinite(requestedStart) && requestedStart >= 0 ? requestedStart : 0)
+const coins = computed(() => store.coins)
+const currentCoin = computed(() => coins.value[currentIndex.value] ?? null)
+
+watch(currentIndex, (index) => {
+  store.galleryIndex = index
+})
+
+watch(() => coins.value.length, (length) => {
+  if (length === 0) return
+  currentIndex.value = Math.min(currentIndex.value, length - 1)
+}, { immediate: true })
+
+onMounted(async () => {
+  if (store.coins.length === 0) {
+    await store.fetchCoins({ page: 1 })
+  }
+  await nextTick()
+  await fullscreen.enter()
+  await wakeLock.request()
+})
+
+onUnmounted(() => {
+  void wakeLock.release()
+  void fullscreen.exit()
+})
+
+function goNext() {
+  if (coins.value.length <= 1) return
+  currentIndex.value = (currentIndex.value + 1) % coins.value.length
+}
+
+function goPrev() {
+  if (coins.value.length <= 1) return
+  currentIndex.value = (currentIndex.value - 1 + coins.value.length) % coins.value.length
+}
+
+async function exitPresentMode() {
+  await wakeLock.release()
+  await fullscreen.exit()
+  await router.push({ name: 'collection' })
+}
+</script>
+
+<style scoped>
+.present-mode-page,
+.present-empty-page {
+  min-height: 100vh;
+  background: var(--bg-primary);
+}
+
+.present-empty-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--text-secondary);
+}
+</style>

--- a/src/web/src/pages/__tests__/CollectionPage.test.ts
+++ b/src/web/src/pages/__tests__/CollectionPage.test.ts
@@ -13,4 +13,11 @@ describe('CollectionPage', () => {
     expect(source).not.toContain('class="add-fab"')
     expect(source).not.toMatch(/\.add-fab\s*\{/)
   })
+
+  it('wires collection headers to Present mode without adding a floating action button', () => {
+    const source = fs.readFileSync(collectionPagePath, 'utf8')
+
+    expect(source).toContain('@present="openPresentMode"')
+    expect(source).toContain("router.push({ name: 'present', query: { start: String(store.galleryIndex) } })")
+  })
 })

--- a/src/web/src/pages/__tests__/PresentModePage.test.ts
+++ b/src/web/src/pages/__tests__/PresentModePage.test.ts
@@ -1,0 +1,96 @@
+import { ref } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import PresentModePage from '../PresentModePage.vue'
+import { buildRomanDenariusCore } from '@/test/fixtures/coins'
+
+const routerPush = vi.fn()
+const fetchCoins = vi.fn()
+const store = {
+  coins: [
+    buildRomanDenariusCore({ id: 1, name: 'First coin' }),
+    buildRomanDenariusCore({ id: 2, name: 'Second coin' }),
+  ],
+  galleryIndex: 0,
+  fetchCoins,
+}
+const fullscreenEnter = vi.fn(async () => true)
+const fullscreenExit = vi.fn(async () => true)
+const wakeRequest = vi.fn(async () => true)
+const wakeRelease = vi.fn(async () => true)
+
+vi.mock('@/stores/coins', () => ({
+  useCoinsStore: () => store,
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: { start: '1' } }),
+  useRouter: () => ({ push: routerPush }),
+}))
+
+vi.mock('@/composables/useReducedMotion', () => ({
+  useReducedMotion: () => ({ prefersReducedMotion: ref(false) }),
+}))
+
+vi.mock('@/composables/useFullscreen', () => ({
+  useFullscreen: () => ({ enter: fullscreenEnter, exit: fullscreenExit }),
+}))
+
+vi.mock('@/composables/useWakeLock', () => ({
+  useWakeLock: () => ({ request: wakeRequest, release: wakeRelease }),
+}))
+
+const presentViewerStub = {
+  props: ['coin', 'index', 'total', 'reducedMotion'],
+  emits: ['next', 'prev', 'exit'],
+  template: `
+    <div class="viewer-stub">
+      <span class="viewer-name">{{ coin.name }}</span>
+      <span class="viewer-index">{{ index }}</span>
+      <button class="next" @click="$emit('next')">Next</button>
+      <button class="exit" @click="$emit('exit')">Exit</button>
+    </div>
+  `,
+}
+
+describe('PresentModePage', () => {
+  beforeEach(() => {
+    store.galleryIndex = 0
+    fetchCoins.mockReset()
+    routerPush.mockReset()
+    fullscreenEnter.mockClear()
+    fullscreenExit.mockClear()
+    wakeRequest.mockClear()
+    wakeRelease.mockClear()
+  })
+
+  it('starts at the requested index and updates the store gallery index while navigating', async () => {
+    const wrapper = mount(PresentModePage, {
+      global: { stubs: { PresentCoinViewer: presentViewerStub } },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('.viewer-name').text()).toBe('Second coin')
+    expect(fullscreenEnter).toHaveBeenCalled()
+    expect(wakeRequest).toHaveBeenCalled()
+
+    await wrapper.find('.next').trigger('click')
+
+    expect(store.galleryIndex).toBe(0)
+    expect(wrapper.find('.viewer-name').text()).toBe('First coin')
+  })
+
+  it('releases wake lock and fullscreen before returning to the collection', async () => {
+    const wrapper = mount(PresentModePage, {
+      global: { stubs: { PresentCoinViewer: presentViewerStub } },
+    })
+    await flushPromises()
+
+    await wrapper.find('.exit').trigger('click')
+    await flushPromises()
+
+    expect(wakeRelease).toHaveBeenCalled()
+    expect(fullscreenExit).toHaveBeenCalled()
+    expect(routerPush).toHaveBeenCalledWith({ name: 'collection' })
+  })
+})

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -24,6 +24,12 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/present',
+      name: 'present',
+      component: () => import('@/pages/PresentModePage.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/coin/:id',
       name: 'coin-detail',
       component: () => import('@/pages/CoinDetailPage.vue'),


### PR DESCRIPTION
Implements specs/223-showcase-lightbox-mode with an authenticated fullscreen Present route, wake-lock lifecycle, privacy-safe metadata overlay, swipe/keyboard navigation, and collection launch actions. Complies with Principle IV and §17.

## Summary
<!-- 1-3 sentences: what changes and why -->

## Constitution self-check
- Principle(s) touched: <!-- e.g., I (Clear Layered Architecture), IV (Simple Complete Changes) -->
- Operational section(s): <!-- e.g., §17 Quality Gate, §21 DoD -->
- ADR added? <!-- yes/no — required for material design choices, §22 -->
- Principle IV check: <!-- simple, complete, proportional; note workflow/sibling paths tested -->
- Workflow contract(s): <!-- user workflow(s), API/UI/config contracts touched -->
- Blast radius / sibling workflows checked: <!-- e.g., Add Coin, Edit Coin, Admin settings, wishlist -->

## Linked work
- Issue: #
- Spec: `specs/NNN-*/spec.md`
- Tasks completed: <!-- specs/NNN-*/tasks.md line(s) -->

## Definition of Done (§21)
- [ ] 1. Code compiles (`go build ./...`, `npm run build`, `pip install -e ".[dev]"` as applicable)
- [ ] 2. Architecture tests green (`go test -run TestArchitecture ./...`)
- [ ] 3. Unit tests pass (`go test ./...`, `pytest tests/`)
- [ ] 4. Type checks pass (`vue-tsc --build`, Go compile)
- [ ] 5. Linters clean (`go vet`, `ruff check`)
- [ ] 6. Bug fixes include a targeted regression test for the exact failing user path, or document why automation is deferred
- [ ] 7. Shared workflow/config/API contract changes list blast radius and sibling workflows checked
- [ ] 8. User/admin-configured UI values are accepted by every API path the UI can submit them to, or blocked with a clear UI message
- [ ] 9. New service methods have ≥1 unit test
- [ ] 10. Public handlers have Swagger annotations
- [ ] 11. If API changed: `task openapi` run and `docs/openapi.json` updated
- [ ] 12. If material design choice: ADR added in `docs/adr/` *(when Phase 3 lands)*
- [ ] 13. Active `specs/NNN-*/tasks.md` items checked off
- [ ] 14. `.squad/decisions/inbox/` written if cross-cutting decision made
- [ ] 15. Simple Complete Changes self-check complete (Principle IV)
- [ ] 16. Secrets scan clean (no credentials in diff)
- [ ] 17. Conventional commit messages
- [ ] 18. `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer present when AI-assisted

## Notes for reviewer
<!-- Anything reviewer should pay special attention to -->
