### PR TITLE
fix: keep mint drawer above map

### DIFF
--- a/src/web/src/components/map/MintCoinDrawer.vue
+++ b/src/web/src/components/map/MintCoinDrawer.vue
@@ -63,7 +63,7 @@ onBeforeUnmount(() => {
   right: 1rem;
   top: 5rem;
   bottom: 1rem;
-  z-index: 300;
+  z-index: 1100;
   width: min(380px, calc(100vw - 2rem));
   overflow-y: auto;
   padding: 1rem;

--- a/src/web/src/components/map/__tests__/MintCoinDrawer.test.ts
+++ b/src/web/src/components/map/__tests__/MintCoinDrawer.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
 import MintCoinDrawer from '@/components/map/MintCoinDrawer.vue'
 import { groupCoinsByMint } from '@/utils/mintMap'
 import { buildMintMapFixtureCoins } from '@/test/fixtures/coins'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 const routerLinkStub = {
   props: ['to'],
@@ -20,5 +26,22 @@ describe('MintCoinDrawer', () => {
     expect(wrapper.text()).toContain('Trajan Denarius Core')
     expect(wrapper.text()).toContain('Roma Alias Denarius')
     expect(wrapper.text()).not.toContain('Byzantium Alias Solidus')
+  })
+
+  it('renders drawer with z-index 1100 to stack above Leaflet map controls (z-index 1000)', () => {
+    const group = groupCoinsByMint(buildMintMapFixtureCoins()).matched.find((item) => item.mint.id === 'rome') ?? null
+    const wrapper = mount(MintCoinDrawer, {
+      props: { open: true, group },
+      global: { stubs: { RouterLink: routerLinkStub } },
+    })
+
+    const drawer = wrapper.find('.mint-drawer')
+    expect(drawer.exists()).toBe(true)
+
+    // Source-level assertion: verify component contains the critical z-index fix
+    const componentPath = resolve(__dirname, '..', 'MintCoinDrawer.vue')
+    const componentSource = readFileSync(componentPath, 'utf-8')
+    expect(componentSource).toContain('.mint-drawer')
+    expect(componentSource).toMatch(/\.mint-drawer\s*{[^}]*z-index:\s*1100/s)
   })
 })


### PR DESCRIPTION
## Summary
- Raise the Mint Map coin drawer above Leaflet panes and controls so selected coin details remain readable
- Add a focused regression check for the critical drawer z-index value

## Root Cause
Leaflet controls can stack up to z-index 1000, while the drawer was at z-index 300, letting map layers bleed over the details panel.

## Constitution / Spec
- Principle IV: simple, complete proportional fix
- §17 Quality Gate
- Feature 225 map interaction regression

## Validation
- `npm.cmd test -- MintCoinDrawer MintMapLeaflet MintMapPage --run` from `src/web`
- `npm.cmd run type-check` from `src/web`
- `npm.cmd run lint` from `src/web` (0 errors; existing warnings remain)
- `npm.cmd run build` from `src/web`
- `git diff --check`