### PR TITLE
fix: polish share card layout

### DIFF
--- a/src/web/src/components/coin/CoinDetailHeaderActions.vue
+++ b/src/web/src/components/coin/CoinDetailHeaderActions.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="detail-header">
-    <div class="detail-navigation">
-      <button class="btn btn-ghost btn-xs back-action" @click="router.push('/')">
-        <ArrowLeft :size="14" />
-        Back to Gallery
-      </button>
+    <button class="btn btn-ghost btn-xs back-action" @click="router.push('/')">
+      <ArrowLeft :size="14" />
+      Back to Gallery
+    </button>
+    <div class="detail-actions">
       <button
         class="icon-action"
         :disabled="sharing"
@@ -14,8 +14,6 @@
       >
         <Share2 :size="18" />
       </button>
-    </div>
-    <div class="detail-actions">
       <button
         v-if="!isWishlist && !isSold"
         class="icon-action"
@@ -28,7 +26,7 @@
       <router-link :to="`/edit/${coinId}`" class="icon-action" title="Edit" aria-label="Edit">
         <Pencil :size="18" />
       </router-link>
-      <button class="icon-action icon-action-danger" title="Delete" aria-label="Delete" @click="$emit('delete')">
+      <button class="icon-action" title="Delete" aria-label="Delete" @click="$emit('delete')">
         <Trash2 :size="18" />
       </button>
     </div>
@@ -66,19 +64,11 @@ const router = useRouter()
   margin-bottom: 0;
 }
 
-.detail-navigation {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  min-width: 0;
-}
-
 .detail-actions {
   display: flex;
   justify-content: flex-end;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  align-items: center;
+  gap: 0.35rem;
   min-width: 0;
 }
 
@@ -91,19 +81,18 @@ const router = useRouter()
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: var(--radius-full);
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-card);
+  padding: 0.4rem;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
-  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+  text-decoration: none;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .icon-action:hover:not(:disabled) {
-  background: var(--bg-card-hover);
-  border-color: var(--border-accent);
+  background: var(--accent-gold-glow);
   color: var(--accent-gold);
 }
 
@@ -112,27 +101,19 @@ const router = useRouter()
   opacity: 0.55;
 }
 
-.icon-action-danger {
-  color: var(--cat-byzantine);
-  border-color: color-mix(in srgb, var(--cat-byzantine) 35%, transparent);
-}
-
-.icon-action-danger:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--cat-byzantine) 18%, transparent);
-  color: var(--cat-byzantine);
-  border-color: color-mix(in srgb, var(--cat-byzantine) 55%, transparent);
-}
-
 @media (max-width: 768px) {
   .detail-header {
-    grid-template-columns: 1fr;
-    gap: 0.5rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.35rem;
     margin-bottom: 1rem;
   }
 
   .detail-actions {
-    justify-content: flex-start;
-    gap: 0.35rem;
+    gap: 0.2rem;
+  }
+
+  .icon-action {
+    padding: 0.35rem;
   }
 }
 </style>

--- a/src/web/src/utils/__tests__/coinShareCard.test.ts
+++ b/src/web/src/utils/__tests__/coinShareCard.test.ts
@@ -151,6 +151,26 @@ describe('coinShareCard', () => {
     const latestContentY = Math.max(...calls.filter((call) => call.text !== 'Ed-Mar Ancient Coins').map((call) => call.y))
     expect(footer!.y - latestContentY).toBeGreaterThanOrEqual(80)
   })
+
+  it('centers the metadata columns as a balanced block', async () => {
+    const toBlob = vi.fn((callback: BlobCallback) => callback(pngBlob))
+    const fillText = vi.fn()
+    const ctx = buildCanvasContext({ fillText })
+    mockCanvas(ctx, toBlob)
+
+    await renderCoinShareCard({
+      coin: buildRomanDenariusCore({ images: [] }),
+      imageUrl: null,
+      appName: 'Ed-Mar Ancient Coins',
+    })
+
+    const labelCalls = fillText.mock.calls
+      .map(([text, x, y]) => ({ text: String(text), x: Number(x), y: Number(y) }))
+      .filter((call) => ['RULER', 'DENOMINATION', 'ERA', 'MINT'].includes(call.text))
+
+    expect(labelCalls.map((call) => call.x)).toEqual([329, 751, 329, 751])
+    expect(labelCalls[0]!.x + labelCalls[1]!.x).toBe(1080)
+  })
 })
 
 function mockCanvas(ctx: CanvasRenderingContext2D, toBlob: ReturnType<typeof vi.fn>) {

--- a/src/web/src/utils/coinShareCard.ts
+++ b/src/web/src/utils/coinShareCard.ts
@@ -277,17 +277,19 @@ function drawImageFrame(ctx: CanvasRenderingContext2D, images: HTMLImageElement[
 
 function drawMetadataGrid(ctx: CanvasRenderingContext2D, fields: CoinShareCardField[]) {
   const columns = 2
-  const columnGap = 48
-  const columnWidth = (CARD_WIDTH - CARD_PADDING * 2 - columnGap) / columns
+  const gridWidth = 760
+  const columnGap = 84
+  const columnWidth = (gridWidth - columnGap) / columns
   const rowHeight = 104
+  const gridX = (CARD_WIDTH - gridWidth) / 2
 
-  ctx.textAlign = 'left'
+  ctx.textAlign = 'center'
   ctx.textBaseline = 'alphabetic'
 
   fields.slice(0, 4).forEach((field, index) => {
     const column = index % columns
     const row = Math.floor(index / columns)
-    const x = CARD_PADDING + column * (columnWidth + columnGap)
+    const x = gridX + column * (columnWidth + columnGap) + columnWidth / 2
     const y = METADATA_START_Y + row * rowHeight
 
     ctx.fillStyle = TOKEN_COLORS.textMuted


### PR DESCRIPTION
## Summary
- Centers the generated share-card metadata block as a balanced museum-style layout
- Removes the circular/background treatment from coin detail action icons
- Aligns Back to Gallery left and Share/Sell/Edit/Delete icons right in one row

## Constitution
Principle IV + §17

## Validation
- npm.cmd test -- coinShareCard CoinDetailHeaderActions CoinDetailPage --run
- npm.cmd test -- --run
- npm.cmd run type-check
- npm.cmd run lint
- npm.cmd run build
- git diff --check