### PR TITLE
fix: improve share card entry and coin image sizing

### DIFF
--- a/src/web/src/components/SwipeGallery.vue
+++ b/src/web/src/components/SwipeGallery.vue
@@ -365,6 +365,7 @@ onUnmounted(() => {
   width: 100%;
   height: 100%;
   object-fit: contain;
+  transform: scale(1.28);
   pointer-events: none;
 }
 

--- a/src/web/src/components/coin/CoinDetailHeaderActions.vue
+++ b/src/web/src/components/coin/CoinDetailHeaderActions.vue
@@ -1,14 +1,16 @@
 <template>
   <div class="detail-header">
-    <button class="btn btn-ghost btn-xs back-action" @click="router.push('/')">
-      <ArrowLeft :size="14" />
-      Back to Gallery
-    </button>
-    <div class="detail-actions">
-      <button class="btn btn-secondary btn-xs" :disabled="sharing" @click="$emit('share')">
+    <div class="detail-navigation">
+      <button class="btn btn-ghost btn-xs back-action" @click="router.push('/')">
+        <ArrowLeft :size="14" />
+        Back to Gallery
+      </button>
+      <button class="btn btn-secondary btn-xs share-action" :disabled="sharing" @click="$emit('share')">
         <Share2 :size="14" />
         {{ sharing ? 'Sharing...' : 'Share' }}
       </button>
+    </div>
+    <div class="detail-actions">
       <button v-if="!isWishlist && !isSold" class="btn btn-secondary btn-xs" @click="$emit('sell')">Sell</button>
       <router-link :to="`/edit/${coinId}`" class="btn btn-secondary btn-xs">Edit</router-link>
       <button class="btn btn-danger btn-xs" @click="$emit('delete')">Delete</button>
@@ -41,10 +43,18 @@ const router = useRouter()
 <style scoped>
 .detail-header {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 0.75rem;
   margin-bottom: 0;
+}
+
+.detail-navigation {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-width: 0;
 }
 
 .detail-actions {
@@ -60,15 +70,19 @@ const router = useRouter()
   white-space: nowrap;
 }
 
+.share-action {
+  white-space: nowrap;
+}
+
 @media (max-width: 768px) {
   .detail-header {
-    grid-template-columns: auto 1fr;
+    grid-template-columns: 1fr;
     gap: 0.5rem;
     margin-bottom: 1rem;
   }
 
   .detail-actions {
-    justify-content: flex-end;
+    justify-content: flex-start;
     gap: 0.35rem;
   }
 }

--- a/src/web/src/pages/CoinDetailPage.vue
+++ b/src/web/src/pages/CoinDetailPage.vue
@@ -282,12 +282,14 @@ async function confirmSell(soldPrice: number | null, soldTo: string) {
   width: 100%;
   height: 100%;
   object-fit: contain;
+  transform: scale(1.28);
   cursor: pointer;
-  transition: opacity var(--transition-fast);
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
 }
 
 .hero-image:hover {
   opacity: 0.85;
+  transform: scale(1.32);
 }
 
 .hero-placeholder {


### PR DESCRIPTION
Moves the detail Share action beside Back to Gallery so it remains visible, and scales gallery/detail coin imagery to avoid the shrunken padded-image presentation reported in PR #283 feedback. Complies with Principle IV and §17.

## Summary
<!-- 1-3 sentences: what changes and why -->

## Constitution self-check
- Principle(s) touched: <!-- e.g., I (Clear Layered Architecture), IV (Simple Complete Changes) -->
- Operational section(s): <!-- e.g., §17 Quality Gate, §21 DoD -->
- ADR added? <!-- yes/no — required for material design choices, §22 -->
- Principle IV check: <!-- simple, complete, proportional; note workflow/sibling paths tested -->
- Workflow contract(s): <!-- user workflow(s), API/UI/config contracts touched -->
- Blast radius / sibling workflows checked: <!-- e.g., Add Coin, Edit Coin, Admin settings, wishlist -->

## Linked work
- Issue: #
- Spec: `specs/NNN-*/spec.md`
- Tasks completed: <!-- specs/NNN-*/tasks.md line(s) -->

## Definition of Done (§21)
- [ ] 1. Code compiles (`go build ./...`, `npm run build`, `pip install -e ".[dev]"` as applicable)
- [ ] 2. Architecture tests green (`go test -run TestArchitecture ./...`)
- [ ] 3. Unit tests pass (`go test ./...`, `pytest tests/`)
- [ ] 4. Type checks pass (`vue-tsc --build`, Go compile)
- [ ] 5. Linters clean (`go vet`, `ruff check`)
- [ ] 6. Bug fixes include a targeted regression test for the exact failing user path, or document why automation is deferred
- [ ] 7. Shared workflow/config/API contract changes list blast radius and sibling workflows checked
- [ ] 8. User/admin-configured UI values are accepted by every API path the UI can submit them to, or blocked with a clear UI message
- [ ] 9. New service methods have ≥1 unit test
- [ ] 10. Public handlers have Swagger annotations
- [ ] 11. If API changed: `task openapi` run and `docs/openapi.json` updated
- [ ] 12. If material design choice: ADR added in `docs/adr/` *(when Phase 3 lands)*
- [ ] 13. Active `specs/NNN-*/tasks.md` items checked off
- [ ] 14. `.squad/decisions/inbox/` written if cross-cutting decision made
- [ ] 15. Simple Complete Changes self-check complete (Principle IV)
- [ ] 16. Secrets scan clean (no credentials in diff)
- [ ] 17. Conventional commit messages
- [ ] 18. `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer present when AI-assisted

## Notes for reviewer
<!-- Anything reviewer should pay special attention to -->
