### PR TITLE
fix: refine coin share card layout

### DIFF
--- a/src/web/src/components/coin/CoinDetailHeaderActions.vue
+++ b/src/web/src/components/coin/CoinDetailHeaderActions.vue
@@ -5,22 +5,39 @@
         <ArrowLeft :size="14" />
         Back to Gallery
       </button>
-      <button class="btn btn-secondary btn-xs share-action" :disabled="sharing" @click="$emit('share')">
-        <Share2 :size="14" />
-        {{ sharing ? 'Sharing...' : 'Share' }}
+      <button
+        class="icon-action"
+        :disabled="sharing"
+        :title="sharing ? 'Sharing...' : 'Share'"
+        :aria-label="sharing ? 'Sharing...' : 'Share'"
+        @click="$emit('share')"
+      >
+        <Share2 :size="18" />
       </button>
     </div>
     <div class="detail-actions">
-      <button v-if="!isWishlist && !isSold" class="btn btn-secondary btn-xs" @click="$emit('sell')">Sell</button>
-      <router-link :to="`/edit/${coinId}`" class="btn btn-secondary btn-xs">Edit</router-link>
-      <button class="btn btn-danger btn-xs" @click="$emit('delete')">Delete</button>
+      <button
+        v-if="!isWishlist && !isSold"
+        class="icon-action"
+        title="Sell"
+        aria-label="Sell"
+        @click="$emit('sell')"
+      >
+        <CircleDollarSign :size="18" />
+      </button>
+      <router-link :to="`/edit/${coinId}`" class="icon-action" title="Edit" aria-label="Edit">
+        <Pencil :size="18" />
+      </router-link>
+      <button class="icon-action icon-action-danger" title="Delete" aria-label="Delete" @click="$emit('delete')">
+        <Trash2 :size="18" />
+      </button>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
-import { ArrowLeft, Share2 } from 'lucide-vue-next'
+import { ArrowLeft, CircleDollarSign, Pencil, Share2, Trash2 } from 'lucide-vue-next'
 
 withDefaults(defineProps<{
   isWishlist: boolean
@@ -70,8 +87,40 @@ const router = useRouter()
   white-space: nowrap;
 }
 
-.share-action {
-  white-space: nowrap;
+.icon-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.icon-action:hover:not(:disabled) {
+  background: var(--bg-card-hover);
+  border-color: var(--border-accent);
+  color: var(--accent-gold);
+}
+
+.icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.icon-action-danger {
+  color: var(--cat-byzantine);
+  border-color: color-mix(in srgb, var(--cat-byzantine) 35%, transparent);
+}
+
+.icon-action-danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--cat-byzantine) 18%, transparent);
+  color: var(--cat-byzantine);
+  border-color: color-mix(in srgb, var(--cat-byzantine) 55%, transparent);
 }
 
 @media (max-width: 768px) {

--- a/src/web/src/components/coin/__tests__/CoinDetailHeaderActions.test.ts
+++ b/src/web/src/components/coin/__tests__/CoinDetailHeaderActions.test.ts
@@ -23,17 +23,21 @@ describe('CoinDetailHeaderActions', () => {
         stubs: {
           RouterLink: routerLinkStub,
           ArrowLeft: true,
+          CircleDollarSign: true,
+          Pencil: true,
           Share2: true,
+          Trash2: true,
         },
       },
     })
 
-    expect(wrapper.text()).toContain('Share')
-    expect(wrapper.text()).toContain('Sell')
+    expect(wrapper.find('button[aria-label="Share"]').exists()).toBe(true)
+    expect(wrapper.find('button[aria-label="Sell"]').exists()).toBe(true)
     expect(wrapper.find('a[href="/edit/42"]').exists()).toBe(true)
-    expect(wrapper.text()).toContain('Delete')
+    expect(wrapper.find('a[aria-label="Edit"]').exists()).toBe(true)
+    expect(wrapper.find('button[aria-label="Delete"]').exists()).toBe(true)
 
-    await wrapper.findAll('button').find((button) => button.text().includes('Share'))!.trigger('click')
+    await wrapper.find('button[aria-label="Share"]').trigger('click')
 
     expect(wrapper.emitted('share')).toHaveLength(1)
   })
@@ -50,12 +54,15 @@ describe('CoinDetailHeaderActions', () => {
         stubs: {
           RouterLink: routerLinkStub,
           ArrowLeft: true,
+          CircleDollarSign: true,
+          Pencil: true,
           Share2: true,
+          Trash2: true,
         },
       },
     })
 
-    const shareButton = wrapper.findAll('button').find((button) => button.text().includes('Sharing...'))!
+    const shareButton = wrapper.find('button[aria-label="Sharing..."]')
     expect(shareButton.attributes('disabled')).toBeDefined()
   })
 })

--- a/src/web/src/composables/__tests__/useCoinShareCard.test.ts
+++ b/src/web/src/composables/__tests__/useCoinShareCard.test.ts
@@ -48,6 +48,12 @@ describe('useCoinShareCard', () => {
     const result = await shareCoinCard(buildRomanDenariusCore())
 
     expect(result).toEqual({ mode: 'shared' })
+    expect(renderCoinShareCard).toHaveBeenCalledWith(expect.objectContaining({
+      imageUrls: [
+        '/uploads/test-fixtures/1001-obverse-10011.webp',
+        '/uploads/test-fixtures/1001-reverse-10012.webp',
+      ],
+    }))
     expect(canShare).toHaveBeenCalledWith(expect.objectContaining({
       files: [expect.any(File)],
     }))

--- a/src/web/src/composables/useCoinShareCard.ts
+++ b/src/web/src/composables/useCoinShareCard.ts
@@ -1,6 +1,6 @@
 import { readonly, ref } from 'vue'
 import type { Coin } from '@/types'
-import { getPreferredShareImage, getShareCardFilename, renderCoinShareCard } from '@/utils/coinShareCard'
+import { getShareCardFilename, getShareImageUrls, renderCoinShareCard } from '@/utils/coinShareCard'
 import { useDialog } from '@/composables/useDialog'
 
 const APP_NAME = 'Ed-Mar Ancient Coins'
@@ -35,8 +35,8 @@ export function useCoinShareCard() {
   async function shareCoinCard(coin: Coin): Promise<CoinShareResult> {
     sharing.value = true
     try {
-      const imageUrl = getPreferredShareImage(coin)
-      const blob = await renderCoinShareCard({ coin, imageUrl, appName: APP_NAME })
+      const imageUrls = getShareImageUrls(coin)
+      const blob = await renderCoinShareCard({ coin, imageUrl: imageUrls[0] ?? null, imageUrls, appName: APP_NAME })
       const filename = getShareCardFilename(coin)
       const file = new File([blob], filename, { type: 'image/png' })
       const navigatorWithShare = navigator as unknown as ShareNavigator

--- a/src/web/src/pages/__tests__/CoinDetailPage.test.ts
+++ b/src/web/src/pages/__tests__/CoinDetailPage.test.ts
@@ -63,7 +63,7 @@ describe('CoinDetailPage', () => {
     })
 
     expect(wrapper.find('.hero-media-grid').exists()).toBe(true)
-    expect(wrapper.text()).toContain('Share')
+    expect(wrapper.find('button[aria-label="Share"]').exists()).toBe(true)
     expect(fetchCoin).toHaveBeenCalledWith(coin.id)
   })
 
@@ -74,7 +74,7 @@ describe('CoinDetailPage', () => {
       },
     })
 
-    await wrapper.findAll('button').find((button) => button.text().includes('Share'))!.trigger('click')
+    await wrapper.find('button[aria-label="Share"]').trigger('click')
     await flushPromises()
 
     expect(shareCoinCard).toHaveBeenCalledWith(coin)
@@ -93,6 +93,9 @@ function pageStubs() {
     CoinListingStatus: true,
     CoinReferencesSection: true,
     ArrowLeft: true,
+    CircleDollarSign: true,
+    Pencil: true,
     Share2: true,
+    Trash2: true,
   }
 }

--- a/src/web/src/utils/__tests__/coinShareCard.test.ts
+++ b/src/web/src/utils/__tests__/coinShareCard.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   getPreferredShareImage,
   getShareCardFilename,
+  getShareImageUrls,
   getShareCardMetadata,
   renderCoinShareCard,
 } from '@/utils/coinShareCard'
@@ -75,6 +76,13 @@ describe('coinShareCard', () => {
     expect(getPreferredShareImage(buildImageHeavyDrachm())).toBe('/uploads/test-fixtures/1008-obverse-10081.webp')
   })
 
+  it('uses obverse and reverse images together for the share card', () => {
+    expect(getShareImageUrls(buildRomanDenariusCore())).toEqual([
+      '/uploads/test-fixtures/1001-obverse-10011.webp',
+      '/uploads/test-fixtures/1001-reverse-10012.webp',
+    ])
+  })
+
   it('falls back to primary, first image, and no image in order', () => {
     const primaryOnly = buildRomanDenariusCore({
       images: [makeImage(1, 'reverse', true), makeImage(2, 'other')],
@@ -98,19 +106,22 @@ describe('coinShareCard', () => {
   it('renders a PNG blob with a loaded coin image', async () => {
     const toBlob = vi.fn((callback: BlobCallback) => callback(pngBlob))
     const drawImage = vi.fn()
-    const ctx = buildCanvasContext({ drawImage })
+    const arc = vi.fn()
+    const ctx = buildCanvasContext({ drawImage, arc })
     mockCanvas(ctx, toBlob)
     mockImageLoad()
 
     const blob = await renderCoinShareCard({
       coin: buildRomanDenariusCore(),
       imageUrl: '/uploads/coin.webp',
+      imageUrls: ['/uploads/obverse.webp', '/uploads/reverse.webp'],
       appName: 'Ed-Mar Ancient Coins',
     })
 
     expect(blob).toBe(pngBlob)
     expect(toBlob).toHaveBeenCalledWith(expect.any(Function), 'image/png')
-    expect(drawImage).toHaveBeenCalled()
+    expect(drawImage).toHaveBeenCalledTimes(2)
+    expect(arc).not.toHaveBeenCalled()
   })
 
   it('keeps title, metadata, and footer in separate vertical zones', async () => {
@@ -187,6 +198,10 @@ function buildCanvasContext(overrides: Partial<CanvasRenderingContext2D> = {}): 
     save: vi.fn(),
     restore: vi.fn(),
     clip: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    closePath: vi.fn(),
     drawImage: vi.fn(),
     fillText: vi.fn(),
     measureText: vi.fn((text: string) => ({ width: text.length * 18 }) as TextMetrics),

--- a/src/web/src/utils/coinShareCard.ts
+++ b/src/web/src/utils/coinShareCard.ts
@@ -3,11 +3,13 @@ import type { Coin, CoinImage } from '@/types'
 const CARD_WIDTH = 1080
 const CARD_HEIGHT = 1350
 const CARD_PADDING = 72
-const IMAGE_FRAME_Y = 96
-const IMAGE_FRAME_SIZE = 560
-const TITLE_START_Y = 730
-const METADATA_START_Y = 910
-const FOOTER_Y = 1278
+const IMAGE_FRAME_X = 96
+const IMAGE_FRAME_Y = 88
+const IMAGE_FRAME_WIDTH = 888
+const IMAGE_FRAME_HEIGHT = 610
+const TITLE_START_Y = 790
+const METADATA_START_Y = 980
+const FOOTER_Y = 1288
 
 const TOKEN_COLORS = {
   bgPrimary: '#0f172a',
@@ -36,6 +38,7 @@ export interface CoinShareCardMetadata {
 export interface CoinShareCardInput {
   coin: Coin
   imageUrl: string | null
+  imageUrls?: string[]
   appName: string
 }
 
@@ -93,6 +96,20 @@ export function getPreferredShareImage(coin: Coin): string | null {
   return first ? imagePath(first) : null
 }
 
+export function getShareImageUrls(coin: Coin): string[] {
+  const images: string[] = []
+  const obverse = coin.images?.find((image) => image.imageType === 'obverse')
+  const reverse = coin.images?.find((image) => image.imageType === 'reverse')
+
+  if (obverse) images.push(imagePath(obverse))
+  if (reverse && reverse.id !== obverse?.id) images.push(imagePath(reverse))
+
+  if (images.length > 0) return images
+
+  const fallback = getPreferredShareImage(coin)
+  return fallback ? [fallback] : []
+}
+
 export function getShareCardFilename(coin: Coin): string {
   const base = cleanText(coin.name)
     .toLowerCase()
@@ -119,15 +136,38 @@ function drawContainedImage(
   y: number,
   maxWidth: number,
   maxHeight: number,
+  visualScale = 1,
 ) {
   const width = image.naturalWidth || image.width
   const height = image.naturalHeight || image.height
   if (!width || !height) return
 
-  const scale = Math.min(maxWidth / width, maxHeight / height)
+  const scale = Math.min(maxWidth / width, maxHeight / height) * visualScale
   const drawWidth = width * scale
   const drawHeight = height * scale
   ctx.drawImage(image, x + (maxWidth - drawWidth) / 2, y + (maxHeight - drawHeight) / 2, drawWidth, drawHeight)
+}
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+) {
+  const safeRadius = Math.min(radius, width / 2, height / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + safeRadius, y)
+  ctx.lineTo(x + width - safeRadius, y)
+  ctx.quadraticCurveTo(x + width, y, x + width, y + safeRadius)
+  ctx.lineTo(x + width, y + height - safeRadius)
+  ctx.quadraticCurveTo(x + width, y + height, x + width - safeRadius, y + height)
+  ctx.lineTo(x + safeRadius, y + height)
+  ctx.quadraticCurveTo(x, y + height, x, y + height - safeRadius)
+  ctx.lineTo(x, y + safeRadius)
+  ctx.quadraticCurveTo(x, y, x + safeRadius, y)
+  ctx.closePath()
 }
 
 function wrapLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: number, maxLines: number): string[] {
@@ -184,42 +224,54 @@ function drawBackground(ctx: CanvasRenderingContext2D, width: number, height: nu
   ctx.fillStyle = gradient
   ctx.fillRect(0, 0, width, height)
 
-  ctx.fillStyle = 'rgba(201, 168, 76, 0.08)'
-  ctx.beginPath()
-  ctx.arc(width / 2, 360, 430, 0, Math.PI * 2)
-  ctx.fill()
+  ctx.fillStyle = 'rgba(201, 168, 76, 0.06)'
+  ctx.fillRect(CARD_PADDING, IMAGE_FRAME_Y + 34, width - CARD_PADDING * 2, IMAGE_FRAME_HEIGHT)
 }
 
-function drawImageFrame(ctx: CanvasRenderingContext2D, image: HTMLImageElement | null) {
-  const frameX = (CARD_WIDTH - IMAGE_FRAME_SIZE) / 2
-  const radius = IMAGE_FRAME_SIZE / 2
-
+function drawImagePanel(
+  ctx: CanvasRenderingContext2D,
+  image: HTMLImageElement | null,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+) {
   ctx.save()
   ctx.fillStyle = TOKEN_COLORS.bgInput
   ctx.strokeStyle = TOKEN_COLORS.borderSubtle
-  ctx.lineWidth = 4
-  ctx.beginPath()
-  ctx.arc(CARD_WIDTH / 2, IMAGE_FRAME_Y + radius, radius, 0, Math.PI * 2)
+  ctx.lineWidth = 3
+  drawRoundedRect(ctx, x, y, width, height, 36)
   ctx.fill()
   ctx.stroke()
   ctx.clip()
 
   if (image) {
-    drawContainedImage(ctx, image, frameX, IMAGE_FRAME_Y, IMAGE_FRAME_SIZE, IMAGE_FRAME_SIZE)
+    drawContainedImage(ctx, image, x, y, width, height, 1.24)
   } else {
     ctx.fillStyle = TOKEN_COLORS.textMuted
     ctx.font = '600 36px Inter, sans-serif'
     ctx.textAlign = 'center'
     ctx.textBaseline = 'middle'
-    ctx.fillText('No coin image', CARD_WIDTH / 2, IMAGE_FRAME_Y + radius)
+    ctx.fillText('No coin image', x + width / 2, y + height / 2)
   }
 
   ctx.restore()
+}
+
+function drawImageFrame(ctx: CanvasRenderingContext2D, images: HTMLImageElement[]) {
+  if (images.length > 1) {
+    const panelGap = 32
+    const panelWidth = (IMAGE_FRAME_WIDTH - panelGap) / 2
+    const panelHeight = IMAGE_FRAME_HEIGHT
+    drawImagePanel(ctx, images[0] ?? null, IMAGE_FRAME_X, IMAGE_FRAME_Y, panelWidth, panelHeight)
+    drawImagePanel(ctx, images[1] ?? null, IMAGE_FRAME_X + panelWidth + panelGap, IMAGE_FRAME_Y, panelWidth, panelHeight)
+  } else {
+    drawImagePanel(ctx, images[0] ?? null, IMAGE_FRAME_X, IMAGE_FRAME_Y, IMAGE_FRAME_WIDTH, IMAGE_FRAME_HEIGHT)
+  }
 
   ctx.strokeStyle = TOKEN_COLORS.accentGold
-  ctx.lineWidth = 5
-  ctx.beginPath()
-  ctx.arc(CARD_WIDTH / 2, IMAGE_FRAME_Y + radius, radius + 6, 0, Math.PI * 2)
+  ctx.lineWidth = 4
+  drawRoundedRect(ctx, IMAGE_FRAME_X - 8, IMAGE_FRAME_Y - 8, IMAGE_FRAME_WIDTH + 16, IMAGE_FRAME_HEIGHT + 16, 42)
   ctx.stroke()
 }
 
@@ -227,26 +279,26 @@ function drawMetadataGrid(ctx: CanvasRenderingContext2D, fields: CoinShareCardFi
   const columns = 2
   const columnGap = 48
   const columnWidth = (CARD_WIDTH - CARD_PADDING * 2 - columnGap) / columns
-  const rowHeight = 96
+  const rowHeight = 104
 
   ctx.textAlign = 'left'
   ctx.textBaseline = 'alphabetic'
 
-  fields.slice(0, 6).forEach((field, index) => {
+  fields.slice(0, 4).forEach((field, index) => {
     const column = index % columns
     const row = Math.floor(index / columns)
     const x = CARD_PADDING + column * (columnWidth + columnGap)
     const y = METADATA_START_Y + row * rowHeight
 
     ctx.fillStyle = TOKEN_COLORS.textMuted
-    ctx.font = '600 22px Inter, sans-serif'
+    ctx.font = '600 20px Inter, sans-serif'
     ctx.fillText(field.label.toUpperCase(), x, y)
 
     ctx.fillStyle = TOKEN_COLORS.textSecondary
-    ctx.font = '400 30px Inter, sans-serif'
+    ctx.font = '400 28px Inter, sans-serif'
     const valueLines = wrapLines(ctx, field.value, columnWidth, 2)
     valueLines.forEach((line, lineIndex) => {
-      ctx.fillText(line, x, y + 38 + lineIndex * 34)
+      ctx.fillText(line, x, y + 38 + lineIndex * 32)
     })
   })
 }
@@ -305,10 +357,11 @@ export async function renderCoinShareCard(
   }
 
   const metadata = getShareCardMetadata(input.coin)
-  const image = input.imageUrl ? await loadImage(input.imageUrl) : null
+  const imageUrls = input.imageUrls ?? (input.imageUrl ? [input.imageUrl] : [])
+  const images = await Promise.all(imageUrls.slice(0, 2).map((imageUrl) => loadImage(imageUrl)))
 
   drawBackground(ctx, width, height)
-  drawImageFrame(ctx, image)
+  drawImageFrame(ctx, images)
   drawMetadata(ctx, metadata, input.appName)
 
   return canvasToPngBlob(canvas)


### PR DESCRIPTION
## Summary
- Removes the circular generated share-card treatment
- Renders obverse and reverse images together in the generated PNG when both are available
- Limits and spaces exported metadata to avoid compressed details/footer overlap
- Converts coin detail actions to accessible icon controls

## Constitution
Principle IV + §17

## Validation
- npm.cmd test -- coinShareCard useCoinShareCard CoinDetailHeaderActions CoinDetailPage --run
- npm.cmd test -- --run
- npm.cmd run type-check
- npm.cmd run lint
- npm.cmd run build
- git diff --check