### PR TITLE
fix: refine stats navigation layout

### DIFF
--- a/specs/225-mint-map-view/plan.md
+++ b/specs/225-mint-map-view/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Pivot the beta Mint Map from a stylized inline SVG approximation to a real Leaflet map using OpenStreetMap tiles. Pins must be rendered from actual mint latitude/longitude data. The feature moves under Stats as `/stats/mint-map`; legacy `/mint-map` redirects there. Stats becomes a landing page with cards for Mint Map, Timeline, and Collection Distribution subviews.
+Pivot the beta Mint Map from a stylized inline SVG approximation to a real Leaflet map using OpenStreetMap tiles. Pins must be rendered from actual mint latitude/longitude data. The feature moves under Stats as `/stats/mint-map`; legacy `/mint-map` redirects there. Stats itself is the summary metrics landing page, and the sidebar exposes the clarified Stats submenu: Timeline, Map, Health, Value Trends.
 
 ## Technical Context
 
@@ -36,7 +36,7 @@ No constitution waiver is expected.
 3. **Coordinates**: Marker placement uses actual `lat`/`lng` from the dataset; remove SVG projection from the active rendering path.
 4. **Feature placement**: Mint Map is a Stats subview only: `/stats/mint-map`.
 5. **Legacy route strategy**: `/mint-map` and `/timeline` redirect to `/stats/mint-map` and `/stats/timeline`.
-6. **Stats IA**: `/stats` is a card-based landing page; Timeline and Collection Distribution are sibling subviews.
+6. **Stats IA**: `/stats` is the summary metrics landing page. The sidebar nests exactly Timeline, Map, Health, and Value Trends under Stats; Collection Distribution remains routable for anchored Health/Value Trends sections but is not shown as a submenu item.
 7. **Tap behavior**: Marker tap opens the in-map/page coin list drawer for that mint; gallery query bridge remains optional only if an explicit tested route contract exists.
 8. **Aliases**: Alias names map to one canonical mint for this follow-up; era-specific splitting remains out of scope.
 
@@ -123,11 +123,11 @@ Remove active dependency on `projectLatLngToViewBox()` for map rendering. It may
 
 ### Phase 4: Stats Subviews and Redirects
 
-1. Change `/stats` to a landing page with cards for Mint Map, Timeline, and Collection Distribution.
+1. Change `/stats` to the summary metrics landing page.
 2. Add authenticated child/sibling routes for `/stats/mint-map`, `/stats/timeline`, and `/stats/distribution`.
 3. Redirect `/mint-map` → `/stats/mint-map` and `/timeline` → `/stats/timeline`.
 4. Remove Mint Map actions from `DesktopCollectionHeader.vue` and `PwaCollectionHeader.vue`.
-5. Move existing Collection Distribution UI out of the landing page into its subview.
+5. Keep Collection Distribution UI in its subview for Health and Value Trends anchors, but do not expose Collection Distribution as a sidebar item.
 
 ### Phase 5: Tests and Validation
 
@@ -135,7 +135,7 @@ Remove active dependency on `projectLatLngToViewBox()` for map rendering. It may
 2. `MintMapLeaflet.test.ts`: verifies marker creation from lat/lng, count labels, selected-mint emission, default bounds/empty state, and OSM tile layer configuration without live network.
 3. `MintMapPage.test.ts`: verifies drawer/unattributed behavior with the Leaflet component stubbed as needed.
 4. Router tests: legacy redirects and authenticated Stats subview route targets.
-5. Stats tests: landing cards link to subviews; Collection headers no longer expose Mint Map.
+5. Stats/App tests: summary metrics render at `/stats`; sidebar Stats submenu contains Timeline, Map, Health, and Value Trends only; Collection headers no longer expose Mint Map.
 
 Run from `src/web`:
 

--- a/specs/225-mint-map-view/spec.md
+++ b/specs/225-mint-map-view/spec.md
@@ -15,7 +15,7 @@ The current beta stylized SVG approximation is not the intended product experien
 
 ## Motivation
 
-The app captures mint information but does not visualize collection geography. A real slippy map makes the collection's spatial spread recognizable at a glance, with zoom/pan behavior users already understand from modern maps. This complements Stats subviews: Mint Map answers "where", Timeline answers "when", and Collection Distribution answers "what".
+The app captures mint information but does not visualize collection geography. A real slippy map makes the collection's spatial spread recognizable at a glance, with zoom/pan behavior users already understand from modern maps. This complements Stats subviews: Map answers "where", Timeline answers "when", Health answers "is the collection complete", and Value Trends answers "how value changes".
 
 ## User Stories
 
@@ -23,7 +23,7 @@ The app captures mint information but does not visualize collection geography. A
 - As a collector, I tap a mint pin and see only the coins struck at that mint.
 - As a collector with multiple coins from one mint, the pin reflects the count.
 - As a collector, I can use existing `/mint-map` or `/timeline` links and land on the new Stats subview URLs.
-- As a collector, I open Stats and see a landing page with cards for Mint Map, Timeline, and Collection Distribution.
+- As a collector, I open Stats and see summary metrics as the landing page, with Stats subviews available only from the sidebar submenu.
 
 ## Scope
 
@@ -31,7 +31,7 @@ The app captures mint information but does not visualize collection geography. A
 
 - Mint Map lives only as the authenticated Stats subview `/stats/mint-map`.
 - Existing `/mint-map` redirects to `/stats/mint-map`; existing `/timeline` redirects to `/stats/timeline`.
-- Main `/stats` becomes a landing page of cards linking to Stats subviews.
+- Main `/stats` becomes the summary metrics landing page.
 - Collection Distribution becomes its own Stats subview.
 - Remove Mint Map launch actions from Collection headers/navigation.
 - Replace the stylized SVG map experience with a Leaflet map using OpenStreetMap tile layers.
@@ -71,13 +71,16 @@ The app captures mint information but does not visualize collection geography. A
 
 **Stats navigation**
 
-- `/stats` is an overview/landing page with cards.
+- `/stats` is the summary metrics landing page previously represented by Summary Cards.
 - Subviews use explicit routes: `/stats/mint-map`, `/stats/timeline`, and `/stats/distribution`.
+- The sidebar shows `Stats` as a parent item with exactly four indented submenu items: `Timeline` → `/stats/timeline`, `Map` → `/stats/mint-map`, `Health` → `/stats/distribution#collection-health`, and `Value Trends` → `/stats/distribution#value-over-time`.
+- `Collection Distribution` remains available at `/stats/distribution` for anchored sections but is not a sidebar submenu item.
 - Legacy flat routes redirect with `router.replace`-style route records, not duplicate standalone pages.
 
 ## Acceptance Criteria
 
-- [ ] `/stats` renders a landing page with cards for Mint Map, Timeline, and Collection Distribution.
+- [ ] `/stats` renders summary metrics/cards, not navigation cards.
+- [ ] Sidebar Stats submenu contains exactly Timeline, Map, Health, and Value Trends; Timeline is not a top-level item.
 - [ ] `/stats/mint-map` renders a Leaflet map with OpenStreetMap tiles.
 - [ ] `/mint-map` redirects to `/stats/mint-map` and `/timeline` redirects to `/stats/timeline`.
 - [ ] Mint Map is not launched from Collection headers.

--- a/specs/225-mint-map-view/tasks.md
+++ b/specs/225-mint-map-view/tasks.md
@@ -67,7 +67,7 @@ The following tasks were completed in the beta implementation. They remain usefu
 - [x] T050 [NAV] Update `src/web/src/router/index.ts` so `/stats/timeline` loads the Timeline subview/page and `/timeline` redirects to `/stats/timeline`
 - [x] T051 [NAV] Create or extract `src/web/src/pages/CollectionDistributionPage.vue` for the current Collection Distribution stats content
 - [x] T052 [NAV] Update `src/web/src/router/index.ts` so `/stats/distribution` loads `CollectionDistributionPage.vue`
-- [x] T053 [NAV] Refactor `src/web/src/pages/StatsPage.vue` into a landing page with cards linking to `/stats/mint-map`, `/stats/timeline`, and `/stats/distribution`
+- [x] T053 [NAV] Refactor `src/web/src/pages/StatsPage.vue` into a landing page with cards linking to `/stats/mint-map`, `/stats/timeline`, and `/stats/distribution` — **superseded by Brian's clarified 2026-06-18 Stats IA**
 - [x] T054 [NAV] Remove Mint Map launch actions from `src/web/src/components/collection/DesktopCollectionHeader.vue`
 - [x] T055 [NAV] Remove Mint Map launch actions from `src/web/src/components/collection/PwaCollectionHeader.vue`
 
@@ -108,6 +108,18 @@ The following tasks were completed in the beta implementation. They remain usefu
 - [x] T068 Run strict frontend type checking from `src/web`: `npm.cmd run type-check`
 - [x] T069 Run frontend production build from `src/web`: `npm.cmd run build`
 - [x] T070 Confirm the final implementation diff contains no `src/api/`, database migration, geocoding, AI inference, Mapbox, custom tile-hosting, or private collection data in OSM tile URLs
+
+---
+
+## Follow-up Phase 13: Clarified Stats Sidebar IA
+
+**Purpose**: Match Brian's revised sketch exactly: Stats is a parent item; `/stats` shows summary metrics only; Collection Distribution is not a visible submenu item.
+
+- [x] T071 [NAV] Update `src/web/src/App.vue` so `Stats` owns exactly four indented submenu links: Timeline, Map, Health, and Value Trends
+- [x] T072 [NAV] Remove standalone top-level Timeline from `src/web/src/App.vue` and keep Stats submenu links tied to the Stats parent during menu reorder mode
+- [x] T073 [NAV] Update `src/web/src/pages/StatsPage.vue` so `/stats` renders only the summary metrics/cards content, not navigation cards
+- [x] T074 [NAV] Keep `/stats/distribution` available for `#collection-health` and `#value-over-time` anchors without exposing `Collection Distribution` in the sidebar submenu
+- [x] T075 [P] [NAV] Update Vitest coverage for Stats summary landing, Stats sidebar submenu contents, absence of top-level Timeline, and legacy redirects
 
 ---
 

--- a/src/web/src/App.vue
+++ b/src/web/src/App.vue
@@ -38,20 +38,37 @@
           </button>
         </div>
         <nav ref="navRef" class="sidebar-nav" :class="{ 'edit-mode': editMode }">
-          <component
+          <div
             v-for="item in orderedNavItems"
             :key="item.id"
-            :is="!editMode && item.to ? 'router-link' : 'button'"
-            v-bind="!editMode && item.to ? { to: item.to, 'active-class': 'active' } : {}"
-            class="sidebar-link"
+            class="sidebar-item"
             :data-id="item.id"
-            @click="handleNavClick(item)"
           >
-            <span v-if="editMode" class="drag-handle"><GripVertical :size="16" /></span>
-            <component :is="item.icon" :size="20" />
-            <span>{{ item.label }}</span>
-            <span v-if="item.badge && item.badge() > 0" class="sidebar-badge">{{ item.badge() }}</span>
-          </component>
+            <component
+              :is="!editMode && item.to ? 'router-link' : 'button'"
+              v-bind="!editMode && item.to ? { to: item.to, 'active-class': 'active' } : {}"
+              class="sidebar-link"
+              @click="handleNavClick(item)"
+            >
+              <span v-if="editMode" class="drag-handle"><GripVertical :size="16" /></span>
+              <component :is="item.icon" :size="20" />
+              <span>{{ item.label }}</span>
+              <span v-if="item.badge && item.badge() > 0" class="sidebar-badge">{{ item.badge() }}</span>
+            </component>
+            <div v-if="item.children?.length && !editMode" class="sidebar-submenu" :aria-label="`${item.label} views`">
+              <router-link
+                v-for="child in item.children"
+                :key="child.id"
+                :to="child.to"
+                class="sidebar-sublink"
+                active-class="active"
+                @click="sidebarOpen = false"
+              >
+                <ChevronRight :size="14" class="sidebar-subchevron" />
+                <span>{{ child.label }}</span>
+              </router-link>
+            </div>
+          </div>
         </nav>
         <div class="sidebar-footer">
           <router-link to="/settings" class="sidebar-link" active-class="active" @click="sidebarOpen = false">
@@ -126,7 +143,7 @@
 import { ref, computed, watch, nextTick, onMounted, onUnmounted, markRaw, type Component } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useRouter } from 'vue-router'
-import { Landmark, Bookmark, BadgeDollarSign, BarChart3, CirclePlus, Settings, ShieldCheck, LogOut, Users as UsersIcon, Clock, Bot, Gavel, X, Bell, Plus, CalendarDays, Share2, GripVertical, BookOpen, Layers3, Search, NotebookPen } from 'lucide-vue-next'
+import { Landmark, Bookmark, BadgeDollarSign, BarChart3, CirclePlus, Settings, ShieldCheck, LogOut, Users as UsersIcon, Bot, Gavel, X, Bell, Plus, CalendarDays, Share2, GripVertical, BookOpen, Layers3, Search, NotebookPen, ChevronRight } from 'lucide-vue-next'
 import { updateProfile, getMe } from '@/api/client'
 import { useNotifications } from '@/composables/useNotifications'
 import { useBulkSelect } from '@/composables/useBulkSelect'
@@ -144,6 +161,13 @@ interface NavItem {
   action?: () => void
   visible: boolean
   badge?: () => number
+  children?: NavSubItem[]
+}
+
+interface NavSubItem {
+  id: string
+  label: string
+  to: string
 }
 
 const auth = useAuthStore()
@@ -171,9 +195,20 @@ const defaultNavItems: NavItem[] = [
   { id: 'auctions', label: 'Auctions', icon: markRaw(Gavel), to: '/auctions', visible: true },
   { id: 'followers', label: 'Followers', icon: markRaw(UsersIcon), to: '/followers', visible: true },
   { id: 'agent', label: 'Agent', icon: markRaw(Bot), action: () => { showChat.value = true; sidebarOpen.value = false }, visible: true },
-  { id: 'stats', label: 'Stats', icon: markRaw(BarChart3), to: '/stats', visible: true },
+  {
+    id: 'stats',
+    label: 'Stats',
+    icon: markRaw(BarChart3),
+    to: '/stats',
+    visible: true,
+    children: [
+      { id: 'stats-timeline', label: 'Timeline', to: '/stats/timeline' },
+      { id: 'stats-map', label: 'Map', to: '/stats/mint-map' },
+      { id: 'stats-health', label: 'Health', to: '/stats/distribution#collection-health' },
+      { id: 'stats-value-trends', label: 'Value Trends', to: '/stats/distribution#value-over-time' },
+    ],
+  },
   { id: 'sets', label: 'Sets', icon: markRaw(Layers3), to: '/sets', visible: true },
-  { id: 'timeline', label: 'Timeline', icon: markRaw(Clock), to: '/stats/timeline', visible: true },
   { id: 'notes', label: 'Notes', icon: markRaw(NotebookPen), to: '/notes', visible: true },
   { id: 'calendar', label: 'Calendar', icon: markRaw(CalendarDays), to: '/calendar', visible: true },
   { id: 'showcases', label: 'Showcases', icon: markRaw(Share2), to: '/showcases', visible: true },
@@ -548,6 +583,10 @@ onUnmounted(() => {
   padding: 0.75rem 0;
 }
 
+.sidebar-item {
+  width: 100%;
+}
+
 .sidebar-link {
   display: flex;
   align-items: center;
@@ -573,6 +612,33 @@ onUnmounted(() => {
   color: var(--accent-gold);
   background: var(--accent-gold-glow);
   border-right: 3px solid var(--accent-gold);
+}
+
+.sidebar-submenu {
+  display: flex;
+  flex-direction: column;
+  padding: 0.15rem 0 0.35rem;
+}
+
+.sidebar-sublink {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 1.25rem 0.45rem 3.25rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-decoration: none;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.sidebar-sublink:hover,
+.sidebar-sublink.active {
+  color: var(--accent-gold);
+  background: var(--accent-gold-glow);
+}
+
+.sidebar-subchevron {
+  flex-shrink: 0;
 }
 
 .sidebar-badge {

--- a/src/web/src/__tests__/AppNavigation.test.ts
+++ b/src/web/src/__tests__/AppNavigation.test.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appPath = path.resolve(__dirname, '../App.vue')
+
+describe('App sidebar navigation', () => {
+  it('renders Stats as the parent for the clarified submenu only', () => {
+    const source = fs.readFileSync(appPath, 'utf8')
+
+    expect(source).toContain("label: 'Stats'")
+    expect(source).toContain("label: 'Timeline', to: '/stats/timeline'")
+    expect(source).toContain("label: 'Map', to: '/stats/mint-map'")
+    expect(source).toContain("label: 'Health', to: '/stats/distribution#collection-health'")
+    expect(source).toContain("label: 'Value Trends', to: '/stats/distribution#value-over-time'")
+    expect(source).not.toContain("id: 'timeline'")
+    expect(source).not.toContain("label: 'Collection Distribution'")
+  })
+})

--- a/src/web/src/pages/StatsPage.vue
+++ b/src/web/src/pages/StatsPage.vue
@@ -1,78 +1,41 @@
 <template>
-  <div class="container stats-landing">
-    <header class="page-header stats-landing-header">
-      <div>
-        <p class="section-label">Collection Insights</p>
-        <h1>Stats</h1>
-        <p class="page-intro">Choose a focused view for collection geography, chronology, and distribution.</p>
-      </div>
-    </header>
+  <PullToRefresh :on-refresh="handleRefresh">
+    <div class="container stats-landing">
+      <header class="page-header stats-landing-header">
+        <div>
+          <p class="section-label">Collection Insights</p>
+          <h1>Stats</h1>
+          <p class="page-intro">Your collection summary at a glance.</p>
+        </div>
+      </header>
 
-    <section class="stats-card-grid" aria-label="Stats views">
-      <router-link
-        v-for="card in statsCards"
-        :key="card.to"
-        class="stats-nav-card card"
-        :to="card.to"
-      >
-        <component :is="card.icon" class="card-icon" :size="24" />
-        <span class="section-label">{{ card.label }}</span>
-        <h2>{{ card.title }}</h2>
-        <p>{{ card.description }}</p>
-        <span class="card-action">Open {{ card.title }}</span>
-      </router-link>
-    </section>
-  </div>
+      <div v-if="!stats" class="loading-overlay">
+        <div class="spinner"></div>
+      </div>
+
+      <section v-else id="summary" aria-label="Summary metrics">
+        <StatsSummaryCards :stats="stats" />
+      </section>
+    </div>
+  </PullToRefresh>
 </template>
 
 <script setup lang="ts">
-import { markRaw } from 'vue'
-import { Activity, BarChart3, Clock, HeartPulse, LineChart, MapPinned } from 'lucide-vue-next'
+import { computed, onMounted } from 'vue'
+import { useCoinsStore } from '@/stores/coins'
+import PullToRefresh from '@/components/PullToRefresh.vue'
+import StatsSummaryCards from '@/components/stats/StatsSummaryCards.vue'
 
-const statsCards = [
-  {
-    label: 'Collection Geography',
-    title: 'Mint Map',
-    description: 'Plot matched mint names from your active collection on a real OpenStreetMap view.',
-    to: '/stats/mint-map',
-    icon: markRaw(MapPinned),
-  },
-  {
-    label: 'Acquisition History',
-    title: 'Timeline',
-    description: 'Review collection, sold, and all-coin acquisition history by month.',
-    to: '/stats/timeline',
-    icon: markRaw(Clock),
-  },
-  {
-    label: 'Collection Makeup',
-    title: 'Collection Distribution',
-    description: 'Compare category, material, era, ruler, price, and heat-map distribution.',
-    to: '/stats/distribution',
-    icon: markRaw(BarChart3),
-  },
-  {
-    label: 'Collection Quality',
-    title: 'Collection Health',
-    description: 'Inspect the health scorecard and 30-day trend in the distribution view.',
-    to: '/stats/distribution#collection-health',
-    icon: markRaw(HeartPulse),
-  },
-  {
-    label: 'Portfolio Trend',
-    title: 'Value Over Time',
-    description: 'Review invested and current value history in the distribution view.',
-    to: '/stats/distribution#value-over-time',
-    icon: markRaw(LineChart),
-  },
-  {
-    label: 'At a Glance',
-    title: 'Summary Cards',
-    description: 'See the existing collection summary metrics in the distribution view.',
-    to: '/stats/distribution#summary',
-    icon: markRaw(Activity),
-  },
-] as const
+const store = useCoinsStore()
+const stats = computed(() => store.stats)
+
+async function handleRefresh() {
+  await store.fetchStats()
+}
+
+onMounted(() => {
+  store.fetchStats()
+})
 </script>
 
 <style scoped>
@@ -90,50 +53,5 @@ const statsCards = [
   margin: 0.35rem 0 0;
   color: var(--text-secondary);
   font-size: 0.9rem;
-}
-
-.stats-card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
-}
-
-.stats-nav-card {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  padding: 1.5rem;
-  color: var(--text-primary);
-  text-decoration: none;
-  transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
-}
-
-.stats-nav-card:hover,
-.stats-nav-card:focus-visible {
-  border-color: var(--accent-gold);
-  box-shadow: var(--shadow-glow);
-  transform: translateY(-2px);
-}
-
-.card-icon {
-  color: var(--accent-gold);
-}
-
-.stats-nav-card h2 {
-  margin: 0;
-}
-
-.stats-nav-card p {
-  flex: 1;
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.card-action {
-  color: var(--accent-gold);
-  font-size: 0.85rem;
-  font-weight: 600;
 }
 </style>

--- a/src/web/src/pages/__tests__/MintMapNavigation.test.ts
+++ b/src/web/src/pages/__tests__/MintMapNavigation.test.ts
@@ -23,12 +23,16 @@ describe('MintMap navigation entry points', () => {
     expect(routerSource).toContain("redirect: '/stats/timeline'")
   })
 
-  it('links to stats subviews from the Stats landing page', () => {
-    const statsSource = fs.readFileSync(path.resolve(srcRoot, 'pages/StatsPage.vue'), 'utf8')
+  it('keeps stats subviews nested under the Stats sidebar item', () => {
+    const appSource = fs.readFileSync(path.resolve(srcRoot, 'App.vue'), 'utf8')
 
-    expect(statsSource).toContain('Collection Geography')
-    expect(statsSource).toContain("to: '/stats/mint-map'")
-    expect(statsSource).toContain("to: '/stats/timeline'")
-    expect(statsSource).toContain("to: '/stats/distribution'")
+    expect(appSource).toContain("id: 'stats'")
+    expect(appSource).toContain("label: 'Stats'")
+    expect(appSource).toContain("label: 'Timeline', to: '/stats/timeline'")
+    expect(appSource).toContain("label: 'Map', to: '/stats/mint-map'")
+    expect(appSource).toContain("label: 'Health', to: '/stats/distribution#collection-health'")
+    expect(appSource).toContain("label: 'Value Trends', to: '/stats/distribution#value-over-time'")
+    expect(appSource).not.toContain("id: 'timeline'")
+    expect(appSource).not.toContain("label: 'Collection Distribution'")
   })
 })

--- a/src/web/src/pages/__tests__/StatsPage.test.ts
+++ b/src/web/src/pages/__tests__/StatsPage.test.ts
@@ -1,25 +1,52 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import StatsPage from '@/pages/StatsPage.vue'
+import type { StatsResponse } from '@/types'
 
-const routerLinkStub = {
-  props: ['to'],
-  template: '<a :href="to"><slot /></a>',
+const stats: StatsResponse = {
+  totalCoins: 42,
+  totalWishlist: 7,
+  byCategory: [],
+  byMaterial: [],
+  byGrade: [],
+  byEra: [],
+  byRuler: [],
+  byPriceRange: [],
+  values: {
+    totalPurchasePrice: 1200,
+    totalCurrentValue: 1500,
+    avgPurchasePrice: 120,
+    avgCurrentValue: 150,
+  },
 }
 
+const store = vi.hoisted(() => ({
+  stats: null as StatsResponse | null,
+  fetchStats: vi.fn(),
+}))
+
+vi.mock('@/stores/coins', () => ({
+  useCoinsStore: () => store,
+}))
+
 describe('StatsPage', () => {
-  it('renders landing cards for stats subviews', () => {
+  it('renders summary metrics instead of stats navigation cards', () => {
+    store.stats = stats
+
     const wrapper = mount(StatsPage, {
-      global: { stubs: { RouterLink: routerLinkStub } },
+      global: {
+        stubs: {
+          PullToRefresh: { template: '<div><slot /></div>' },
+        },
+      },
     })
 
-    expect(wrapper.text()).toContain('Mint Map')
-    expect(wrapper.text()).toContain('Timeline')
-    expect(wrapper.text()).toContain('Collection Distribution')
-    expect(wrapper.text()).toContain('Collection Health')
-    expect(wrapper.text()).toContain('Value Over Time')
-    expect(wrapper.html()).toContain('href="/stats/mint-map"')
-    expect(wrapper.html()).toContain('href="/stats/timeline"')
-    expect(wrapper.html()).toContain('href="/stats/distribution"')
+    expect(wrapper.text()).toContain('Coins Owned')
+    expect(wrapper.text()).toContain('On Wishlist')
+    expect(wrapper.text()).toContain('Total Value')
+    expect(wrapper.text()).toContain('Value Summary')
+    expect(wrapper.text()).not.toContain('Open Mint Map')
+    expect(wrapper.text()).not.toContain('Collection Distribution')
+    expect(wrapper.findAll('a[href^="/stats/"]')).toHaveLength(0)
   })
 })

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -3,8 +3,10 @@ import { useAuthStore } from '@/stores/auth'
 
 const router = createRouter({
   history: createWebHistory(),
-  scrollBehavior(_to, _from, savedPosition) {
-    return savedPosition ?? { top: 0 }
+  scrollBehavior(to, _from, savedPosition) {
+    if (savedPosition) return savedPosition
+    if (to.hash) return { el: to.hash }
+    return { top: 0 }
   },
   routes: [
     {


### PR DESCRIPTION
## Summary
- Updates sidebar navigation so Stats has exactly Timeline, Map, Health, and Value Trends subitems
- Removes the top-level Timeline menu item
- Keeps Collection Distribution out of the sidebar submenu
- Changes /stats from navigation-card landing to summary metric cards only
- Preserves redirects for /mint-map and /timeline

## Constitution
Principle IV + §17

## Validation
- npm.cmd test -- Stats MintMapNavigation App --run
- npm.cmd test -- --run
- npm.cmd run type-check
- npm.cmd run lint (0 errors; existing unrelated warnings remain)
- npm.cmd run build
- git diff --check

## Notes
Manual mobile/PWA map verification remains unchecked in tasks.md because it requires interactive phone viewport testing outside this CLI.