### PR TITLE
feat: add improved coin share cards

### DIFF
--- a/specs/221-share-card-generator/spec.md
+++ b/specs/221-share-card-generator/spec.md
@@ -1,0 +1,54 @@
+# Spec: Share Card Generator
+
+**Status:** Draft  
+**Area:** Frontend (Vue 3 / TS), client-side rendering  
+**Depends on:** existing coin images + metadata  
+**Related:** Collection Showcase, Social Features, PWA share flows
+
+---
+
+## Summary
+
+Generate a clean, branded shareable image of a single coin — the coin photo plus
+key stats and the app's Ed-Mar branding — and hand it to the native share sheet
+via the Web Share API. This rerun keeps the current beta/main coin detail display
+unchanged and only adds the share action and card generator.
+
+## Motivation
+
+Collectors naturally want to show off individual coins. A purpose-built share
+card produces a consistent, attractive, branded image without screenshotting and
+cropping. Pricing, value, notes, and private analysis stay off the card.
+
+## Scope
+
+### In scope
+
+- A "Share" action on the coin detail page.
+- Client-side composition of a share card PNG.
+- A spacious fixed template with separate image, title/category, metadata, and
+  footer branding zones.
+- Web Share API with file attachment where supported.
+- Download fallback where Web Share files are unsupported.
+- Preservation of the existing beta/main two-image coin detail display.
+
+### Out of scope
+
+- 3D coin viewer or Present mode changes.
+- Bulk/multi-coin collage cards.
+- Editing the card layout in-app.
+- Server-side rendering or OG-image endpoints.
+
+## Acceptance Criteria
+
+- [x] A "Share" action is available on the coin detail page.
+- [x] The coin detail hero remains the beta/main two-image display.
+- [x] Tapping Share generates a branded PNG card containing the coin image and
+      default public metadata, with no price/value shown.
+- [x] The generated card keeps image, title/category, metadata, and footer text
+      separated with no overlapping or pushed-together text.
+- [x] On a device supporting Web Share with files, the native share sheet opens
+      with the generated image attached.
+- [x] On unsupported browsers, the generated image downloads as a PNG.
+- [x] Card generation is client-side and requires no server endpoint.
+- [x] `npm run type-check` passes.

--- a/specs/221-share-card-generator/tasks.md
+++ b/specs/221-share-card-generator/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: Share Card Generator rerun
+
+- [x] Rebuild 221 from reverted `beta`/`main` without 222 or 223 display changes.
+- [x] Preserve the existing coin detail two-image display.
+- [x] Add a Share action to coin detail header actions.
+- [x] Generate a privacy-safe PNG share card client-side.
+- [x] Use a spacious non-overlapping card layout with separated image, title, metadata, and footer zones.
+- [x] Use Web Share API for supported file sharing and download fallback otherwise.
+- [x] Add regression tests for metadata allowlist, layout spacing, share orchestration, and detail-page/header wiring.

--- a/src/web/src/__tests__/design-tokens.test.ts
+++ b/src/web/src/__tests__/design-tokens.test.ts
@@ -46,7 +46,7 @@ describe('Design Token Enforcement (Constitution Principle V)', () => {
 
   describe('no hardcoded border-radius in scoped styles', () => {
     // border-radius must use var(--radius-*), not raw px values
-    const BORDER_RADIUS_RAW = /border-radius\s*:\s*(?!0[;\s]|var\(|50%|inherit|initial|unset)([^;]+)/g
+    const BORDER_RADIUS_RAW = /border-radius\s*:\s*(?!\s*(?:0[;\s]|var\(|50%|inherit|initial|unset))([^;]+)/g
 
     // Budget: known pre-existing violations as of 2026-06-06 after syncing origin/main.
     const VIOLATION_BUDGET = 264

--- a/src/web/src/components/coin/CoinDetailHeaderActions.vue
+++ b/src/web/src/components/coin/CoinDetailHeaderActions.vue
@@ -5,6 +5,10 @@
       Back to Gallery
     </button>
     <div class="detail-actions">
+      <button class="btn btn-secondary btn-xs" :disabled="sharing" @click="$emit('share')">
+        <Share2 :size="14" />
+        {{ sharing ? 'Sharing...' : 'Share' }}
+      </button>
       <button v-if="!isWishlist && !isSold" class="btn btn-secondary btn-xs" @click="$emit('sell')">Sell</button>
       <router-link :to="`/edit/${coinId}`" class="btn btn-secondary btn-xs">Edit</router-link>
       <button class="btn btn-danger btn-xs" @click="$emit('delete')">Delete</button>
@@ -14,15 +18,19 @@
 
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
-import { ArrowLeft } from 'lucide-vue-next'
+import { ArrowLeft, Share2 } from 'lucide-vue-next'
 
-defineProps<{
+withDefaults(defineProps<{
   isWishlist: boolean
   isSold: boolean
   coinId: number
-}>()
+  sharing?: boolean
+}>(), {
+  sharing: false,
+})
 
 defineEmits<{
+  share: []
   sell: []
   delete: []
 }>()

--- a/src/web/src/components/coin/__tests__/CoinDetailHeaderActions.test.ts
+++ b/src/web/src/components/coin/__tests__/CoinDetailHeaderActions.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CoinDetailHeaderActions from '../CoinDetailHeaderActions.vue'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const routerLinkStub = {
+  props: ['to'],
+  template: '<a :href="to"><slot /></a>',
+}
+
+describe('CoinDetailHeaderActions', () => {
+  it('emits share and keeps existing actions available', async () => {
+    const wrapper = mount(CoinDetailHeaderActions, {
+      props: {
+        isWishlist: false,
+        isSold: false,
+        coinId: 42,
+      },
+      global: {
+        stubs: {
+          RouterLink: routerLinkStub,
+          ArrowLeft: true,
+          Share2: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Share')
+    expect(wrapper.text()).toContain('Sell')
+    expect(wrapper.find('a[href="/edit/42"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Delete')
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Share'))!.trigger('click')
+
+    expect(wrapper.emitted('share')).toHaveLength(1)
+  })
+
+  it('disables the share button while a share card is being generated', () => {
+    const wrapper = mount(CoinDetailHeaderActions, {
+      props: {
+        isWishlist: false,
+        isSold: false,
+        coinId: 42,
+        sharing: true,
+      },
+      global: {
+        stubs: {
+          RouterLink: routerLinkStub,
+          ArrowLeft: true,
+          Share2: true,
+        },
+      },
+    })
+
+    const shareButton = wrapper.findAll('button').find((button) => button.text().includes('Sharing...'))!
+    expect(shareButton.attributes('disabled')).toBeDefined()
+  })
+})

--- a/src/web/src/composables/__tests__/useCoinShareCard.test.ts
+++ b/src/web/src/composables/__tests__/useCoinShareCard.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useCoinShareCard } from '@/composables/useCoinShareCard'
+import { buildRomanDenariusCore } from '@/test/fixtures/coins'
+import { renderCoinShareCard } from '@/utils/coinShareCard'
+
+const showAlert = vi.fn()
+
+vi.mock('@/utils/coinShareCard', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/coinShareCard')>()
+  return {
+    ...actual,
+    renderCoinShareCard: vi.fn(),
+  }
+})
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({
+    showAlert,
+  }),
+}))
+
+describe('useCoinShareCard', () => {
+  const blob = new Blob(['png'], { type: 'image/png' })
+
+  beforeEach(() => {
+    vi.mocked(renderCoinShareCard).mockReset()
+    vi.mocked(renderCoinShareCard).mockResolvedValue(blob)
+    showAlert.mockReset()
+    showAlert.mockResolvedValue(true)
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:share-card'),
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('uses native Web Share when file sharing is supported', async () => {
+    const share = vi.fn().mockResolvedValue(undefined)
+    const canShare = vi.fn(() => true)
+    vi.stubGlobal('navigator', { share, canShare })
+    const { shareCoinCard, sharing } = useCoinShareCard()
+
+    const result = await shareCoinCard(buildRomanDenariusCore())
+
+    expect(result).toEqual({ mode: 'shared' })
+    expect(canShare).toHaveBeenCalledWith(expect.objectContaining({
+      files: [expect.any(File)],
+    }))
+    expect(share).toHaveBeenCalledWith(expect.objectContaining({
+      files: [expect.any(File)],
+      title: 'Trajan Denarius Core',
+    }))
+    expect(sharing.value).toBe(false)
+  })
+
+  it('downloads the generated card when file sharing is unsupported', async () => {
+    const click = vi.fn()
+    const remove = vi.fn()
+    const anchor = {
+      href: '',
+      download: '',
+      rel: '',
+      click,
+      remove,
+    } as HTMLAnchorElement
+    const originalCreateElement = document.createElement.bind(document)
+    const appendChild = vi.spyOn(document.body, 'appendChild').mockImplementation((node: Node) => node)
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'a') return anchor
+      return originalCreateElement(tagName)
+    })
+    vi.stubGlobal('navigator', { canShare: vi.fn(() => false) })
+    const { shareCoinCard } = useCoinShareCard()
+
+    const result = await shareCoinCard(buildRomanDenariusCore({ name: 'Trajan: Denarius' }))
+
+    expect(result).toEqual({ mode: 'downloaded' })
+    expect(anchor.href).toBe('blob:share-card')
+    expect(anchor.download).toBe('trajan-denarius-share-card.png')
+    expect(click).toHaveBeenCalled()
+    expect(remove).toHaveBeenCalled()
+    expect(appendChild).toHaveBeenCalledWith(anchor)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:share-card')
+  })
+
+  it('shows an alert and resets sharing state when generation fails', async () => {
+    vi.mocked(renderCoinShareCard).mockRejectedValue(new Error('Canvas failed'))
+    vi.stubGlobal('navigator', {})
+    const { shareCoinCard, sharing } = useCoinShareCard()
+    const promise = shareCoinCard(buildRomanDenariusCore())
+    await nextTick()
+    expect(sharing.value).toBe(true)
+
+    await expect(promise).rejects.toThrow('Canvas failed')
+
+    expect(showAlert).toHaveBeenCalledWith('Canvas failed', { title: 'Share Failed' })
+    expect(sharing.value).toBe(false)
+  })
+})

--- a/src/web/src/composables/useCoinShareCard.ts
+++ b/src/web/src/composables/useCoinShareCard.ts
@@ -1,0 +1,69 @@
+import { readonly, ref } from 'vue'
+import type { Coin } from '@/types'
+import { getPreferredShareImage, getShareCardFilename, renderCoinShareCard } from '@/utils/coinShareCard'
+import { useDialog } from '@/composables/useDialog'
+
+const APP_NAME = 'Ed-Mar Ancient Coins'
+
+export type CoinShareResultMode = 'shared' | 'downloaded'
+
+export interface CoinShareResult {
+  mode: CoinShareResultMode
+}
+
+interface ShareNavigator {
+  canShare?: (data?: ShareData) => boolean
+  share?: (data: ShareData) => Promise<void>
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.rel = 'noopener'
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
+export function useCoinShareCard() {
+  const sharing = ref(false)
+  const { showAlert } = useDialog()
+
+  async function shareCoinCard(coin: Coin): Promise<CoinShareResult> {
+    sharing.value = true
+    try {
+      const imageUrl = getPreferredShareImage(coin)
+      const blob = await renderCoinShareCard({ coin, imageUrl, appName: APP_NAME })
+      const filename = getShareCardFilename(coin)
+      const file = new File([blob], filename, { type: 'image/png' })
+      const navigatorWithShare = navigator as unknown as ShareNavigator
+      const shareData: ShareData = {
+        files: [file],
+        title: coin.name || 'Coin share card',
+        text: `Shared from ${APP_NAME}`,
+      }
+
+      if (navigatorWithShare.share && navigatorWithShare.canShare?.(shareData)) {
+        await navigatorWithShare.share(shareData)
+        return { mode: 'shared' }
+      }
+
+      downloadBlob(blob, filename)
+      return { mode: 'downloaded' }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to generate share card.'
+      await showAlert(message, { title: 'Share Failed' })
+      throw error
+    } finally {
+      sharing.value = false
+    }
+  }
+
+  return {
+    sharing: readonly(sharing),
+    shareCoinCard,
+  }
+}

--- a/src/web/src/pages/CoinDetailPage.vue
+++ b/src/web/src/pages/CoinDetailPage.vue
@@ -10,6 +10,8 @@
           :is-wishlist="coin.isWishlist"
           :is-sold="coin.isSold"
           :coin-id="coin.id"
+          :sharing="sharing"
+          @share="handleShare"
           @sell="showSellModal = true"
           @delete="handleDelete"
         />
@@ -156,6 +158,7 @@ import CoinReferencesSection from '@/components/coin/CoinReferencesSection.vue'
 import { deleteCoin, purchaseCoin, sellCoin } from '@/api/client'
 import { useDialog } from '@/composables/useDialog'
 import { useCoinDetailMetadataRows } from '@/composables/useCoinDetailMetadataRows'
+import { useCoinShareCard } from '@/composables/useCoinShareCard'
 import type { CoinImage } from '@/types'
 
 const { showConfirm, showAlert } = useDialog()
@@ -166,6 +169,7 @@ const store = useCoinsStore()
 const showSellModal = ref(false)
 const showPurchaseModal = ref(false)
 const lightboxImage = ref<CoinImage | null>(null)
+const { sharing, shareCoinCard } = useCoinShareCard()
 
 const coin = computed(() => store.currentCoin)
 
@@ -196,6 +200,11 @@ function openLightbox(image: CoinImage) {
 
 function handleImageSaved() {
   refreshCoin()
+}
+
+async function handleShare() {
+  if (!coin.value) return
+  await shareCoinCard(coin.value)
 }
 
 async function confirmPurchase(data: { purchasePrice?: number; purchaseDate?: string; purchaseLocation?: string }) {

--- a/src/web/src/pages/__tests__/CoinDetailPage.test.ts
+++ b/src/web/src/pages/__tests__/CoinDetailPage.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import CoinDetailPage from '../CoinDetailPage.vue'
+import { buildRomanDenariusCore } from '@/test/fixtures/coins'
+
+const coin = buildRomanDenariusCore()
+const fetchCoin = vi.fn()
+const shareCoinCard = vi.fn()
+const sharing = ref(false)
+
+vi.mock('@/stores/coins', () => ({
+  useCoinsStore: () => ({
+    loading: false,
+    currentCoin: coin,
+    fetchCoin,
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: String(coin.id) } }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/api/client', () => ({
+  deleteCoin: vi.fn(),
+  purchaseCoin: vi.fn(),
+  sellCoin: vi.fn(),
+}))
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({
+    showConfirm: vi.fn(),
+    showAlert: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useCoinShareCard', () => ({
+  useCoinShareCard: () => ({
+    sharing,
+    shareCoinCard,
+  }),
+}))
+
+const routerLinkStub = {
+  props: ['to'],
+  template: '<a :href="to"><slot /></a>',
+}
+
+describe('CoinDetailPage', () => {
+  beforeEach(() => {
+    fetchCoin.mockReset()
+    shareCoinCard.mockReset()
+    shareCoinCard.mockResolvedValue({ mode: 'downloaded' })
+    sharing.value = false
+  })
+
+  it('keeps the beta/main two-image hero display and shows the share action', () => {
+    const wrapper = mount(CoinDetailPage, {
+      global: {
+        stubs: pageStubs(),
+      },
+    })
+
+    expect(wrapper.find('.hero-media-grid').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Share')
+    expect(fetchCoin).toHaveBeenCalledWith(coin.id)
+  })
+
+  it('shares the currently loaded coin when the Share action is clicked', async () => {
+    const wrapper = mount(CoinDetailPage, {
+      global: {
+        stubs: pageStubs(),
+      },
+    })
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Share'))!.trigger('click')
+    await flushPromises()
+
+    expect(shareCoinCard).toHaveBeenCalledWith(coin)
+  })
+})
+
+function pageStubs() {
+  return {
+    RouterLink: routerLinkStub,
+    SellModal: true,
+    PurchaseModal: true,
+    ImageLightbox: true,
+    CoinTagsSection: true,
+    CoinDetailMetadataTable: true,
+    CoinDetailSectionLinks: true,
+    CoinListingStatus: true,
+    CoinReferencesSection: true,
+    ArrowLeft: true,
+    Share2: true,
+  }
+}

--- a/src/web/src/utils/__tests__/coinShareCard.test.ts
+++ b/src/web/src/utils/__tests__/coinShareCard.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getPreferredShareImage,
+  getShareCardFilename,
+  getShareCardMetadata,
+  renderCoinShareCard,
+} from '@/utils/coinShareCard'
+import { buildByzantineSolidusSetMember, buildImageHeavyDrachm, buildRomanDenariusCore } from '@/test/fixtures/coins'
+import type { CoinImage } from '@/types'
+
+const pngBlob = new Blob(['png'], { type: 'image/png' })
+
+function flattenMetadata(coin = buildRomanDenariusCore()) {
+  return JSON.stringify(getShareCardMetadata(coin))
+}
+
+function makeImage(id: number, imageType: CoinImage['imageType'], isPrimary = false): CoinImage {
+  return {
+    id,
+    coinId: 77,
+    filePath: `coins/${id}.webp`,
+    imageType,
+    isPrimary,
+    createdAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+describe('coinShareCard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns only approved public metadata fields for a share card', () => {
+    const coin = buildRomanDenariusCore()
+    const metadata = getShareCardMetadata(coin)
+
+    expect(metadata.title).toBe(coin.name)
+    expect(metadata.category).toBe(coin.category)
+    expect(metadata.fields.map((field) => field.label)).toEqual([
+      'Ruler',
+      'Denomination',
+      'Era',
+      'Mint',
+      'Material',
+      'Grade',
+    ])
+  })
+
+  it('excludes value, purchase, notes, AI, owner, listing, tag, set, and privacy fields', () => {
+    const coin = buildRomanDenariusCore({
+      purchasePrice: 999,
+      currentValue: 1200,
+      purchaseLocation: 'Secret Dealer',
+      notes: 'Private owner note',
+      aiAnalysis: 'AI private analysis',
+      listingStatus: 'available',
+      userId: 42,
+      isPrivate: true,
+    })
+    const text = flattenMetadata(coin)
+
+    expect(text).not.toContain('999')
+    expect(text).not.toContain('1200')
+    expect(text).not.toContain('Secret Dealer')
+    expect(text).not.toContain('Private owner note')
+    expect(text).not.toContain('AI private analysis')
+    expect(text).not.toContain('available')
+    expect(text).not.toContain('userId')
+    expect(text).not.toContain('isPrivate')
+    expect(text).not.toContain('tags')
+    expect(text).not.toContain('sets')
+  })
+
+  it('prefers obverse image for sharing', () => {
+    expect(getPreferredShareImage(buildImageHeavyDrachm())).toBe('/uploads/test-fixtures/1008-obverse-10081.webp')
+  })
+
+  it('falls back to primary, first image, and no image in order', () => {
+    const primaryOnly = buildRomanDenariusCore({
+      images: [makeImage(1, 'reverse', true), makeImage(2, 'other')],
+    })
+    const firstOnly = buildRomanDenariusCore({
+      images: [makeImage(3, 'detail'), makeImage(4, 'other')],
+    })
+    const noImages = buildRomanDenariusCore({ images: [] })
+
+    expect(getPreferredShareImage(primaryOnly)).toBe('/uploads/coins/1.webp')
+    expect(getPreferredShareImage(firstOnly)).toBe('/uploads/coins/3.webp')
+    expect(getPreferredShareImage(noImages)).toBeNull()
+  })
+
+  it('generates a safe share-card filename', () => {
+    const coin = buildRomanDenariusCore({ name: 'Trajan: Denarius / Rare?' })
+
+    expect(getShareCardFilename(coin)).toBe('trajan-denarius-rare-share-card.png')
+  })
+
+  it('renders a PNG blob with a loaded coin image', async () => {
+    const toBlob = vi.fn((callback: BlobCallback) => callback(pngBlob))
+    const drawImage = vi.fn()
+    const ctx = buildCanvasContext({ drawImage })
+    mockCanvas(ctx, toBlob)
+    mockImageLoad()
+
+    const blob = await renderCoinShareCard({
+      coin: buildRomanDenariusCore(),
+      imageUrl: '/uploads/coin.webp',
+      appName: 'Ed-Mar Ancient Coins',
+    })
+
+    expect(blob).toBe(pngBlob)
+    expect(toBlob).toHaveBeenCalledWith(expect.any(Function), 'image/png')
+    expect(drawImage).toHaveBeenCalled()
+  })
+
+  it('keeps title, metadata, and footer in separate vertical zones', async () => {
+    const toBlob = vi.fn((callback: BlobCallback) => callback(pngBlob))
+    const fillText = vi.fn()
+    const ctx = buildCanvasContext({ fillText })
+    mockCanvas(ctx, toBlob)
+
+    await renderCoinShareCard({
+      coin: buildByzantineSolidusSetMember({
+        name: 'Leo the Wise Extremely Long Ceremonial Byzantine Solidus',
+        denomination: 'Gold Solidus with Long Denomination Text',
+        ruler: 'Leo VI the Wise',
+        era: 'Byzantine Middle Period',
+        mint: 'Constantinople',
+        grade: 'Choice Very Fine',
+        images: [],
+      }),
+      imageUrl: null,
+      appName: 'Ed-Mar Ancient Coins',
+    })
+
+    const calls = fillText.mock.calls.map(([text, _x, y]) => ({ text: String(text), y: Number(y) }))
+    const footer = calls.find((call) => call.text === 'Ed-Mar Ancient Coins')
+    expect(footer).toBeDefined()
+
+    const latestContentY = Math.max(...calls.filter((call) => call.text !== 'Ed-Mar Ancient Coins').map((call) => call.y))
+    expect(footer!.y - latestContentY).toBeGreaterThanOrEqual(80)
+  })
+})
+
+function mockCanvas(ctx: CanvasRenderingContext2D, toBlob: ReturnType<typeof vi.fn>) {
+  const originalCreateElement = document.createElement.bind(document)
+  vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+    if (tagName === 'canvas') {
+      return {
+        width: 0,
+        height: 0,
+        getContext: vi.fn(() => ctx),
+        toBlob,
+      } as unknown as HTMLCanvasElement
+    }
+    return originalCreateElement(tagName)
+  })
+}
+
+function mockImageLoad() {
+  vi.stubGlobal('Image', class {
+    onload: (() => void) | null = null
+    onerror: (() => void) | null = null
+    naturalWidth = 400
+    naturalHeight = 400
+    width = 400
+    height = 400
+    set src(_value: string) {
+      this.onload?.()
+    }
+  })
+}
+
+function buildCanvasContext(overrides: Partial<CanvasRenderingContext2D> = {}): CanvasRenderingContext2D {
+  return {
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    clip: vi.fn(),
+    drawImage: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn((text: string) => ({ width: text.length * 18 }) as TextMetrics),
+    createLinearGradient: vi.fn(() => ({
+      addColorStop: vi.fn(),
+    }) as unknown as CanvasGradient),
+    ...overrides,
+  } as unknown as CanvasRenderingContext2D
+}

--- a/src/web/src/utils/coinShareCard.ts
+++ b/src/web/src/utils/coinShareCard.ts
@@ -1,0 +1,315 @@
+import type { Coin, CoinImage } from '@/types'
+
+const CARD_WIDTH = 1080
+const CARD_HEIGHT = 1350
+const CARD_PADDING = 72
+const IMAGE_FRAME_Y = 96
+const IMAGE_FRAME_SIZE = 560
+const TITLE_START_Y = 730
+const METADATA_START_Y = 910
+const FOOTER_Y = 1278
+
+const TOKEN_COLORS = {
+  bgPrimary: '#0f172a',
+  bgSecondary: '#1a1a2e',
+  bgCard: '#16213e',
+  bgInput: '#1e2a4a',
+  accentGold: '#c9a84c',
+  accentBronze: '#b08d57',
+  textPrimary: '#e8e0d0',
+  textSecondary: '#a09880',
+  textMuted: '#706858',
+  borderSubtle: 'rgba(201, 168, 76, 0.28)',
+}
+
+export interface CoinShareCardField {
+  label: string
+  value: string
+}
+
+export interface CoinShareCardMetadata {
+  title: string
+  category: string
+  fields: CoinShareCardField[]
+}
+
+export interface CoinShareCardInput {
+  coin: Coin
+  imageUrl: string | null
+  appName: string
+}
+
+export interface CoinShareCardRenderOptions {
+  width?: number
+  height?: number
+}
+
+interface TextLine {
+  text: string
+  y: number
+}
+
+function cleanText(value: string | null | undefined): string {
+  return value?.trim() ?? ''
+}
+
+function addField(fields: CoinShareCardField[], label: string, value: string | null | undefined) {
+  const clean = cleanText(value)
+  if (clean) {
+    fields.push({ label, value: clean })
+  }
+}
+
+export function getShareCardMetadata(coin: Coin): CoinShareCardMetadata {
+  const fields: CoinShareCardField[] = []
+  addField(fields, 'Ruler', coin.ruler)
+  addField(fields, 'Denomination', coin.denomination)
+  addField(fields, 'Era', coin.era)
+  addField(fields, 'Mint', coin.mint)
+  addField(fields, 'Material', coin.material)
+  addField(fields, 'Grade', coin.grade)
+
+  return {
+    title: cleanText(coin.name) || 'Untitled Coin',
+    category: cleanText(coin.category),
+    fields,
+  }
+}
+
+function imagePath(image: CoinImage): string {
+  const path = image.filePath.trim()
+  if (path.startsWith('/uploads/')) return path
+  return `/uploads/${path.replace(/^\/+/, '')}`
+}
+
+export function getPreferredShareImage(coin: Coin): string | null {
+  const obverse = coin.images?.find((image) => image.imageType === 'obverse')
+  if (obverse) return imagePath(obverse)
+
+  const primary = coin.images?.find((image) => image.isPrimary)
+  if (primary) return imagePath(primary)
+
+  const first = coin.images?.[0]
+  return first ? imagePath(first) : null
+}
+
+export function getShareCardFilename(coin: Coin): string {
+  const base = cleanText(coin.name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+
+  return `${base || 'coin'}-share-card.png`
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('Unable to load coin image for share card.'))
+    image.src = src
+  })
+}
+
+function drawContainedImage(
+  ctx: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  x: number,
+  y: number,
+  maxWidth: number,
+  maxHeight: number,
+) {
+  const width = image.naturalWidth || image.width
+  const height = image.naturalHeight || image.height
+  if (!width || !height) return
+
+  const scale = Math.min(maxWidth / width, maxHeight / height)
+  const drawWidth = width * scale
+  const drawHeight = height * scale
+  ctx.drawImage(image, x + (maxWidth - drawWidth) / 2, y + (maxHeight - drawHeight) / 2, drawWidth, drawHeight)
+}
+
+function wrapLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: number, maxLines: number): string[] {
+  const words = text.split(/\s+/).filter(Boolean)
+  const lines: string[] = []
+  let line = ''
+
+  for (const word of words) {
+    const next = line ? `${line} ${word}` : word
+    if (ctx.measureText(next).width > maxWidth && line) {
+      lines.push(line)
+      line = word
+      if (lines.length === maxLines - 1) break
+    } else {
+      line = next
+    }
+  }
+  if (line && lines.length < maxLines) lines.push(line)
+
+  if (lines.length === maxLines && words.join(' ') !== lines.join(' ')) {
+    let last = lines[lines.length - 1] ?? ''
+    while (last.length > 4 && ctx.measureText(`${last}...`).width > maxWidth) {
+      last = last.slice(0, -1).trimEnd()
+    }
+    lines[lines.length - 1] = `${last}...`
+  }
+
+  return lines
+}
+
+function drawCenteredWrappedText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  y: number,
+  maxWidth: number,
+  lineHeight: number,
+  maxLines: number,
+): TextLine[] {
+  const lines = wrapLines(ctx, text, maxWidth, maxLines)
+  const drawn: TextLine[] = []
+  lines.forEach((line, index) => {
+    const lineY = y + index * lineHeight
+    ctx.fillText(line, CARD_WIDTH / 2, lineY)
+    drawn.push({ text: line, y: lineY })
+  })
+  return drawn
+}
+
+function drawBackground(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  const gradient = ctx.createLinearGradient(0, 0, width, height)
+  gradient.addColorStop(0, TOKEN_COLORS.bgCard)
+  gradient.addColorStop(0.55, TOKEN_COLORS.bgPrimary)
+  gradient.addColorStop(1, '#0b1020')
+  ctx.fillStyle = gradient
+  ctx.fillRect(0, 0, width, height)
+
+  ctx.fillStyle = 'rgba(201, 168, 76, 0.08)'
+  ctx.beginPath()
+  ctx.arc(width / 2, 360, 430, 0, Math.PI * 2)
+  ctx.fill()
+}
+
+function drawImageFrame(ctx: CanvasRenderingContext2D, image: HTMLImageElement | null) {
+  const frameX = (CARD_WIDTH - IMAGE_FRAME_SIZE) / 2
+  const radius = IMAGE_FRAME_SIZE / 2
+
+  ctx.save()
+  ctx.fillStyle = TOKEN_COLORS.bgInput
+  ctx.strokeStyle = TOKEN_COLORS.borderSubtle
+  ctx.lineWidth = 4
+  ctx.beginPath()
+  ctx.arc(CARD_WIDTH / 2, IMAGE_FRAME_Y + radius, radius, 0, Math.PI * 2)
+  ctx.fill()
+  ctx.stroke()
+  ctx.clip()
+
+  if (image) {
+    drawContainedImage(ctx, image, frameX, IMAGE_FRAME_Y, IMAGE_FRAME_SIZE, IMAGE_FRAME_SIZE)
+  } else {
+    ctx.fillStyle = TOKEN_COLORS.textMuted
+    ctx.font = '600 36px Inter, sans-serif'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText('No coin image', CARD_WIDTH / 2, IMAGE_FRAME_Y + radius)
+  }
+
+  ctx.restore()
+
+  ctx.strokeStyle = TOKEN_COLORS.accentGold
+  ctx.lineWidth = 5
+  ctx.beginPath()
+  ctx.arc(CARD_WIDTH / 2, IMAGE_FRAME_Y + radius, radius + 6, 0, Math.PI * 2)
+  ctx.stroke()
+}
+
+function drawMetadataGrid(ctx: CanvasRenderingContext2D, fields: CoinShareCardField[]) {
+  const columns = 2
+  const columnGap = 48
+  const columnWidth = (CARD_WIDTH - CARD_PADDING * 2 - columnGap) / columns
+  const rowHeight = 96
+
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'alphabetic'
+
+  fields.slice(0, 6).forEach((field, index) => {
+    const column = index % columns
+    const row = Math.floor(index / columns)
+    const x = CARD_PADDING + column * (columnWidth + columnGap)
+    const y = METADATA_START_Y + row * rowHeight
+
+    ctx.fillStyle = TOKEN_COLORS.textMuted
+    ctx.font = '600 22px Inter, sans-serif'
+    ctx.fillText(field.label.toUpperCase(), x, y)
+
+    ctx.fillStyle = TOKEN_COLORS.textSecondary
+    ctx.font = '400 30px Inter, sans-serif'
+    const valueLines = wrapLines(ctx, field.value, columnWidth, 2)
+    valueLines.forEach((line, lineIndex) => {
+      ctx.fillText(line, x, y + 38 + lineIndex * 34)
+    })
+  })
+}
+
+function drawMetadata(ctx: CanvasRenderingContext2D, metadata: CoinShareCardMetadata, appName: string) {
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'alphabetic'
+  ctx.fillStyle = TOKEN_COLORS.textPrimary
+  ctx.font = '600 54px Cinzel, serif'
+  const titleLines = drawCenteredWrappedText(ctx, metadata.title, TITLE_START_Y, 900, 58, 2)
+
+  let categoryY = TITLE_START_Y + 126
+  if (titleLines.length === 1) {
+    categoryY = TITLE_START_Y + 80
+  }
+
+  if (metadata.category) {
+    ctx.font = '600 26px Inter, sans-serif'
+    ctx.fillStyle = TOKEN_COLORS.accentGold
+    ctx.fillText(metadata.category.toUpperCase(), CARD_WIDTH / 2, categoryY)
+  }
+
+  drawMetadataGrid(ctx, metadata.fields)
+
+  ctx.fillStyle = TOKEN_COLORS.accentBronze
+  ctx.font = '600 28px Cinzel, serif'
+  ctx.textAlign = 'center'
+  ctx.fillText(appName, CARD_WIDTH / 2, FOOTER_Y)
+}
+
+function canvasToPngBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob)
+      } else {
+        reject(new Error('Unable to generate share card image.'))
+      }
+    }, 'image/png')
+  })
+}
+
+export async function renderCoinShareCard(
+  input: CoinShareCardInput,
+  options: CoinShareCardRenderOptions = {},
+): Promise<Blob> {
+  const width = options.width ?? CARD_WIDTH
+  const height = options.height ?? CARD_HEIGHT
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    throw new Error('Canvas rendering is not available in this browser.')
+  }
+
+  const metadata = getShareCardMetadata(input.coin)
+  const image = input.imageUrl ? await loadImage(input.imageUrl) : null
+
+  drawBackground(ctx, width, height)
+  drawImageFrame(ctx, image)
+  drawMetadata(ctx, metadata, input.appName)
+
+  return canvasToPngBlob(canvas)
+}


### PR DESCRIPTION
## Summary
- Reimplements spec 221 share cards from reverted beta/main
- Keeps the existing beta/main two-image coin detail display unchanged
- Adds privacy-safe PNG share card generation with a spaced canvas layout to avoid cramped title/metadata/footer output
- Adds tests for metadata privacy, layout zones, share fallback behavior, and detail-page wiring

## Constitution
Principle IV + §17

## Validation
- npm.cmd test -- coinShareCard useCoinShareCard CoinDetailHeaderActions CoinDetailPage --run
- npm.cmd test
- npm.cmd run type-check
- npm.cmd run lint
- npm.cmd run build
- git diff --check