### PR TITLE
feat: add museum tray view

### DIFF
--- a/specs/224-museum-tray-view/plan.md
+++ b/specs/224-museum-tray-view/plan.md
@@ -44,7 +44,7 @@ Add a read-only frontend-only Tray display mode that renders the current collect
 
 **§17 Quality Gate**: Tests must cover diameter scaling, missing diameter fallback, drawer pagination, responsive grid, and action routing; `type-check`, `build` must pass.
 
-**§21 DoD**: Component tests, utility tests, type safety, responsive design tested, integration with collection headers verified.
+**§21 DoD**: Component tests, utility tests, type safety, responsive design tested, and sidebar navigation integration verified.
 
 ---
 
@@ -57,12 +57,9 @@ specs/224-museum-tray-view/
 
 src/web/src/
 ├── pages/
-│   ├── CollectionPage.vue               # Existing; add Tray button to headers
+│   ├── CollectionPage.vue               # Existing; no changes
 │   └── TrayViewPage.vue                 # NEW: Main tray view page
 ├── components/
-│   ├── collection/
-│   │   ├── DesktopCollectionHeader.vue  # Existing; add Tray button
-│   │   └── PwaCollectionHeader.vue      # Existing; add Tray button
 │   ├── tray/                            # NEW: Tray-specific components
 │   │   ├── MuseumTray.vue               # NEW: Grid container with felt background
 │   │   ├── MuseumTrayWell.vue           # NEW: Single coin well component
@@ -78,11 +75,12 @@ src/web/src/
 │   ├── useTrayPreference.ts             # NEW: LocalStorage felt color persistence
 │   └── __tests__/
 │       └── useTrayPreference.test.ts    # NEW: Test localStorage persistence
+├── App.vue                              # Existing; update sidebar navigation to add Tray submenu
 └── router/
     └── index.ts                         # Existing; add /tray route
 ```
 
-**Structure Decision**: All tray-specific presentation under `components/tray/`. Layout math in `utils/trayLayout.ts` for independent testing and reuse. Composable for preference logic. Tests follow repo convention in `__tests__/` subdirectories at component/utils/composables level.
+**Structure Decision**: All tray-specific presentation under `components/tray/`. Layout math in `utils/trayLayout.ts` for independent testing and reuse. Composable for preference logic. Tests follow repo convention in `__tests__/` subdirectories at component/utils/composables level. Sidebar navigation updated in `App.vue` to add "Tray" as a submenu item under Collection (parallel to Stats structure).
 
 ---
 
@@ -211,7 +209,7 @@ interface TrayLayoutOptions {
 
 ### Phase 3: Page and Route (Dependency: Phase 2 complete)
 
-**Purpose**: Wire tray into app and make it reachable.
+**Purpose**: Wire tray into app and make it reachable via sidebar.
 
 1. Create `src/web/src/pages/TrayViewPage.vue`:
    - Use `useCoinsStore()` to access `store.coins`.
@@ -228,19 +226,17 @@ interface TrayLayoutOptions {
 2. Update `src/web/src/router/index.ts`:
    - Add route: `{ path: '/tray', component: TrayViewPage, meta: { requiresAuth: true } }`.
 
-3. Update `src/web/src/components/collection/DesktopCollectionHeader.vue`:
-   - Add "Tray" chip/button in the toolbar-right area (alongside other view options).
+3. Update `src/web/src/App.vue`:
+   - Add "Tray" submenu item under Collection in the sidebar navigation.
+   - Follow the same submenu structure as Stats (e.g., Gallery under Collection as the main collection view, Tray as a submenu item).
    - Router link or click handler to navigate to `/tray`.
-
-4. Update `src/web/src/components/collection/PwaCollectionHeader.vue`:
-   - Add "Tray" chip/button in the View section of pwa-menu (alongside existing view toggles).
-   - Router link or click handler to navigate to `/tray`.
+   - Ensure submenu expands/collapses consistently with existing navigation patterns.
 
 ---
 
 ### Phase 4: Coin Interaction (Dependency: Phase 3 complete)
 
-**Purpose**: Handle user actions in tray.
+**Purpose**: Handle user actions in tray and verify navigation works end-to-end.
 
 1. Update `TrayViewPage.vue`:
    - On `coin-clicked` event, route to `/coin/:id` using `router.push({ name: 'coin-detail', params: { id: coin.id } })`.
@@ -253,6 +249,11 @@ interface TrayLayoutOptions {
 
 3. Test drawer preservation:
    - Open a coin from drawer 2, return via browser back, verify on drawer 2 still.
+
+4. Test sidebar navigation:
+   - Verify Collection submenu expands/collapses.
+   - Verify clicking "Tray" navigates to `/tray` and Collection submenu remains accessible.
+   - Verify Gallery (collection main view) and Tray submenu items are distinct and work independently.
 
 ---
 

--- a/specs/224-museum-tray-view/plan.md
+++ b/specs/224-museum-tray-view/plan.md
@@ -1,0 +1,332 @@
+# Implementation Plan: Museum Coin Tray View
+
+**Branch**: `224-museum-tray-view-rerun` | **Date**: 2026-06-18 | **Spec**: `specs/224-museum-tray-view/spec.md`
+**Merge target**: `beta`
+**Last Updated**: 2026-06-18 (tightened for accuracy)
+
+---
+
+## Update History
+
+| Date | Change |
+|------|--------|
+| 2026-06-18 | Corrected store name to `useCoinsStore()`; updated router navigation to use `/coin/:id` route name; removed Zod/Pydantic validation mentions; simplified responsive description to avoid false claims about specific class names; aligned test locations to repo conventions (`__tests__/` subdirectories). |
+
+## Summary
+
+Add a read-only frontend-only Tray display mode that renders the current collection as physical coins seated in felt-lined wells. The tray is responsive, paginates large collections, scales coins by `diameterMm` within safe bounds, offers felt color themes, and routes coin interaction to detail pages. No API changes or schema additions required.
+
+---
+
+## Technical Context
+
+**Language/Version**: Vue 3 with TypeScript (Composition API), Vite
+**Primary Dependencies**: Vue Router, Pinia coins store, existing `Coin` and `CoinImage` types, CSS Grid/Flexbox
+**Storage**: LocalStorage for felt color theme preference (UI state only, non-sensitive)
+**Testing**: Vitest component and utility tests; `npm run type-check`; `npm run build`
+**Target Platform**: Mobile PWA (375px+), tablet (768px+), desktop (1024px+)
+**Project Type**: Frontend-only collection display feature
+**Performance Goals**: Render 50 visible tray wells without jank (60fps); lazy-load coin images as needed
+**Constraints**: No API changes, no schema additions, no drag-and-drop, no editing, no saved layouts
+**Scale/Scope**: Current loaded filtered/sorted result set for v1; cross-page tray is a future enhancement
+
+---
+
+## Constitution Check
+
+**Principle I (Clear Layered Architecture)**: Tray components use Pinia store (no direct backend calls); layout math isolated in `utils/trayLayout.ts` for testability.
+
+**Principle III (Strict Types and Explicit Contracts)**: All props, composables, and utilities typed; nullable `diameterMm` handled without casts.
+
+**Principle IV (Simple Complete Changes)**: Flat top-down CSS tray only (no 3D, no perspective, no saved drag layouts); direct mapping of current collection data to well grid.
+
+**Principle VI (Consistent UX)**: Design tokens for all colors/spacing; existing global CSS classes (`btn`, `chip`); dark theme default; no emojis; PWA-compatible interaction.
+
+**§17 Quality Gate**: Tests must cover diameter scaling, missing diameter fallback, drawer pagination, responsive grid, and action routing; `type-check`, `build` must pass.
+
+**§21 DoD**: Component tests, utility tests, type safety, responsive design tested, integration with collection headers verified.
+
+---
+
+## Project Structure
+
+```text
+specs/224-museum-tray-view/
+├── spec.md                              # Feature specification (user stories, requirements)
+└── plan.md                              # This file
+
+src/web/src/
+├── pages/
+│   ├── CollectionPage.vue               # Existing; add Tray button to headers
+│   └── TrayViewPage.vue                 # NEW: Main tray view page
+├── components/
+│   ├── collection/
+│   │   ├── DesktopCollectionHeader.vue  # Existing; add Tray button
+│   │   └── PwaCollectionHeader.vue      # Existing; add Tray button
+│   ├── tray/                            # NEW: Tray-specific components
+│   │   ├── MuseumTray.vue               # NEW: Grid container with felt background
+│   │   ├── MuseumTrayWell.vue           # NEW: Single coin well component
+│   │   └── TrayControls.vue             # NEW: Drawer pagination + felt theme chips
+│   └── __tests__/
+│       ├── MuseumTrayWell.test.ts       # NEW: Test rendering, click/keyboard
+│       ├── MuseumTray.test.ts           # NEW: Test grid, theme, responsive
+├── utils/
+│   ├── trayLayout.ts                    # NEW: Diameter scaling, grid layout helpers
+│   └── __tests__/
+│       └── trayLayout.test.ts           # NEW: Test diameter scaling, pagination
+├── composables/
+│   ├── useTrayPreference.ts             # NEW: LocalStorage felt color persistence
+│   └── __tests__/
+│       └── useTrayPreference.test.ts    # NEW: Test localStorage persistence
+└── router/
+    └── index.ts                         # Existing; add /tray route
+```
+
+**Structure Decision**: All tray-specific presentation under `components/tray/`. Layout math in `utils/trayLayout.ts` for independent testing and reuse. Composable for preference logic. Tests follow repo convention in `__tests__/` subdirectories at component/utils/composables level.
+
+---
+
+## Tray Layout Contracts
+
+### Type: `TrayCoin`
+
+```typescript
+interface TrayCoin {
+  id: number
+  name: string
+  diameterMm: number | null
+  images: readonly CoinImage[]
+}
+```
+
+### Type: `TrayLayoutOptions`
+
+```typescript
+interface TrayLayoutOptions {
+  minCoinPx: number           // e.g., 40
+  maxCoinPx: number           // e.g., 120
+  defaultDiameterMm: number   // e.g., 20 (fallback when missing)
+}
+```
+
+### Function: `normalizeDiameterMm(diameterMm: number | null | undefined, defaultDiameterMm: number): number`
+
+- Returns `diameterMm` if > 0; otherwise returns `defaultDiameterMm`.
+- Used before any scaling calculation.
+
+### Function: `getCoinRenderSizePx(diameterMm: number, allDiameters: number[], options: TrayLayoutOptions): number`
+
+- Calculates render size by scaling proportionally relative to all coins' diameters.
+- Formula: `minSize + (normalized / maxInSet) * (maxSize - minSize)`.
+- Clamps to `[minCoinPx, maxCoinPx]`.
+- Handles empty/missing diameter gracefully.
+
+### Function: `getDrawerCoins(coins: TrayCoin[], drawerIndex: number, coinsPerDrawer: number): TrayCoin[]`
+
+- Slices coins for a given drawer.
+- Returns empty array if drawerIndex is out of bounds.
+- Used for pagination.
+
+### Function: `getTotalDrawers(totalCoins: number, coinsPerDrawer: number): number`
+
+- Calculates drawer count: `Math.ceil(totalCoins / coinsPerDrawer)`.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Layout Utilities & Composable (Dependency: None)
+
+**Purpose**: Core layout logic and preference persistence.
+
+1. Create `src/web/src/utils/trayLayout.ts`:
+   - Export `normalizeDiameterMm()`, `getCoinRenderSizePx()`, `getDrawerCoins()`, `getTotalDrawers()`.
+   - Handle edge cases: empty diameter, negative diameter, single coin, all same diameter.
+
+2. Create `src/web/src/composables/useTrayPreference.ts`:
+   - Hook for reading/writing felt color theme from/to localStorage.
+   - Reactive ref, computed getter.
+
+3. Create `src/web/src/utils/__tests__/trayLayout.test.ts`:
+   - Test `normalizeDiameterMm()`: small obol (8mm), large sestertius (35mm), zero/negative, null.
+   - Test `getCoinRenderSizePx()`: proportional scaling, clamp bounds, missing diameter.
+   - Test `getDrawerCoins()`: drawer slicing, boundary conditions.
+   - Test `getTotalDrawers()`: various collection sizes.
+
+---
+
+### Phase 2: Core Tray Components (Dependency: Phase 1 complete)
+
+**Purpose**: Render tray UI.
+
+1. Create `src/web/src/components/tray/MuseumTrayWell.vue`:
+   - Props: `coin: TrayCoin`, `renderSizePx: number`.
+   - Render circular well with:
+     - Recessed shadow (darker inner circle).
+     - Coin image centered in well (or placeholder if missing).
+     - Contact shadow below coin (soft shadow effect).
+     - Accessible label (aria-label = coin name).
+   - Handle click → emit event.
+   - Handle keyboard focus (Enter key) → emit event.
+   - Use design tokens for colors, shadows.
+   - Respect `prefers-reduced-motion`.
+
+2. Create `src/web/src/components/tray/MuseumTray.vue`:
+   - Props: `coins: TrayCoin[]`, `feltTheme: 'red' | 'green' | 'navy'` (default 'red').
+   - Render felt background with CSS texture/gradient.
+   - CSS Grid layout with responsive columns: adjust column count based on viewport (mobile 2–3, tablet 4–5, desktop 6–8).
+   - Render `MuseumTrayWell` for each coin, passing calculated `renderSizePx`.
+   - Use `trayLayout.getCoinRenderSizePx()` to calculate sizes.
+   - Emit `coin-clicked` event.
+   - Apply theme to root (e.g., class-binding for felt color).
+   - Use design tokens for gap, padding, shadows.
+
+3. Create `src/web/src/components/tray/TrayControls.vue`:
+   - Props: `drawerIndex: number`, `totalDrawers: number`, `feltTheme: 'red' | 'green' | 'navy'`.
+   - Render:
+     - "Drawer 1 of 3" label.
+     - Previous/Next buttons.
+     - Felt color chips (red, green, navy).
+   - Emit `prev`, `next`, `update:feltTheme`.
+   - Disable Previous on first drawer, Next on last drawer.
+
+4. Create `src/web/src/components/__tests__/MuseumTrayWell.test.ts`:
+   - Test coin image rendering, placeholder fallback.
+   - Test click event emission.
+   - Test keyboard (Enter) event emission.
+   - Test accessibility (aria-label).
+
+5. Create `src/web/src/components/__tests__/MuseumTray.test.ts`:
+   - Test well grid rendering.
+   - Test felt theme application (style or class-binding).
+   - Test responsive layout behavior (viewport-based column adjustment).
+   - Test coin-clicked event propagation.
+
+6. Create `src/web/src/composables/__tests__/useTrayPreference.test.ts`:
+   - Test reading/writing localStorage.
+   - Test reactive updates.
+   - Test default fallback.
+
+---
+
+### Phase 3: Page and Route (Dependency: Phase 2 complete)
+
+**Purpose**: Wire tray into app and make it reachable.
+
+1. Create `src/web/src/pages/TrayViewPage.vue`:
+   - Use `useCoinsStore()` to access `store.coins`.
+   - Use `useTrayPreference()` for felt color.
+   - Local state: `drawerIndex`.
+   - Render:
+     - `MuseumTray` with current drawer coins.
+     - `TrayControls` for pagination and theme.
+     - Empty state if `store.coins.length === 0`.
+   - Handle `coin-clicked` → route to `/coin/:id` using router.
+   - Handle Previous/Next → update drawer index.
+   - Preserve drawer position in component state (simplicity).
+
+2. Update `src/web/src/router/index.ts`:
+   - Add route: `{ path: '/tray', component: TrayViewPage, meta: { requiresAuth: true } }`.
+
+3. Update `src/web/src/components/collection/DesktopCollectionHeader.vue`:
+   - Add "Tray" chip/button in the toolbar-right area (alongside other view options).
+   - Router link or click handler to navigate to `/tray`.
+
+4. Update `src/web/src/components/collection/PwaCollectionHeader.vue`:
+   - Add "Tray" chip/button in the View section of pwa-menu (alongside existing view toggles).
+   - Router link or click handler to navigate to `/tray`.
+
+---
+
+### Phase 4: Coin Interaction (Dependency: Phase 3 complete)
+
+**Purpose**: Handle user actions in tray.
+
+1. Update `TrayViewPage.vue`:
+   - On `coin-clicked` event, route to `/coin/:id` using `router.push({ name: 'coin-detail', params: { id: coin.id } })`.
+   - Preserve return path so Back button returns to tray.
+
+2. Test keyboard navigation:
+   - Tab focus on wells.
+   - Enter key opens coin detail.
+   - Escape returns to tray (browser back).
+
+3. Test drawer preservation:
+   - Open a coin from drawer 2, return via browser back, verify on drawer 2 still.
+
+---
+
+### Phase 5: Tests and Validation (Dependency: Phase 4 complete)
+
+**Purpose**: Verify end-to-end behavior.
+
+1. Run component tests: `npm run test -- tray --run`.
+2. Run type-check: `npm run type-check`.
+3. Run build: `npm run build`.
+4. Manual PWA/mobile viewport testing:
+   - 375px (mobile): 2–3 columns.
+   - 768px (tablet): 4–5 columns.
+   - 1024px+ (desktop): 6–8 columns.
+5. Manual interaction testing:
+   - Click coin well → opens detail page.
+   - Keyboard Enter on focused well → opens detail page.
+   - Return from detail → tray drawer position preserved.
+   - Felt color chip click → theme updates and persists.
+6. Optional Playwright smoke test:
+   - Navigate to `/tray` → verify coins render → click a coin → open detail → back → verify tray position.
+
+---
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Flat top-down tray, not 3D perspective | Simpler CSS/rendering, works on all devices, aligns with Principle IV. |
+| Use current loaded result set, not fetch all coins | Avoids API overload, aligns with collection filtering; future enhancement for cross-page tray. |
+| Default tap opens detail, no required long-press | Discoverable, accessible, keyboard-friendly. Inline flip can be opt-in later. |
+| Pure CSS felt texture | Lighter, themeable, no image asset overhead. |
+| Fixed 50 coins per drawer (or page-based) | Simple, matches collection pagination; adaptive per-viewport is a future polish. |
+| Prefer state-based drawer position, not URL param | Simpler component state, avoids URL clutter; position lost on page reload (acceptable for MVP). |
+| Store felt color in localStorage | Non-sensitive UI preference; persistent across sessions without backend. |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Tray shows more coins than loaded in store** | Scope v1 to `store.coins` only; label drawers clearly; future enhancement for full collection cross-page fetch. |
+| **Small coins become untappable** | Clamp render size to minimum 40px; verify tap target in tests. |
+| **Large coins dominate layout** | Clamp to maximum 120px; test with realistic diameter range (8mm–50mm). |
+| **Visual drift from design tokens** | Use tokens for all colors, spacing, shadows; no hardcoded values. |
+| **Felt color theme not persisting** | Test localStorage save/load in composable tests. |
+| **Responsive grid breaks on edge viewports** | Test at exact breakpoints (375, 768, 1024) and intermediate widths. |
+| **Drawer position lost on return** | Preserve in component state (not query param) for simplicity. |
+| **Animation jank on low-end devices** | Respect `prefers-reduced-motion`, use CSS Grid (efficient), lazy-load images. |
+
+---
+
+## Out of Scope (Future Enhancements)
+
+- Drag-and-drop tray rearrangement.
+- Saved custom tray layouts.
+- Full-collection cross-page tray (would require API pagination expansion).
+- 3D perspective or flip animation within wells.
+- Public/shared tray links.
+- Editable tray (bulk actions, selection mode).
+- Pinch-zoom or swipe navigation.
+
+---
+
+## Success Criteria (from Spec)
+
+- ✅ Tray reachable from collection page in one click.
+- ✅ Coins render in felt-lined wells with shadows.
+- ✅ Grid reflows: 2–3 mobile, 4–5 tablet, 6–8 desktop.
+- ✅ Large collections paginate with Previous/Next navigation.
+- ✅ Tap/keyboard opens coin detail.
+- ✅ Drawer position preserved on return.
+- ✅ Diameter scaling works proportionally, fallback for missing.
+- ✅ Felt color theme updates and persists.
+- ✅ All tests pass; type-check, build succeed.
+- ✅ `prefers-reduced-motion` respected.

--- a/specs/224-museum-tray-view/spec.md
+++ b/specs/224-museum-tray-view/spec.md
@@ -24,15 +24,15 @@ Add a read-only **Tray view** display mode that presents the collection as physi
 
 ### User Story 1: Enter Tray View (Priority: P1)
 
-As a collector, I open the "Tray" view from the collection page and see my coins seated in felt-lined wells, so the collection reads as physical objects.
+As a collector, I open the "Tray" view from the Collection submenu in the sidebar and see my coins seated in felt-lined wells, so the collection reads as physical objects.
 
 **Why this priority**: Core feature. Without this, the tray doesn't exist. Enables all other stories.
 
-**Independent Test**: Able to navigate from collection page to tray view and see coins rendered in wells. Empty tray shows friendly message if collection is empty.
+**Independent Test**: Able to navigate from Collection submenu to tray view and see coins rendered in wells. Empty tray shows friendly message if collection is empty.
 
 **Acceptance Scenarios**:
 
-1. **Given** I am on the collection page with coins loaded, **When** I click/tap the "Tray" view button, **Then** I navigate to `/tray` and see coins seated in felt-lined wells with soft shadows.
+1. **Given** I am viewing the app sidebar with the Collection menu expanded, **When** I click/tap the "Tray" submenu item, **Then** I navigate to `/tray` and see coins seated in felt-lined wells with soft shadows.
 2. **Given** I am on an empty collection, **When** I navigate to `/tray`, **Then** I see a friendly empty state and option to return to collection or add coins.
 3. **Given** I am viewing the tray, **When** I return to the collection page, **Then** my filters and sort order are preserved.
 
@@ -147,7 +147,7 @@ As an accessibility-conscious user with `prefers-reduced-motion` enabled, the tr
 - **FR-008**: System MUST offer at least 3 felt color themes (red, green, navy) and persist the user's selection in localStorage.
 - **FR-009**: System MUST respect `prefers-reduced-motion: reduce` and avoid animations on hover/focus.
 - **FR-010**: System MUST show a friendly empty state if the collection is empty or the current filtered set is empty.
-- **FR-011**: System MUST be reachable via a "Tray" button/chip in both desktop and PWA collection headers.
+- **FR-011**: System MUST be reachable via a "Tray" submenu item under Collection in the sidebar navigation (consistent with Stats submenu structure).
 - **FR-012**: System MUST use only existing design tokens and global button/chip CSS classes; no hardcoded colors or spacing.
 
 ### Key Entities
@@ -158,8 +158,8 @@ As an accessibility-conscious user with `prefers-reduced-motion` enabled, the tr
 
 ### Data Flow
 
-1. **CollectionPage** / **Headers** → User clicks "Tray" button.
-2. **Router** → Navigate to `/tray`.
+1. **App.vue** → Collection submenu expands to show sub-items (Gallery, Tray).
+2. **User clicks "Tray"** → Navigate to `/tray`.
 3. **TrayViewPage** → Fetch `store.coins` (already loaded from collection); if empty, show empty state.
 4. **MuseumTray** → Calculate layout via `trayLayout.ts`, render wells grid.
 5. **MuseumTrayWell** → Render coin image, shadow, handle click/keyboard.
@@ -171,7 +171,7 @@ As an accessibility-conscious user with `prefers-reduced-motion` enabled, the tr
 
 ### Measurable Outcomes
 
-- **SC-001**: Users can navigate to tray view from collection page in one click/tap.
+- **SC-001**: Users can navigate to tray view from the Collection submenu in the sidebar in one click/tap.
 - **SC-002**: Tray renders all loaded coins in the current drawer without jank (60fps on mobile, no long paint times).
 - **SC-003**: 100% of coins with `diameterMm` are scaled proportionally; 100% of coins without it use safe default size.
 - **SC-004**: On mobile, tray grid is 2–3 columns; on tablet 4–5; on desktop 6–8 (responsive layout verified, no hardcoded pixel values).

--- a/specs/224-museum-tray-view/spec.md
+++ b/specs/224-museum-tray-view/spec.md
@@ -1,0 +1,200 @@
+# Spec: Museum Coin Tray View
+
+**Feature Branch**: `224-museum-tray-view-rerun`
+**Created**: 2026-06-18
+**Last Updated**: 2026-06-18 (tightened for accuracy)
+**Status**: Draft
+**Input**: Historical spec from `224-museum-tray-view` branch, adapted for current beta state
+
+---
+
+## Update History
+
+| Date | Change |
+|------|--------|
+| 2026-06-18 | Tightened spec to match actual codebase (store is `useCoinsStore()`, route is `/coin/:id`); clarified responsive behavior without specific class names; simplified scope to current loaded collection only. |
+
+## Summary
+
+Add a read-only **Tray view** display mode that presents the collection as physical coins seated in a museum exhibit tray. Coins rest in felt-lined circular wells on a textured felt background with soft shadows, conveying the collection as tangible objects rather than data cards. The tray is responsive, paginates large collections into multiple drawers, and scales coins proportionally by their diameter when available.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Enter Tray View (Priority: P1)
+
+As a collector, I open the "Tray" view from the collection page and see my coins seated in felt-lined wells, so the collection reads as physical objects.
+
+**Why this priority**: Core feature. Without this, the tray doesn't exist. Enables all other stories.
+
+**Independent Test**: Able to navigate from collection page to tray view and see coins rendered in wells. Empty tray shows friendly message if collection is empty.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am on the collection page with coins loaded, **When** I click/tap the "Tray" view button, **Then** I navigate to `/tray` and see coins seated in felt-lined wells with soft shadows.
+2. **Given** I am on an empty collection, **When** I navigate to `/tray`, **Then** I see a friendly empty state and option to return to collection or add coins.
+3. **Given** I am viewing the tray, **When** I return to the collection page, **Then** my filters and sort order are preserved.
+
+---
+
+### User Story 2: Size-Accurate Coin Display (Priority: P2)
+
+As a collector with a varied collection, I see coins sized relative to each other based on their actual diameter, so the tray honestly reflects their physical scale.
+
+**Why this priority**: Enhances visual authenticity. Depends on diameter data availability. If diameter is missing, fallback gracefully.
+
+**Independent Test**: Can verify coins with different diameters (small obol 8mm, large sestertius 35mm) render at proportionally different sizes; coins without diameter use safe default size; all coins remain tappable (min tap target met).
+
+**Acceptance Scenarios**:
+
+1. **Given** I have coins with `diameterMm` populated, **When** I view the tray, **Then** coins are scaled proportionally (larger coins appear visibly larger than smaller coins).
+2. **Given** I have coins with missing or zero `diameterMm`, **When** they render in the tray, **Then** they use a sensible default size and remain fully tappable.
+3. **Given** coin diameters range from 8mm to 40mm, **When** displayed in the tray, **Then** render sizes are clamped to safe min/max bounds (e.g., 40px–120px) so small coins remain visible and large coins don't dominate.
+
+---
+
+### User Story 3: Responsive Tray Layout (Priority: P2)
+
+As a collector on mobile, tablet, or desktop, the tray grid reflows sensibly for my viewport, wells remain finger-friendly on small screens, and pagination controls are compact and discoverable.
+
+**Why this priority**: Core UX requirement for PWA. Tray is useless if it doesn't adapt to device orientation and size.
+
+**Independent Test**: On mobile (375px), tablet (768px), and desktop (1024px+), verify wells are appropriately sized, pagination controls are visible, and no horizontal scroll is needed.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am on a mobile device (375px), **When** I view the tray, **Then** wells stack in a 2–3 column grid, remain finger-friendly, and pagination is compact and accessible.
+2. **Given** I am on a tablet (768px), **When** I view the tray, **Then** wells stack in a 4–5 column grid with appropriate gaps.
+3. **Given** I am on desktop (1024px+), **When** I view the tray, **Then** wells stack in a 6–8 column grid with balanced spacing.
+4. **Given** any viewport, **When** I rotate the device, **Then** the grid reflows smoothly and content remains accessible.
+
+---
+
+### User Story 4: Pagination and Navigation (Priority: P2)
+
+As a collector with a large collection, my tray paginates into multiple "drawers" so I can browse without overwhelming the page, and I can navigate between drawers.
+
+**Why this priority**: Necessary for usability with 100+ coins. Drawer navigation must be intuitive and position-preserving.
+
+**Independent Test**: With a collection of 100+ coins, verify Previous/Next drawer buttons work, drawer count updates correctly, opening a coin and returning preserves drawer position.
+
+**Acceptance Scenarios**:
+
+1. **Given** I have 150 coins and the tray shows 50 per drawer, **When** I view the tray, **Then** I see Drawer 1 of 3 with Previous/Next navigation.
+2. **Given** I am on Drawer 2 of 3, **When** I click a coin to open detail, **Then** I open the coin detail page.
+3. **Given** I am viewing a coin detail and return to the tray, **Then** I return to the same drawer and position I left.
+4. **Given** I am on the last drawer, **When** I click Next, **Then** the button is disabled or no-op (no wrapping).
+
+---
+
+### User Story 5: Coin Interaction (Priority: P1)
+
+As a collector in the tray, I can tap a coin to open its detail page, so I can inspect or edit it without leaving the tray view unnecessarily.
+
+**Why this priority**: Core interaction. Tray is read-only presentation, but users must be able to access full coin details.
+
+**Independent Test**: Tap/click a coin well, and it routes to `/coin/:id` detail page. Keyboard Enter on a focused well also opens detail. Long-press is not required.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am viewing the tray, **When** I click/tap a coin well, **Then** I navigate to the coin's detail page (`/coin/:id`).
+2. **Given** I am viewing the tray and a well is focused (keyboard), **When** I press Enter, **Then** the coin detail page opens.
+3. **Given** I am viewing a coin from the tray and click back, **Then** I return to the tray (not the collection page).
+
+---
+
+### User Story 6: Felt Theming (Priority: P3)
+
+As a collector with an eye for aesthetics, I can choose a felt color theme (red, green, navy) for the tray, so it matches my collection's presentation style or personal taste.
+
+**Why this priority**: Nice-to-have visual polish. Ships after core interaction. Preference stored in localStorage.
+
+**Independent Test**: Can click/tap felt color chips in the tray controls, tray background updates immediately, preference persists across session reloads.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am viewing the tray, **When** I click a felt color chip (red, green, navy), **Then** the tray background theme updates immediately.
+2. **Given** I have selected a felt color theme, **When** I reload the page, **Then** the selected theme persists.
+
+---
+
+### User Story 7: Reduced Motion Support (Priority: P3)
+
+As an accessibility-conscious user with `prefers-reduced-motion` enabled, the tray respects my preference and avoids distracting animations.
+
+**Why this priority**: Accessibility requirement per Principle V. Optional polish if unrelated animations exist.
+
+**Independent Test**: With `prefers-reduced-motion: reduce`, verify hover/focus effects and any transitions are instant, not animated.
+
+**Acceptance Scenarios**:
+
+1. **Given** I have `prefers-reduced-motion: reduce` set in my OS, **When** I view the tray and hover/focus wells, **Then** transitions are instant (no animations).
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST render coins in a grid of circular felt-lined wells on a textured felt background.
+- **FR-002**: System MUST use the current collection result set (`store.coins`) for v1; no API changes or cross-page data fetching.
+- **FR-003**: System MUST scale coins proportionally by `diameterMm` within safe clamp bounds (min 40px, max 120px) when available; use a default size (e.g., 70px) when missing.
+- **FR-004**: System MUST paginate the tray into drawable chunks (e.g., 50 coins per drawer) with Previous/Next navigation.
+- **FR-005**: System MUST reflow the tray grid responsively: 2–3 columns on mobile (375px), 4–5 on tablet (768px), 6–8 on desktop (1024px+).
+- **FR-006**: System MUST open coin detail (`/coin/:id`) when a user taps/clicks a well or presses Enter on a focused well.
+- **FR-007**: System MUST preserve tray drawer position and return to the same drawer when a user navigates back from a coin detail page.
+- **FR-008**: System MUST offer at least 3 felt color themes (red, green, navy) and persist the user's selection in localStorage.
+- **FR-009**: System MUST respect `prefers-reduced-motion: reduce` and avoid animations on hover/focus.
+- **FR-010**: System MUST show a friendly empty state if the collection is empty or the current filtered set is empty.
+- **FR-011**: System MUST be reachable via a "Tray" button/chip in both desktop and PWA collection headers.
+- **FR-012**: System MUST use only existing design tokens and global button/chip CSS classes; no hardcoded colors or spacing.
+
+### Key Entities
+
+- **Coin**: Existing entity with `id`, `name`, `diameterMm` (nullable), `images: CoinImage[]`. Reused from collection store.
+- **Tray Layout**: Internal helper struct for calculating coin render sizes and grid layout based on viewport and coin diameter data.
+- **TrayPreference**: LocalStorage key-value pair for felt color theme (e.g., `tray:feltColor = 'red'`).
+
+### Data Flow
+
+1. **CollectionPage** / **Headers** → User clicks "Tray" button.
+2. **Router** → Navigate to `/tray`.
+3. **TrayViewPage** → Fetch `store.coins` (already loaded from collection); if empty, show empty state.
+4. **MuseumTray** → Calculate layout via `trayLayout.ts`, render wells grid.
+5. **MuseumTrayWell** → Render coin image, shadow, handle click/keyboard.
+6. **Route on click** → Open `/coin/:id`; preserve return path.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can navigate to tray view from collection page in one click/tap.
+- **SC-002**: Tray renders all loaded coins in the current drawer without jank (60fps on mobile, no long paint times).
+- **SC-003**: 100% of coins with `diameterMm` are scaled proportionally; 100% of coins without it use safe default size.
+- **SC-004**: On mobile, tray grid is 2–3 columns; on tablet 4–5; on desktop 6–8 (responsive layout verified, no hardcoded pixel values).
+- **SC-005**: Users can navigate between drawers (Previous/Next) and the drawer count is accurately displayed.
+- **SC-006**: Tapping a coin opens its detail page; keyboard Enter also works.
+- **SC-007**: Returning from a coin detail preserves drawer position (no loss of context).
+- **SC-008**: Felt color theme updates immediately on click and persists across reloads.
+- **SC-009**: All component and utility tests pass: `npm run test -- tray --run`.
+- **SC-010**: Type checking passes: `npm run type-check`.
+- **SC-011**: Build succeeds: `npm run build`.
+- **SC-012**: `prefers-reduced-motion: reduce` disables animations (visual inspection + test).
+
+---
+
+## Assumptions
+
+- **Assumption 1**: The `diameterMm` field already exists on the Coin model and is populated for most coins; missing/zero values are acceptable and handled gracefully.
+- **Assumption 2**: The collection store (`store.coins`) is already populated when the user navigates to `/tray`, so no additional API call is needed for v1.
+- **Assumption 3**: The tray uses the **current loaded result set** (filtered, sorted, paginated) from the collection, not a separate "all coins" fetch. This simplifies the MVP and focuses on the current visible collection.
+- **Assumption 4**: The default tap action is to open coin detail (`/coin/:id`). A secondary inline flip control (if 3D viewer exists) can be added but is not required for MVP.
+- **Assumption 5**: Felt texture is pure CSS (gradients/layered backgrounds), not an image asset, for performance and themability.
+- **Assumption 6**: Drag-and-drop tray rearrangement and saving custom layouts are out of scope and deferred to a future backlog card.
+- **Assumption 7**: The tray is read-only. Editing coins, bulk actions, and selection mode do not apply in tray view.
+- **Assumption 8**: PWA and desktop browsers share the same tray component; no separate mobile-only implementation is needed.
+- **Assumption 9**: `localStorage` is available and secure enough for felt color preference (non-sensitive, UI-only data).
+- **Assumption 10**: Coins per drawer is fixed at 50 (or adaptive based on page size) for v1; fully dynamic per-viewport sizing can be a follow-up polish task.

--- a/specs/224-museum-tray-view/tasks.md
+++ b/specs/224-museum-tray-view/tasks.md
@@ -2,8 +2,8 @@
 
 **Input**: Design documents from `specs/224-museum-tray-view/`
 **Prerequisites**: spec.md ✅, plan.md ✅
-**Last Updated**: 2026-06-18 (tightened for accuracy)
-**Total Tasks**: 21
+**Last Updated**: 2026-06-18 (updated navigation to sidebar per Brian's decision)
+**Total Tasks**: 25
 **Phases**: 1 (Setup) + 2 (Utilities & Composable) + 3 (Components) + 4 (Page & Route) + 5 (Coin Interaction) + 6 (Tests) + 7 (Polish)
 
 ---
@@ -12,6 +12,7 @@
 
 | Date | Change |
 |------|--------|
+| 2026-06-18 | Updated navigation decision: Tray submenu item under Collection in sidebar (App.vue), not collection header buttons. Removed DesktopCollectionHeader and PwaCollectionHeader tasks; added App.vue sidebar navigation task. Total tasks reduced from 26 to 25. |
 | 2026-06-18 | Fixed test locations to follow repo convention (`src/web/src/utils/__tests__/`, `src/web/src/composables/__tests__/`, `src/web/src/components/__tests__/`); corrected store reference to `useCoinsStore()` in TrayViewPage task; removed false claims about specific class names (e.g., `tray-felt-red`, `tray-cols-mobile`); clarified responsive testing as viewport-based, not class-based. |
 
 ## Phase 1: Setup (Shared Infrastructure)
@@ -137,7 +138,7 @@
 
 ## Phase 4: Page and Route
 
-**Purpose**: Wire tray into app, make it reachable from collection.
+**Purpose**: Wire tray into app, make it reachable via sidebar.
 
 - [ ] **T015** Create `src/web/src/pages/TrayViewPage.vue`:
   - Setup:
@@ -159,29 +160,30 @@
   - Add route: `{ path: '/tray', name: 'tray', component: TrayViewPage, meta: { requiresAuth: true } }`.
   - Verify no route name conflicts.
 
-- [ ] **T017** [P] Update `src/web/src/components/collection/DesktopCollectionHeader.vue`:
-  - Add "Tray" chip/button in the toolbar-right area alongside existing options.
+- [ ] **T017** [P] Update `src/web/src/App.vue`:
+  - Add "Tray" submenu item under Collection in the sidebar navigation.
+  - Follow the same submenu structure as Stats (parent expandable/collapsible with sub-items).
+  - Submenu items should include Gallery (main collection view) and Tray (new feature).
   - Click handler or router-link: navigate to `/tray`.
+  - Ensure submenu expand/collapse works consistently with existing navigation patterns.
 
-- [ ] **T018** [P] Update `src/web/src/components/collection/PwaCollectionHeader.vue`:
-  - Add "Tray" chip/button in the View section of pwa-menu (alongside existing view toggles).
-  - Click handler or router-link: navigate to `/tray`.
-
-**Checkpoint**: Tray reachable from collection page. Coin click routes to detail. Drawer controls work.
+**Checkpoint**: Tray reachable from sidebar. Coin click routes to detail. Drawer controls work.
 
 ---
 
 ## Phase 5: Coin Interaction & Return Path
 
-**Purpose**: Ensure seamless navigation to coin detail and back to tray with position preserved.
+**Purpose**: Ensure seamless navigation to coin detail and back to tray with position preserved; verify sidebar navigation.
 
-- [ ] **T019** Test coin detail return:
+- [ ] **T018** Test coin detail return and sidebar navigation:
   - From tray drawer 2, click a coin → coin detail page opens.
   - In coin detail page (or browser back button) → return to `/tray`.
   - Verify still on drawer 2 (component state preserved, not cleared).
   - Verify keyboard navigation: Tab focus on wells, Enter opens detail.
+  - Verify Collection submenu in sidebar expands/collapses correctly.
+  - Verify both Gallery and Tray submenu items navigate to their respective routes.
 
-**Checkpoint**: Coin interaction complete and intuitive.
+**Checkpoint**: Coin interaction complete and intuitive. Sidebar navigation working.
 
 ---
 
@@ -189,11 +191,11 @@
 
 **Purpose**: Ensure no TypeScript errors, build succeeds.
 
-- [ ] **T020** [P] Run type-check: `cd src/web && npm run type-check`
+- [ ] **T019** [P] Run type-check: `cd src/web && npm run type-check`
   - Fix any errors related to tray components.
   - Verify `TrayCoin`, `TrayLayoutOptions`, prop types are correct.
 
-- [ ] **T021** [P] Run build: `cd src/web && npm run build`
+- [ ] **T020** [P] Run build: `cd src/web && npm run build`
   - Verify no build errors or warnings.
   - Check bundle size impact (should be minimal, < 10KB gzipped for tray feature).
 
@@ -205,30 +207,30 @@
 
 **Purpose**: Final integration, responsive design check, documentation.
 
-- [ ] **T022** [P] Responsive viewport testing:
+- [ ] **T021** [P] Responsive viewport testing:
   - Mobile (375px): Tray renders 2–3 columns, wells remain tappable, pagination controls visible.
   - Tablet (768px): Tray renders 4–5 columns.
   - Desktop (1024px+): Tray renders 6–8 columns.
   - Use browser DevTools or responsive design mode.
   - Verify no horizontal scroll, no layout jank.
 
-- [ ] **T023** [P] Felt color theme testing:
+- [ ] **T022** [P] Felt color theme testing:
   - Click each felt color chip (red, green, navy).
   - Verify background changes immediately.
   - Reload page → verify selected theme persists.
   - Test on mobile and desktop.
 
-- [ ] **T024** [P] Accessibility testing:
+- [ ] **T023** [P] Accessibility testing:
   - Verify `prefers-reduced-motion: reduce` disables animations (no hover transitions).
   - Verify keyboard navigation (Tab, Enter on wells).
   - Verify aria-labels on wells.
 
-- [ ] **T025** [P] Verify no design token violations:
+- [ ] **T024** [P] Verify no design token violations:
   - Inspect all colors, spacing, shadows in rendered tray.
   - Confirm all use design tokens (--accent-gold, --bg-card, --radius-sm, etc.).
   - No hardcoded hex colors, px values for spacing.
 
-- [ ] **T026** [P] Clean up and finalize:
+- [ ] **T025** [P] Clean up and finalize:
   - Remove any console.log or debug code.
   - Verify git status: only spec + src/web files modified.
   - Verify no unintended file changes.
@@ -244,19 +246,19 @@
 1. **Phase 1 (Setup)**: T001–T003 (parallel)
 2. **Phase 2 (Utilities)**: T004–T005 (tests, parallel) → T006–T007 (implementation, parallel) → T008 (verify)
 3. **Phase 3 (Components)**: T009–T010 (tests, parallel) → T011–T013 (implementation, parallel) → T014 (verify)
-4. **Phase 4 (Page/Route)**: T015–T018 (parallel for header updates)
-5. **Phase 5 (Interaction)**: T019 (manual test)
-6. **Phase 6 (Build)**: T020–T021 (parallel)
-7. **Phase 7 (Polish)**: T022–T026 (parallel for different concerns)
+4. **Phase 4 (Page/Route)**: T015–T017 (parallel for route and sidebar)
+5. **Phase 5 (Interaction)**: T018 (manual test)
+6. **Phase 6 (Build)**: T019–T020 (parallel)
+7. **Phase 7 (Polish)**: T021–T025 (parallel for different concerns)
 
 ### Parallelization Opportunities
 
 - **Within Phase 1**: All 3 tasks [P] can run in parallel (directory creation).
 - **Within Phase 2**: Tests T004–T005 [P] can run in parallel; implementation T006–T007 [P] can run in parallel.
 - **Within Phase 3**: Tests T009–T010 [P] can run in parallel; implementation T011–T013 [P] can run in parallel.
-- **Within Phase 4**: Header updates T017–T018 [P] can run in parallel.
-- **Within Phase 6**: T020–T021 [P] can run in parallel.
-- **Within Phase 7**: All T022–T026 [P] can run in parallel.
+- **Within Phase 4**: T015–T017 [P] can run in parallel (page creation, route addition, sidebar update).
+- **Within Phase 6**: T019–T020 [P] can run in parallel.
+- **Within Phase 7**: All T021–T025 [P] can run in parallel.
 
 ### No Task Blocks Another (Within Phase)
 
@@ -269,9 +271,9 @@ Each task is self-contained and modifies different files. Once Phase 2 is comple
 For each component/utility:
 
 1. **Write tests first**: FAIL tests before implementation (T004, T005, T009, T010).
-2. **Implement**: Make tests PASS (T006, T007, T011, T013).
+2. **Implement**: Make tests PASS (T006, T007, T011–T013).
 3. **Verify**: `npm run test -- [name] --run`.
-4. **Type-check & build**: Ensure no errors (T020, T021).
+4. **Type-check & build**: Ensure no errors (T019, T020).
 
 ---
 
@@ -286,10 +288,10 @@ For each component/utility:
 | T009–T010 | Tests written, all FAIL before implementation. |
 | T011–T013 | Tests PASS; components render correctly, events emit as expected. |
 | T014 | `npm run test -- MuseumTrayWell MuseumTray --run` shows all PASS. |
-| T015–T018 | Tray page reachable; header buttons navigate to `/tray`; no errors in console. |
-| T019 | Open tray, click coin, verify detail page opens; return via back, verify drawer position preserved. |
-| T020–T021 | `npm run type-check` and `npm run build` both exit with code 0. |
-| T022–T026 | Manual testing on multiple viewports passes; all design tokens used; no console errors. |
+| T015–T017 | Tray page reachable via sidebar; route added; sidebar navigation updated; no errors in console. |
+| T018 | Open tray, click coin, verify detail page opens; return via back, verify drawer position preserved; sidebar submenu works. |
+| T019–T020 | `npm run type-check` and `npm run build` both exit with code 0. |
+| T021–T025 | Manual testing on multiple viewports passes; all design tokens used; no console errors. |
 
 ---
 
@@ -301,3 +303,5 @@ For each component/utility:
 - Phase 2 must complete before Phase 3; Phase 3 before Phase 4; all phases before Phase 5 sign-off.
 - Avoid: vague task titles, same-file conflicts, cross-story dependencies.
 - Commit after each phase checkpoint (or after 2–3 related tasks) to keep history clean.
+- Navigation moved from collection page headers to sidebar (App.vue) per Brian's decision to follow Stats submenu pattern.
+- DesktopCollectionHeader.vue and PwaCollectionHeader.vue are NOT modified; no header buttons needed.

--- a/specs/224-museum-tray-view/tasks.md
+++ b/specs/224-museum-tray-view/tasks.md
@@ -19,9 +19,9 @@
 
 **Purpose**: Prepare directory structure and confirm no blocking issues.
 
-- [ ] **T001** [P] Create `src/web/src/components/tray/` directory
-- [ ] **T002** [P] Verify `src/web/src/utils/` directory exists; create if missing
-- [ ] **T003** [P] Verify `src/web/src/composables/` directory exists; create if missing
+- [x] **T001** [P] Create `src/web/src/components/tray/` directory
+- [x] **T002** [P] Verify `src/web/src/utils/` directory exists; create if missing
+- [x] **T003** [P] Verify `src/web/src/composables/` directory exists; create if missing
 
 **Checkpoint**: Directories ready. No blocking issues.
 
@@ -33,14 +33,14 @@
 
 ### Tests First (Write Failing, Then Implement)
 
-- [ ] **T004** [P] Write `src/web/src/utils/__tests__/trayLayout.test.ts`:
+- [x] **T004** [P] Write `src/web/src/utils/__tests__/trayLayout.test.ts`:
   - Test `normalizeDiameterMm()`: null → default, zero → default, negative → default, positive → return as-is.
   - Test `getCoinRenderSizePx()`: small (8mm) renders smaller than large (35mm), both clamped to [40px, 120px], missing diameter uses default.
   - Test `getDrawerCoins()`: slice coins correctly, boundary index returns empty.
   - Test `getTotalDrawers()`: 100 coins, 50 per drawer → 2 drawers; 101 coins → 3 drawers.
   - Verify all tests FAIL before implementing.
 
-- [ ] **T005** [P] Write `src/web/src/composables/__tests__/useTrayPreference.test.ts`:
+- [x] **T005** [P] Write `src/web/src/composables/__tests__/useTrayPreference.test.ts`:
   - Test read/write felt color from localStorage.
   - Test default color ('red') when localStorage is empty.
   - Test reactive updates when preference changes.
@@ -48,21 +48,21 @@
 
 ### Implementation
 
-- [ ] **T006** [P] Implement `src/web/src/utils/trayLayout.ts`:
+- [x] **T006** [P] Implement `src/web/src/utils/trayLayout.ts`:
   - Export `normalizeDiameterMm(diameterMm: number | null | undefined, defaultDiameterMm: number): number`.
   - Export `getCoinRenderSizePx(diameterMm: number, allDiameters: number[], options: TrayLayoutOptions): number`.
   - Export `getDrawerCoins(coins: TrayCoin[], drawerIndex: number, coinsPerDrawer: number): TrayCoin[]`.
   - Export `getTotalDrawers(totalCoins: number, coinsPerDrawer: number): number`.
   - Implement types: `TrayCoin`, `TrayLayoutOptions`.
 
-- [ ] **T007** [P] Implement `src/web/src/composables/useTrayPreference.ts`:
+- [x] **T007** [P] Implement `src/web/src/composables/useTrayPreference.ts`:
   - Export composable `useTrayPreference()`.
   - Return reactive `feltColor` ref (type: 'red' | 'green' | 'navy').
   - Implement getter from localStorage key 'tray:feltColor'.
   - Implement setter to localStorage on change.
   - Default to 'red' if localStorage empty.
 
-- [ ] **T008** Verify T004, T005 tests now PASS: `npm run test -- trayLayout useTrayPreference --run`
+- [x] **T008** Verify T004, T005 tests now PASS: `npm run test -- trayLayout useTrayPreference --run`
 
 **Checkpoint**: Layout math and preference logic testable and working. Ready for components.
 
@@ -74,7 +74,7 @@
 
 ### Tests First (Write Failing, Then Implement)
 
-- [ ] **T009** [P] Write `src/web/src/components/__tests__/MuseumTrayWell.test.ts`:
+- [x] **T009** [P] Write `src/web/src/components/__tests__/MuseumTrayWell.test.ts`:
   - Test coin image rendering (happy path with valid image).
   - Test placeholder rendering when `coin.images` is empty.
   - Test click event emission.
@@ -82,7 +82,7 @@
   - Test accessibility: aria-label = coin name.
   - Verify all tests FAIL before implementing.
 
-- [ ] **T010** [P] Write `src/web/src/components/__tests__/MuseumTray.test.ts`:
+- [x] **T010** [P] Write `src/web/src/components/__tests__/MuseumTray.test.ts`:
   - Test well grid renders all coins.
   - Test felt theme applied (class-binding or style check).
   - Test coin-clicked event emitted on click.
@@ -91,7 +91,7 @@
 
 ### Implementation
 
-- [ ] **T011** [P] Implement `src/web/src/components/tray/MuseumTrayWell.vue`:
+- [x] **T011** [P] Implement `src/web/src/components/tray/MuseumTrayWell.vue`:
   - Props: `coin: TrayCoin`, `renderSizePx: number`.
   - Render circular well container (CSS border-radius 50%).
   - Inner recessed shadow (darker inner circle using box-shadow or border).
@@ -104,7 +104,7 @@
   - Use only design tokens for colors (shadows, backgrounds).
   - Respect `prefers-reduced-motion` (no hover transitions if reduced).
 
-- [ ] **T012** [P] Implement `src/web/src/components/tray/MuseumTray.vue`:
+- [x] **T012** [P] Implement `src/web/src/components/tray/MuseumTray.vue`:
   - Props: `coins: TrayCoin[]`, `feltTheme: 'red' | 'green' | 'navy'` (default 'red').
   - Root div with felt background (CSS gradient/texture effect per theme).
   - CSS Grid with responsive columns:
@@ -117,7 +117,7 @@
   - Emit 'coin-clicked' event from child wells.
   - Use design tokens for gap, padding, shadows.
 
-- [ ] **T013** [P] Implement `src/web/src/components/tray/TrayControls.vue`:
+- [x] **T013** [P] Implement `src/web/src/components/tray/TrayControls.vue`:
   - Props: `drawerIndex: number`, `totalDrawers: number`, `feltTheme: 'red' | 'green' | 'navy'`.
   - Render:
     - Text: "Drawer {{ drawerIndex + 1 }} of {{ totalDrawers }}".
@@ -130,7 +130,7 @@
   - Emit 'update:feltTheme' event on felt color chip click.
   - Use `.btn-sm` and `.chip` global classes.
 
-- [ ] **T014** Verify T009, T010 tests now PASS: `npm run test -- MuseumTrayWell MuseumTray --run`
+- [x] **T014** Verify T009, T010 tests now PASS: `npm run test -- MuseumTrayWell MuseumTray --run`
 
 **Checkpoint**: All tray components render correctly and interact properly. Ready for page/route.
 
@@ -140,7 +140,7 @@
 
 **Purpose**: Wire tray into app, make it reachable via sidebar.
 
-- [ ] **T015** Create `src/web/src/pages/TrayViewPage.vue`:
+- [x] **T015** Create `src/web/src/pages/TrayViewPage.vue`:
   - Setup:
     - Import `useCoinsStore()`, `useRouter()`, `useTrayPreference()`.
     - Local state: `drawerIndex = ref(0)`, `coinsPerDrawer = 50`.
@@ -156,11 +156,11 @@
     - `@update:feltTheme` → `feltTheme.value = newTheme`.
   - Style: simple container, flex layout, use design tokens.
 
-- [ ] **T016** Update `src/web/src/router/index.ts`:
+- [x] **T016** Update `src/web/src/router/index.ts`:
   - Add route: `{ path: '/tray', name: 'tray', component: TrayViewPage, meta: { requiresAuth: true } }`.
   - Verify no route name conflicts.
 
-- [ ] **T017** [P] Update `src/web/src/App.vue`:
+- [x] **T017** [P] Update `src/web/src/App.vue`:
   - Add "Tray" submenu item under Collection in the sidebar navigation.
   - Follow the same submenu structure as Stats (parent expandable/collapsible with sub-items).
   - Submenu items should include Gallery (main collection view) and Tray (new feature).
@@ -191,11 +191,11 @@
 
 **Purpose**: Ensure no TypeScript errors, build succeeds.
 
-- [ ] **T019** [P] Run type-check: `cd src/web && npm run type-check`
+- [x] **T019** [P] Run type-check: `cd src/web && npm run type-check`
   - Fix any errors related to tray components.
   - Verify `TrayCoin`, `TrayLayoutOptions`, prop types are correct.
 
-- [ ] **T020** [P] Run build: `cd src/web && npm run build`
+- [x] **T020** [P] Run build: `cd src/web && npm run build`
   - Verify no build errors or warnings.
   - Check bundle size impact (should be minimal, < 10KB gzipped for tray feature).
 

--- a/specs/224-museum-tray-view/tasks.md
+++ b/specs/224-museum-tray-view/tasks.md
@@ -1,0 +1,303 @@
+# Tasks: Museum Coin Tray View (Feature 224)
+
+**Input**: Design documents from `specs/224-museum-tray-view/`
+**Prerequisites**: spec.md ✅, plan.md ✅
+**Last Updated**: 2026-06-18 (tightened for accuracy)
+**Total Tasks**: 21
+**Phases**: 1 (Setup) + 2 (Utilities & Composable) + 3 (Components) + 4 (Page & Route) + 5 (Coin Interaction) + 6 (Tests) + 7 (Polish)
+
+---
+
+## Update History
+
+| Date | Change |
+|------|--------|
+| 2026-06-18 | Fixed test locations to follow repo convention (`src/web/src/utils/__tests__/`, `src/web/src/composables/__tests__/`, `src/web/src/components/__tests__/`); corrected store reference to `useCoinsStore()` in TrayViewPage task; removed false claims about specific class names (e.g., `tray-felt-red`, `tray-cols-mobile`); clarified responsive testing as viewport-based, not class-based. |
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare directory structure and confirm no blocking issues.
+
+- [ ] **T001** [P] Create `src/web/src/components/tray/` directory
+- [ ] **T002** [P] Verify `src/web/src/utils/` directory exists; create if missing
+- [ ] **T003** [P] Verify `src/web/src/composables/` directory exists; create if missing
+
+**Checkpoint**: Directories ready. No blocking issues.
+
+---
+
+## Phase 2: Layout Utilities & Composable (No Dependencies)
+
+**Purpose**: Core layout logic for diameter scaling, pagination, and theme persistence.
+
+### Tests First (Write Failing, Then Implement)
+
+- [ ] **T004** [P] Write `src/web/src/utils/__tests__/trayLayout.test.ts`:
+  - Test `normalizeDiameterMm()`: null → default, zero → default, negative → default, positive → return as-is.
+  - Test `getCoinRenderSizePx()`: small (8mm) renders smaller than large (35mm), both clamped to [40px, 120px], missing diameter uses default.
+  - Test `getDrawerCoins()`: slice coins correctly, boundary index returns empty.
+  - Test `getTotalDrawers()`: 100 coins, 50 per drawer → 2 drawers; 101 coins → 3 drawers.
+  - Verify all tests FAIL before implementing.
+
+- [ ] **T005** [P] Write `src/web/src/composables/__tests__/useTrayPreference.test.ts`:
+  - Test read/write felt color from localStorage.
+  - Test default color ('red') when localStorage is empty.
+  - Test reactive updates when preference changes.
+  - Verify all tests FAIL before implementing.
+
+### Implementation
+
+- [ ] **T006** [P] Implement `src/web/src/utils/trayLayout.ts`:
+  - Export `normalizeDiameterMm(diameterMm: number | null | undefined, defaultDiameterMm: number): number`.
+  - Export `getCoinRenderSizePx(diameterMm: number, allDiameters: number[], options: TrayLayoutOptions): number`.
+  - Export `getDrawerCoins(coins: TrayCoin[], drawerIndex: number, coinsPerDrawer: number): TrayCoin[]`.
+  - Export `getTotalDrawers(totalCoins: number, coinsPerDrawer: number): number`.
+  - Implement types: `TrayCoin`, `TrayLayoutOptions`.
+
+- [ ] **T007** [P] Implement `src/web/src/composables/useTrayPreference.ts`:
+  - Export composable `useTrayPreference()`.
+  - Return reactive `feltColor` ref (type: 'red' | 'green' | 'navy').
+  - Implement getter from localStorage key 'tray:feltColor'.
+  - Implement setter to localStorage on change.
+  - Default to 'red' if localStorage empty.
+
+- [ ] **T008** Verify T004, T005 tests now PASS: `npm run test -- trayLayout useTrayPreference --run`
+
+**Checkpoint**: Layout math and preference logic testable and working. Ready for components.
+
+---
+
+## Phase 3: Core Tray Components
+
+**Purpose**: Render tray UI (well, grid, controls).
+
+### Tests First (Write Failing, Then Implement)
+
+- [ ] **T009** [P] Write `src/web/src/components/__tests__/MuseumTrayWell.test.ts`:
+  - Test coin image rendering (happy path with valid image).
+  - Test placeholder rendering when `coin.images` is empty.
+  - Test click event emission.
+  - Test keyboard Enter event emission.
+  - Test accessibility: aria-label = coin name.
+  - Verify all tests FAIL before implementing.
+
+- [ ] **T010** [P] Write `src/web/src/components/__tests__/MuseumTray.test.ts`:
+  - Test well grid renders all coins.
+  - Test felt theme applied (class-binding or style check).
+  - Test coin-clicked event emitted on click.
+  - Test responsive layout: verify grid adjusts column count based on viewport simulation.
+  - Verify all tests FAIL before implementing.
+
+### Implementation
+
+- [ ] **T011** [P] Implement `src/web/src/components/tray/MuseumTrayWell.vue`:
+  - Props: `coin: TrayCoin`, `renderSizePx: number`.
+  - Render circular well container (CSS border-radius 50%).
+  - Inner recessed shadow (darker inner circle using box-shadow or border).
+  - Coin image centered (`object-fit: cover`); use `renderSizePx` for size.
+  - Placeholder icon (Coins lucide icon) if no images.
+  - Contact shadow below coin (soft drop-shadow CSS).
+  - Aria-label with coin name.
+  - Click handler → emit 'coin-clicked' with coin.id.
+  - Keyboard handler: Enter key → emit 'coin-clicked'.
+  - Use only design tokens for colors (shadows, backgrounds).
+  - Respect `prefers-reduced-motion` (no hover transitions if reduced).
+
+- [ ] **T012** [P] Implement `src/web/src/components/tray/MuseumTray.vue`:
+  - Props: `coins: TrayCoin[]`, `feltTheme: 'red' | 'green' | 'navy'` (default 'red').
+  - Root div with felt background (CSS gradient/texture effect per theme).
+  - CSS Grid with responsive columns:
+    - 2–3 columns on mobile (< 576px).
+    - 4–5 columns on tablet (576px–768px).
+    - 6–8 columns on desktop (> 768px).
+  - Apply theme to root (class-binding or style for felt color).
+  - Render `MuseumTrayWell` for each coin.
+  - Calculate render size for each coin using `trayLayout.getCoinRenderSizePx()`.
+  - Emit 'coin-clicked' event from child wells.
+  - Use design tokens for gap, padding, shadows.
+
+- [ ] **T013** [P] Implement `src/web/src/components/tray/TrayControls.vue`:
+  - Props: `drawerIndex: number`, `totalDrawers: number`, `feltTheme: 'red' | 'green' | 'navy'`.
+  - Render:
+    - Text: "Drawer {{ drawerIndex + 1 }} of {{ totalDrawers }}".
+    - Button "Previous" (disabled if drawerIndex === 0).
+    - Button "Next" (disabled if drawerIndex === totalDrawers - 1).
+    - Chip buttons for felt colors ('red', 'green', 'navy').
+    - Active chip: use `active` class from existing global CSS.
+  - Emit 'prev' event on Previous click.
+  - Emit 'next' event on Next click.
+  - Emit 'update:feltTheme' event on felt color chip click.
+  - Use `.btn-sm` and `.chip` global classes.
+
+- [ ] **T014** Verify T009, T010 tests now PASS: `npm run test -- MuseumTrayWell MuseumTray --run`
+
+**Checkpoint**: All tray components render correctly and interact properly. Ready for page/route.
+
+---
+
+## Phase 4: Page and Route
+
+**Purpose**: Wire tray into app, make it reachable from collection.
+
+- [ ] **T015** Create `src/web/src/pages/TrayViewPage.vue`:
+  - Setup:
+    - Import `useCoinsStore()`, `useRouter()`, `useTrayPreference()`.
+    - Local state: `drawerIndex = ref(0)`, `coinsPerDrawer = 50`.
+  - Computed: `currentDrawerCoins` = `getDrawerCoins(store.coins, drawerIndex.value, coinsPerDrawer)`.
+  - Computed: `totalDrawers` = `getTotalDrawers(store.coins.length, coinsPerDrawer)`.
+  - Render:
+    - If `store.coins.length === 0`: empty state (message + link to `/add` or back to `/`).
+    - Else: `TrayControls`, `MuseumTray`, handle events.
+  - Event handlers:
+    - `@coin-clicked` → `router.push({ name: 'coin-detail', params: { id: coinId } })`.
+    - `@prev` → `drawerIndex.value = Math.max(0, drawerIndex.value - 1)`.
+    - `@next` → `drawerIndex.value = Math.min(totalDrawers - 1, drawerIndex.value + 1)`.
+    - `@update:feltTheme` → `feltTheme.value = newTheme`.
+  - Style: simple container, flex layout, use design tokens.
+
+- [ ] **T016** Update `src/web/src/router/index.ts`:
+  - Add route: `{ path: '/tray', name: 'tray', component: TrayViewPage, meta: { requiresAuth: true } }`.
+  - Verify no route name conflicts.
+
+- [ ] **T017** [P] Update `src/web/src/components/collection/DesktopCollectionHeader.vue`:
+  - Add "Tray" chip/button in the toolbar-right area alongside existing options.
+  - Click handler or router-link: navigate to `/tray`.
+
+- [ ] **T018** [P] Update `src/web/src/components/collection/PwaCollectionHeader.vue`:
+  - Add "Tray" chip/button in the View section of pwa-menu (alongside existing view toggles).
+  - Click handler or router-link: navigate to `/tray`.
+
+**Checkpoint**: Tray reachable from collection page. Coin click routes to detail. Drawer controls work.
+
+---
+
+## Phase 5: Coin Interaction & Return Path
+
+**Purpose**: Ensure seamless navigation to coin detail and back to tray with position preserved.
+
+- [ ] **T019** Test coin detail return:
+  - From tray drawer 2, click a coin → coin detail page opens.
+  - In coin detail page (or browser back button) → return to `/tray`.
+  - Verify still on drawer 2 (component state preserved, not cleared).
+  - Verify keyboard navigation: Tab focus on wells, Enter opens detail.
+
+**Checkpoint**: Coin interaction complete and intuitive.
+
+---
+
+## Phase 6: Type Safety & Build Verification
+
+**Purpose**: Ensure no TypeScript errors, build succeeds.
+
+- [ ] **T020** [P] Run type-check: `cd src/web && npm run type-check`
+  - Fix any errors related to tray components.
+  - Verify `TrayCoin`, `TrayLayoutOptions`, prop types are correct.
+
+- [ ] **T021** [P] Run build: `cd src/web && npm run build`
+  - Verify no build errors or warnings.
+  - Check bundle size impact (should be minimal, < 10KB gzipped for tray feature).
+
+**Checkpoint**: Code type-safe and builds successfully.
+
+---
+
+## Phase 7: Polish & Documentation
+
+**Purpose**: Final integration, responsive design check, documentation.
+
+- [ ] **T022** [P] Responsive viewport testing:
+  - Mobile (375px): Tray renders 2–3 columns, wells remain tappable, pagination controls visible.
+  - Tablet (768px): Tray renders 4–5 columns.
+  - Desktop (1024px+): Tray renders 6–8 columns.
+  - Use browser DevTools or responsive design mode.
+  - Verify no horizontal scroll, no layout jank.
+
+- [ ] **T023** [P] Felt color theme testing:
+  - Click each felt color chip (red, green, navy).
+  - Verify background changes immediately.
+  - Reload page → verify selected theme persists.
+  - Test on mobile and desktop.
+
+- [ ] **T024** [P] Accessibility testing:
+  - Verify `prefers-reduced-motion: reduce` disables animations (no hover transitions).
+  - Verify keyboard navigation (Tab, Enter on wells).
+  - Verify aria-labels on wells.
+
+- [ ] **T025** [P] Verify no design token violations:
+  - Inspect all colors, spacing, shadows in rendered tray.
+  - Confirm all use design tokens (--accent-gold, --bg-card, --radius-sm, etc.).
+  - No hardcoded hex colors, px values for spacing.
+
+- [ ] **T026** [P] Clean up and finalize:
+  - Remove any console.log or debug code.
+  - Verify git status: only spec + src/web files modified.
+  - Verify no unintended file changes.
+
+**Checkpoint**: Feature complete, polished, tested, documented.
+
+---
+
+## Dependencies & Execution Order
+
+### Critical Path
+
+1. **Phase 1 (Setup)**: T001–T003 (parallel)
+2. **Phase 2 (Utilities)**: T004–T005 (tests, parallel) → T006–T007 (implementation, parallel) → T008 (verify)
+3. **Phase 3 (Components)**: T009–T010 (tests, parallel) → T011–T013 (implementation, parallel) → T014 (verify)
+4. **Phase 4 (Page/Route)**: T015–T018 (parallel for header updates)
+5. **Phase 5 (Interaction)**: T019 (manual test)
+6. **Phase 6 (Build)**: T020–T021 (parallel)
+7. **Phase 7 (Polish)**: T022–T026 (parallel for different concerns)
+
+### Parallelization Opportunities
+
+- **Within Phase 1**: All 3 tasks [P] can run in parallel (directory creation).
+- **Within Phase 2**: Tests T004–T005 [P] can run in parallel; implementation T006–T007 [P] can run in parallel.
+- **Within Phase 3**: Tests T009–T010 [P] can run in parallel; implementation T011–T013 [P] can run in parallel.
+- **Within Phase 4**: Header updates T017–T018 [P] can run in parallel.
+- **Within Phase 6**: T020–T021 [P] can run in parallel.
+- **Within Phase 7**: All T022–T026 [P] can run in parallel.
+
+### No Task Blocks Another (Within Phase)
+
+Each task is self-contained and modifies different files. Once Phase 2 is complete, Phase 3 and Phase 4 can proceed in parallel if staffed.
+
+---
+
+## Test-First Workflow
+
+For each component/utility:
+
+1. **Write tests first**: FAIL tests before implementation (T004, T005, T009, T010).
+2. **Implement**: Make tests PASS (T006, T007, T011, T013).
+3. **Verify**: `npm run test -- [name] --run`.
+4. **Type-check & build**: Ensure no errors (T020, T021).
+
+---
+
+## Acceptance Criteria per Task
+
+| Task | Success Criteria |
+|------|------------------|
+| T001–T003 | Directories exist and are empty. |
+| T004–T005 | Tests written, all FAIL before implementation. |
+| T006–T007 | Tests PASS; utilities/composables export correct types and functions. |
+| T008 | `npm run test -- trayLayout useTrayPreference --run` shows all PASS. |
+| T009–T010 | Tests written, all FAIL before implementation. |
+| T011–T013 | Tests PASS; components render correctly, events emit as expected. |
+| T014 | `npm run test -- MuseumTrayWell MuseumTray --run` shows all PASS. |
+| T015–T018 | Tray page reachable; header buttons navigate to `/tray`; no errors in console. |
+| T019 | Open tray, click coin, verify detail page opens; return via back, verify drawer position preserved. |
+| T020–T021 | `npm run type-check` and `npm run build` both exit with code 0. |
+| T022–T026 | Manual testing on multiple viewports passes; all design tokens used; no console errors. |
+
+---
+
+## Notes
+
+- All tasks use exact file paths; no ambiguity.
+- Tests are written first, ensuring implementation is correct before deployment.
+- [P] tasks are safe to parallelize (different files, no interdependencies).
+- Phase 2 must complete before Phase 3; Phase 3 before Phase 4; all phases before Phase 5 sign-off.
+- Avoid: vague task titles, same-file conflicts, cross-story dependencies.
+- Commit after each phase checkpoint (or after 2–3 related tasks) to keep history clean.

--- a/src/web/src/App.vue
+++ b/src/web/src/App.vue
@@ -58,11 +58,13 @@
                 v-if="item.children?.length && !editMode"
                 :size="16"
                 class="sidebar-chevron"
-                :class="{ expanded: item.id === 'stats' && statsExpanded }"
+                :class="{
+                  expanded: (item.id === 'stats' && statsExpanded) || (item.id === 'collection' && collectionExpanded)
+                }"
               />
             </component>
             <div
-              v-if="item.children?.length && !editMode && (item.id === 'stats' ? statsExpanded : true)"
+              v-if="item.children?.length && !editMode && ((item.id === 'stats' && statsExpanded) || (item.id === 'collection' && collectionExpanded))"
               class="sidebar-submenu"
               :aria-label="`${item.label} views`"
             >
@@ -196,9 +198,20 @@ let sortableInstance: Sortable | null = null
 const { unreadCount, startPolling, stopPolling } = useNotifications()
 const { bulkSelectActive } = useBulkSelect()
 const statsExpanded = ref(false)
+const collectionExpanded = ref(false)
 
 const defaultNavItems: NavItem[] = [
-  { id: 'collection', label: 'Collection', icon: markRaw(Landmark), to: '/', visible: true },
+  {
+    id: 'collection',
+    label: 'Collection',
+    icon: markRaw(Landmark),
+    to: '/',
+    visible: true,
+    children: [
+      { id: 'collection-gallery', label: 'Gallery', to: '/' },
+      { id: 'collection-tray', label: 'Tray', to: '/tray' },
+    ],
+  },
   { id: 'add-coin', label: 'Add Coin', icon: markRaw(CirclePlus), to: '/add', visible: isPwa },
   { id: 'lookup', label: 'Identify Coin', icon: markRaw(Search), to: '/lookup', visible: true },
   { id: 'wishlist', label: 'Wishlist', icon: markRaw(Bookmark), to: '/wishlist', visible: true },
@@ -268,7 +281,13 @@ const fullOrder = computed(() => {
 
 function handleNavClick(item: NavItem) {
   if (editMode.value) return
-  if (item.id === 'stats' && item.children?.length) {
+  if (item.id === 'collection' && item.children?.length) {
+    collectionExpanded.value = !collectionExpanded.value
+    if (!collectionExpanded.value && item.to) {
+      router.push(item.to)
+      sidebarOpen.value = false
+    }
+  } else if (item.id === 'stats' && item.children?.length) {
     statsExpanded.value = !statsExpanded.value
     if (!statsExpanded.value && item.to) {
       router.push(item.to)

--- a/src/web/src/assets/styles/variables.css
+++ b/src/web/src/assets/styles/variables.css
@@ -32,6 +32,20 @@
   --mat-copper: #b87333;
   --mat-electrum: #e8d876;
 
+  /* Felt colors for museum tray */
+  --felt-red-base: #8b2020;
+  --felt-red-dark: #6b1515;
+  --felt-red-bright: #c54545;
+  --felt-red-dim: rgba(139, 32, 32, 0.2);
+  --felt-green-base: #2d5016;
+  --felt-green-dark: #1f3a10;
+  --felt-green-bright: #4a8526;
+  --felt-green-dim: rgba(45, 80, 22, 0.2);
+  --felt-navy-base: #1a2744;
+  --felt-navy-dark: #0f1829;
+  --felt-navy-bright: #4a6fa5;
+  --felt-navy-dim: rgba(26, 39, 68, 0.3);
+
   /* Borders & shadows */
   --border-subtle: rgba(201, 168, 76, 0.15);
   --border-accent: rgba(201, 168, 76, 0.4);

--- a/src/web/src/components/__tests__/MuseumTray.test.ts
+++ b/src/web/src/components/__tests__/MuseumTray.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MuseumTray from '../tray/MuseumTray.vue'
+import MuseumTrayWell from '../tray/MuseumTrayWell.vue'
+import type { TrayCoin } from '@/utils/trayLayout'
+
+describe('MuseumTray', () => {
+  const mockCoins: TrayCoin[] = [
+    {
+      id: 1,
+      name: 'Coin 1',
+      diameterMm: 20,
+      images: [],
+    },
+    {
+      id: 2,
+      name: 'Coin 2',
+      diameterMm: 30,
+      images: [],
+    },
+    {
+      id: 3,
+      name: 'Coin 3',
+      diameterMm: 25,
+      images: [],
+    },
+  ]
+
+  it('renders all coin wells', () => {
+    const wrapper = mount(MuseumTray, {
+      props: {
+        coins: mockCoins,
+        feltTheme: 'red',
+      },
+    })
+
+    const wells = wrapper.findAllComponents(MuseumTrayWell)
+    expect(wells).toHaveLength(3)
+  })
+
+  it('applies red felt theme class', () => {
+    const wrapper = mount(MuseumTray, {
+      props: {
+        coins: mockCoins,
+        feltTheme: 'red',
+      },
+    })
+
+    const tray = wrapper.find('.museum-tray')
+    expect(tray.classes()).toContain('felt-red')
+  })
+
+  it('applies green felt theme class', () => {
+    const wrapper = mount(MuseumTray, {
+      props: {
+        coins: mockCoins,
+        feltTheme: 'green',
+      },
+    })
+
+    const tray = wrapper.find('.museum-tray')
+    expect(tray.classes()).toContain('felt-green')
+  })
+
+  it('applies navy felt theme class', () => {
+    const wrapper = mount(MuseumTray, {
+      props: {
+        coins: mockCoins,
+        feltTheme: 'navy',
+      },
+    })
+
+    const tray = wrapper.find('.museum-tray')
+    expect(tray.classes()).toContain('felt-navy')
+  })
+
+  it('emits coin-clicked when well is clicked', async () => {
+    const wrapper = mount(MuseumTray, {
+      props: {
+        coins: mockCoins,
+        feltTheme: 'red',
+      },
+    })
+
+    const wells = wrapper.findAllComponents(MuseumTrayWell)
+    await wells[0]?.vm.$emit('coin-clicked', 1)
+
+    expect(wrapper.emitted('coin-clicked')).toBeTruthy()
+    expect(wrapper.emitted('coin-clicked')?.[0]).toEqual([1])
+  })
+
+  it('handles empty coin array', () => {
+    const wrapper = mount(MuseumTray, {
+      props: {
+        coins: [],
+        feltTheme: 'red',
+      },
+    })
+
+    const wells = wrapper.findAllComponents(MuseumTrayWell)
+    expect(wells).toHaveLength(0)
+  })
+
+  it('calculates different render sizes for different diameters', () => {
+    const wrapper = mount(MuseumTray, {
+      props: {
+        coins: mockCoins,
+        feltTheme: 'red',
+      },
+    })
+
+    const wells = wrapper.findAllComponents(MuseumTrayWell)
+    const sizes = wells.map(well => well.props('renderSizePx'))
+    
+    // Should have different sizes for different diameter coins
+    expect(new Set(sizes).size).toBeGreaterThan(1)
+    
+    // All sizes should be within bounds
+    sizes.forEach(size => {
+      expect(size).toBeGreaterThanOrEqual(40)
+      expect(size).toBeLessThanOrEqual(120)
+    })
+  })
+
+  it('has responsive grid layout class', () => {
+    const wrapper = mount(MuseumTray, {
+      props: {
+        coins: mockCoins,
+        feltTheme: 'red',
+      },
+    })
+
+    const grid = wrapper.find('.tray-grid')
+    expect(grid.exists()).toBe(true)
+  })
+})

--- a/src/web/src/components/__tests__/MuseumTrayWell.test.ts
+++ b/src/web/src/components/__tests__/MuseumTrayWell.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MuseumTrayWell from '../tray/MuseumTrayWell.vue'
+import type { TrayCoin } from '@/utils/trayLayout'
+
+describe('MuseumTrayWell', () => {
+  const mockCoin: TrayCoin = {
+    id: 1,
+    name: 'Test Coin',
+    diameterMm: 25,
+    images: [
+      {
+        id: 1,
+        coinId: 1,
+        filePath: 'relative-image.jpg',
+        imageType: 'obverse' as const,
+        isPrimary: true,
+        createdAt: '2026-01-01',
+      },
+    ],
+  }
+
+  const mockCoinAbsolutePath: TrayCoin = {
+    id: 3,
+    name: 'Coin With Absolute Path',
+    diameterMm: 22,
+    images: [
+      {
+        id: 3,
+        coinId: 3,
+        filePath: '/absolute/path/image.jpg',
+        imageType: 'obverse' as const,
+        isPrimary: true,
+        createdAt: '2026-01-01',
+      },
+    ],
+  }
+
+  const mockCoinExternalUrl: TrayCoin = {
+    id: 4,
+    name: 'Coin With External URL',
+    diameterMm: 24,
+    images: [
+      {
+        id: 4,
+        coinId: 4,
+        filePath: 'https://example.com/coin.jpg',
+        imageType: 'obverse' as const,
+        isPrimary: true,
+        createdAt: '2026-01-01',
+      },
+    ],
+  }
+
+  const mockCoinNoImage: TrayCoin = {
+    id: 2,
+    name: 'Coin Without Image',
+    diameterMm: 20,
+    images: [],
+  }
+
+  it('renders coin image when available', () => {
+    const wrapper = mount(MuseumTrayWell, {
+      props: {
+        coin: mockCoin,
+        renderSizePx: 70,
+      },
+    })
+
+    const img = wrapper.find('img')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe('/uploads/relative-image.jpg')
+    expect(img.attributes('alt')).toBe('Test Coin')
+  })
+
+  it('preserves absolute path for images', () => {
+    const wrapper = mount(MuseumTrayWell, {
+      props: {
+        coin: mockCoinAbsolutePath,
+        renderSizePx: 70,
+      },
+    })
+
+    const img = wrapper.find('img')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe('/absolute/path/image.jpg')
+  })
+
+  it('preserves external URL for images', () => {
+    const wrapper = mount(MuseumTrayWell, {
+      props: {
+        coin: mockCoinExternalUrl,
+        renderSizePx: 70,
+      },
+    })
+
+    const img = wrapper.find('img')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe('https://example.com/coin.jpg')
+  })
+
+  it('renders placeholder when no images', () => {
+    const wrapper = mount(MuseumTrayWell, {
+      props: {
+        coin: mockCoinNoImage,
+        renderSizePx: 70,
+      },
+    })
+
+    const img = wrapper.find('img')
+    expect(img.exists()).toBe(false)
+    // Placeholder should be rendered (Coins icon from lucide)
+    expect(wrapper.html()).toContain('well-placeholder')
+  })
+
+  it('emits coin-clicked on click', async () => {
+    const wrapper = mount(MuseumTrayWell, {
+      props: {
+        coin: mockCoin,
+        renderSizePx: 70,
+      },
+    })
+
+    await wrapper.find('.tray-well').trigger('click')
+    expect(wrapper.emitted('coin-clicked')).toBeTruthy()
+    expect(wrapper.emitted('coin-clicked')?.[0]).toEqual([1])
+  })
+
+  it('emits coin-clicked on Enter key', async () => {
+    const wrapper = mount(MuseumTrayWell, {
+      props: {
+        coin: mockCoin,
+        renderSizePx: 70,
+      },
+    })
+
+    await wrapper.find('.tray-well').trigger('keydown.enter')
+    expect(wrapper.emitted('coin-clicked')).toBeTruthy()
+    expect(wrapper.emitted('coin-clicked')?.[0]).toEqual([1])
+  })
+
+  it('does not emit on other keys', async () => {
+    const wrapper = mount(MuseumTrayWell, {
+      props: {
+        coin: mockCoin,
+        renderSizePx: 70,
+      },
+    })
+
+    await wrapper.find('.tray-well').trigger('keydown.space')
+    await wrapper.find('.tray-well').trigger('keydown.escape')
+    expect(wrapper.emitted('coin-clicked')).toBeFalsy()
+  })
+
+  it('has accessible aria-label', () => {
+    const wrapper = mount(MuseumTrayWell, {
+      props: {
+        coin: mockCoin,
+        renderSizePx: 70,
+      },
+    })
+
+    const well = wrapper.find('.tray-well')
+    expect(well.attributes('aria-label')).toBe('Test Coin')
+  })
+
+  it('is keyboard focusable', () => {
+    const wrapper = mount(MuseumTrayWell, {
+      props: {
+        coin: mockCoin,
+        renderSizePx: 70,
+      },
+    })
+
+    const well = wrapper.find('.tray-well')
+    expect(well.attributes('tabindex')).toBe('0')
+  })
+
+  it('applies correct size from renderSizePx prop', () => {
+    const wrapper = mount(MuseumTrayWell, {
+      props: {
+        coin: mockCoin,
+        renderSizePx: 100,
+      },
+    })
+
+    const well = wrapper.find('.tray-well')
+    const style = well.attributes('style')
+    expect(style).toContain('100px')
+  })
+})

--- a/src/web/src/components/tray/MuseumTray.vue
+++ b/src/web/src/components/tray/MuseumTray.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="museum-tray" :class="`felt-${feltTheme}`">
+    <div class="tray-grid">
+      <MuseumTrayWell
+        v-for="coin in coins"
+        :key="coin.id"
+        :coin="coin"
+        :render-size-px="getRenderSize(coin)"
+        @coin-clicked="emit('coin-clicked', $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import MuseumTrayWell from './MuseumTrayWell.vue'
+import { getCoinRenderSizePx, normalizeDiameterMm, type TrayCoin } from '@/utils/trayLayout'
+import type { FeltColor } from '@/composables/useTrayPreference'
+
+interface Props {
+  coins: TrayCoin[]
+  feltTheme: FeltColor
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  'coin-clicked': [coinId: number]
+}>()
+
+const layoutOptions = {
+  minCoinPx: 40,
+  maxCoinPx: 120,
+  defaultDiameterMm: 20,
+}
+
+const allDiameters = computed(() => {
+  return props.coins.map(coin => normalizeDiameterMm(coin.diameterMm, layoutOptions.defaultDiameterMm))
+})
+
+function getRenderSize(coin: TrayCoin): number {
+  const diameter = normalizeDiameterMm(coin.diameterMm, layoutOptions.defaultDiameterMm)
+  return getCoinRenderSizePx(diameter, allDiameters.value, layoutOptions)
+}
+</script>
+
+<style scoped>
+.museum-tray {
+  position: relative;
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  min-height: 400px;
+}
+
+/* Felt texture backgrounds with design tokens */
+.felt-red {
+  background:
+    linear-gradient(135deg, rgba(0,0,0,0.05) 25%, transparent 25%,
+                    transparent 75%, rgba(0,0,0,0.05) 75%,
+                    rgba(0,0,0,0.05)),
+    linear-gradient(45deg, rgba(0,0,0,0.05) 25%, transparent 25%,
+                    transparent 75%, rgba(0,0,0,0.05) 75%),
+    linear-gradient(to bottom, var(--felt-red-base), var(--felt-red-dark));
+  background-size: 4px 4px, 4px 4px, 100% 100%;
+  background-position: 0 0, 2px 2px, 0 0;
+  box-shadow:
+    inset 0 2px 8px rgba(0, 0, 0, 0.3),
+    var(--shadow-card);
+}
+
+.felt-green {
+  background:
+    linear-gradient(135deg, rgba(0,0,0,0.05) 25%, transparent 25%,
+                    transparent 75%, rgba(0,0,0,0.05) 75%,
+                    rgba(0,0,0,0.05)),
+    linear-gradient(45deg, rgba(0,0,0,0.05) 25%, transparent 25%,
+                    transparent 75%, rgba(0,0,0,0.05) 75%),
+    linear-gradient(to bottom, var(--felt-green-base), var(--felt-green-dark));
+  background-size: 4px 4px, 4px 4px, 100% 100%;
+  background-position: 0 0, 2px 2px, 0 0;
+  box-shadow:
+    inset 0 2px 8px rgba(0, 0, 0, 0.3),
+    var(--shadow-card);
+}
+
+.felt-navy {
+  background:
+    linear-gradient(135deg, rgba(0,0,0,0.05) 25%, transparent 25%,
+                    transparent 75%, rgba(0,0,0,0.05) 75%,
+                    rgba(0,0,0,0.05)),
+    linear-gradient(45deg, rgba(0,0,0,0.05) 25%, transparent 25%,
+                    transparent 75%, rgba(0,0,0,0.05) 75%),
+    linear-gradient(to bottom, var(--felt-navy-base), var(--felt-navy-dark));
+  background-size: 4px 4px, 4px 4px, 100% 100%;
+  background-position: 0 0, 2px 2px, 0 0;
+  box-shadow:
+    inset 0 2px 8px rgba(0, 0, 0, 0.3),
+    var(--shadow-card);
+}
+
+.tray-grid {
+  display: grid;
+  gap: 1.5rem;
+  justify-items: center;
+  align-items: center;
+  padding: 1rem;
+}
+
+/* Responsive columns based on viewport */
+@media (max-width: 575px) {
+  .tray-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
+}
+
+@media (min-width: 576px) and (max-width: 767px) {
+  .tray-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .tray-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (min-width: 1024px) and (max-width: 1279px) {
+  .tray-grid {
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+
+@media (min-width: 1280px) {
+  .tray-grid {
+    grid-template-columns: repeat(8, 1fr);
+  }
+}
+</style>

--- a/src/web/src/components/tray/MuseumTrayWell.vue
+++ b/src/web/src/components/tray/MuseumTrayWell.vue
@@ -1,0 +1,121 @@
+<template>
+  <div
+    class="tray-well"
+    :style="{ width: `${renderSizePx}px`, height: `${renderSizePx}px` }"
+    :aria-label="coin.name"
+    tabindex="0"
+    role="button"
+    @click="handleClick"
+    @keydown.enter="handleClick"
+  >
+    <div class="well-container">
+      <img
+        v-if="primaryImage"
+        :src="primaryImage"
+        :alt="coin.name"
+        class="well-coin"
+        loading="lazy"
+      />
+      <div v-else class="well-placeholder">
+        <Coins :size="Math.floor(renderSizePx * 0.4)" :stroke-width="1" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Coins } from 'lucide-vue-next'
+import type { TrayCoin } from '@/utils/trayLayout'
+
+interface Props {
+  coin: TrayCoin
+  renderSizePx: number
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  'coin-clicked': [coinId: number]
+}>()
+
+const primaryImage = computed(() => {
+  const path = props.coin.images.find(img => img.isPrimary)?.filePath ?? props.coin.images[0]?.filePath ?? null
+  if (!path) return null
+  // Preserve absolute URLs; prefix relative paths with /uploads/
+  if (path.startsWith('/') || path.startsWith('http://') || path.startsWith('https://')) {
+    return path
+  }
+  return `/uploads/${path}`
+})
+
+function handleClick() {
+  emit('coin-clicked', props.coin.id)
+}
+</script>
+
+<style scoped>
+.tray-well {
+  position: relative;
+  cursor: pointer;
+  transition: var(--transition-fast);
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at center,
+    rgba(0, 0, 0, 0.3) 0%,
+    rgba(0, 0, 0, 0.15) 40%,
+    transparent 70%
+  );
+  padding: 8%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tray-well:hover {
+  transform: translateY(-2px);
+  filter: brightness(1.1);
+}
+
+.tray-well:focus-visible {
+  outline: 2px solid var(--accent-gold);
+  outline-offset: 4px;
+}
+
+.well-container {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 
+    0 2px 4px rgba(0, 0, 0, 0.3),
+    0 4px 8px rgba(0, 0, 0, 0.2),
+    inset 0 1px 2px rgba(255, 255, 255, 0.1);
+}
+
+.well-coin {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.4));
+}
+
+.well-placeholder {
+  color: var(--text-muted);
+  opacity: 0.5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tray-well {
+    transition: none;
+  }
+  .tray-well:hover {
+    transform: none;
+  }
+}
+</style>

--- a/src/web/src/components/tray/TrayControls.vue
+++ b/src/web/src/components/tray/TrayControls.vue
@@ -1,0 +1,172 @@
+<template>
+  <div class="tray-controls">
+    <div class="drawer-navigation">
+      <button
+        class="btn btn-sm"
+        :disabled="drawerIndex === 0"
+        @click="emit('prev')"
+      >
+        <ChevronLeft :size="16" />
+        Previous
+      </button>
+      <span class="drawer-label">
+        Drawer {{ drawerIndex + 1 }} of {{ totalDrawers }}
+      </span>
+      <button
+        class="btn btn-sm"
+        :disabled="drawerIndex >= totalDrawers - 1"
+        @click="emit('next')"
+      >
+        Next
+        <ChevronRight :size="16" />
+      </button>
+    </div>
+    <div class="felt-theme-selector">
+      <span class="theme-label">Felt Color:</span>
+      <div class="theme-chips">
+        <button
+          class="chip theme-chip theme-chip-red"
+          :class="{ active: feltTheme === 'red' }"
+          @click="emit('update:feltTheme', 'red')"
+          aria-label="Red felt"
+        >
+          Red
+        </button>
+        <button
+          class="chip theme-chip theme-chip-green"
+          :class="{ active: feltTheme === 'green' }"
+          @click="emit('update:feltTheme', 'green')"
+          aria-label="Green felt"
+        >
+          Green
+        </button>
+        <button
+          class="chip theme-chip theme-chip-navy"
+          :class="{ active: feltTheme === 'navy' }"
+          @click="emit('update:feltTheme', 'navy')"
+          aria-label="Navy felt"
+        >
+          Navy
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
+import type { FeltColor } from '@/composables/useTrayPreference'
+
+interface Props {
+  drawerIndex: number
+  totalDrawers: number
+  feltTheme: FeltColor
+}
+
+defineProps<Props>()
+const emit = defineEmits<{
+  prev: []
+  next: []
+  'update:feltTheme': [theme: FeltColor]
+}>()
+</script>
+
+<style scoped>
+.tray-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.drawer-navigation {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.drawer-label {
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  min-width: 120px;
+  text-align: center;
+}
+
+.felt-theme-selector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.theme-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.theme-chips {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.theme-chip {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.85rem;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  transition: var(--transition-fast);
+}
+
+.theme-chip:hover {
+  border-color: var(--border-accent);
+  background: var(--bg-card-hover);
+}
+
+.theme-chip.active {
+  background: var(--accent-gold-dim);
+  border-color: var(--accent-gold);
+  color: var(--accent-gold);
+}
+
+.theme-chip-red.active {
+  background: var(--felt-red-dim);
+  border-color: var(--felt-red-base);
+  color: var(--felt-red-bright);
+}
+
+.theme-chip-green.active {
+  background: var(--felt-green-dim);
+  border-color: var(--felt-green-base);
+  color: var(--felt-green-bright);
+}
+
+.theme-chip-navy.active {
+  background: var(--felt-navy-dim);
+  border-color: var(--felt-navy-base);
+  color: var(--felt-navy-bright);
+}
+
+@media (max-width: 575px) {
+  .tray-controls {
+    gap: 0.75rem;
+  }
+  
+  .drawer-navigation {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  
+  .drawer-label {
+    order: -1;
+    margin-bottom: 0.25rem;
+  }
+  
+  .felt-theme-selector {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+</style>

--- a/src/web/src/composables/__tests__/useTrayPreference.test.ts
+++ b/src/web/src/composables/__tests__/useTrayPreference.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+import { useTrayPreference } from '../useTrayPreference'
+
+describe('useTrayPreference', () => {
+  const STORAGE_KEY = 'tray:feltColor'
+
+  beforeEach(() => {
+    // Clear localStorage before each test
+    localStorage.clear()
+  })
+
+  it('returns default color when localStorage is empty', () => {
+    const { feltColor } = useTrayPreference()
+    expect(feltColor.value).toBe('red')
+  })
+
+  it('reads felt color from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'green')
+    const { feltColor } = useTrayPreference()
+    expect(feltColor.value).toBe('green')
+  })
+
+  it('updates feltColor reactively', () => {
+    const { feltColor } = useTrayPreference()
+    expect(feltColor.value).toBe('red')
+    
+    feltColor.value = 'navy'
+    expect(feltColor.value).toBe('navy')
+  })
+
+  it('persists feltColor to localStorage on change', async () => {
+    const { feltColor } = useTrayPreference()
+    feltColor.value = 'green'
+    
+    await nextTick()
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('green')
+  })
+
+  it('handles invalid color value by using default', () => {
+    localStorage.setItem(STORAGE_KEY, 'invalid-color')
+    const { feltColor } = useTrayPreference()
+    expect(feltColor.value).toBe('red')
+  })
+
+  it('persists navy theme', async () => {
+    const { feltColor } = useTrayPreference()
+    feltColor.value = 'navy'
+    
+    await nextTick()
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('navy')
+    
+    // Simulate page reload
+    const { feltColor: feltColor2 } = useTrayPreference()
+    expect(feltColor2.value).toBe('navy')
+  })
+})

--- a/src/web/src/composables/useTrayPreference.ts
+++ b/src/web/src/composables/useTrayPreference.ts
@@ -1,0 +1,30 @@
+import { ref, watch } from 'vue'
+
+export type FeltColor = 'red' | 'green' | 'navy'
+
+const STORAGE_KEY = 'tray:feltColor'
+const DEFAULT_COLOR: FeltColor = 'red'
+
+const validColors: FeltColor[] = ['red', 'green', 'navy']
+
+/**
+ * Composable for managing tray felt color theme preference
+ * Persists to localStorage
+ */
+export function useTrayPreference() {
+  // Read from localStorage with validation
+  const stored = localStorage.getItem(STORAGE_KEY)
+  const isValid = stored && validColors.includes(stored as FeltColor)
+  const initialColor: FeltColor = isValid ? (stored as FeltColor) : DEFAULT_COLOR
+
+  const feltColor = ref<FeltColor>(initialColor)
+
+  // Persist to localStorage on change
+  watch(feltColor, (newColor) => {
+    localStorage.setItem(STORAGE_KEY, newColor)
+  })
+
+  return {
+    feltColor,
+  }
+}

--- a/src/web/src/pages/TrayViewPage.vue
+++ b/src/web/src/pages/TrayViewPage.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="tray-view-page">
+    <!-- Empty state -->
+    <div v-if="store.coins.length === 0 && !store.loading" class="empty-state card">
+      <Landmark :size="64" :stroke-width="1" class="empty-icon" />
+      <h2>No Coins in Tray</h2>
+      <p>Your collection is empty or no coins match the current filters.</p>
+      <div class="empty-actions">
+        <router-link to="/" class="btn btn-secondary">
+          <ArrowLeft :size="18" />
+          Back to Collection
+        </router-link>
+        <router-link to="/add" class="btn btn-primary">
+          <Plus :size="18" />
+          Add Coin
+        </router-link>
+      </div>
+    </div>
+
+    <!-- Tray view -->
+    <div v-else-if="!store.loading" class="tray-content">
+      <TrayControls
+        :drawer-index="drawerIndex"
+        :total-drawers="totalDrawers"
+        :felt-theme="feltColor"
+        @prev="handlePrevDrawer"
+        @next="handleNextDrawer"
+        @update:felt-theme="feltColor = $event"
+      />
+      <MuseumTray
+        :coins="currentDrawerCoins"
+        :felt-theme="feltColor"
+        @coin-clicked="handleCoinClicked"
+      />
+    </div>
+
+    <!-- Loading state -->
+    <div v-else class="loading-state">
+      <div class="spinner"></div>
+      <p>Loading coins...</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useCoinsStore } from '@/stores/coins'
+import { useTrayPreference } from '@/composables/useTrayPreference'
+import { getDrawerCoins, getTotalDrawers, type TrayCoin } from '@/utils/trayLayout'
+import MuseumTray from '@/components/tray/MuseumTray.vue'
+import TrayControls from '@/components/tray/TrayControls.vue'
+import { Landmark, ArrowLeft, Plus } from 'lucide-vue-next'
+
+const store = useCoinsStore()
+const router = useRouter()
+const { feltColor } = useTrayPreference()
+
+const drawerIndex = ref(0)
+const coinsPerDrawer = 50
+
+const trayCoins = computed((): TrayCoin[] => {
+  return store.coins.map(coin => ({
+    id: coin.id,
+    name: coin.name,
+    diameterMm: coin.diameterMm,
+    images: coin.images,
+  }))
+})
+
+const currentDrawerCoins = computed(() => {
+  return getDrawerCoins(trayCoins.value, drawerIndex.value, coinsPerDrawer)
+})
+
+const totalDrawers = computed(() => {
+  return getTotalDrawers(trayCoins.value.length, coinsPerDrawer)
+})
+
+function handlePrevDrawer() {
+  drawerIndex.value = Math.max(0, drawerIndex.value - 1)
+}
+
+function handleNextDrawer() {
+  drawerIndex.value = Math.min(totalDrawers.value - 1, drawerIndex.value + 1)
+}
+
+function handleCoinClicked(coinId: number) {
+  router.push({ name: 'coin-detail', params: { id: coinId } })
+}
+</script>
+
+<style scoped>
+.tray-view-page {
+  padding: 1rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.tray-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.empty-state {
+  padding: 3rem 2rem;
+  text-align: center;
+  max-width: 500px;
+  margin: 3rem auto;
+}
+
+.empty-icon {
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.empty-state h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--text-heading);
+}
+
+.empty-state p {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.empty-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  gap: 1rem;
+}
+
+.loading-state p {
+  color: var(--text-secondary);
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid var(--border-subtle);
+  border-top-color: var(--accent-gold);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+    border-top-color: var(--accent-gold);
+  }
+}
+
+@media (max-width: 575px) {
+  .tray-view-page {
+    padding: 0.75rem;
+  }
+  
+  .empty-state {
+    padding: 2rem 1.5rem;
+    margin: 2rem auto;
+  }
+}
+</style>

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -219,6 +219,12 @@ const router = createRouter({
       component: () => import('@/pages/CalendarPage.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/tray',
+      name: 'tray',
+      component: () => import('@/pages/TrayViewPage.vue'),
+      meta: { requiresAuth: true },
+    },
     // Set routes - placeholder for Phase 2 and Phase 3 implementation
     {
       path: '/sets',

--- a/src/web/src/utils/__tests__/trayLayout.test.ts
+++ b/src/web/src/utils/__tests__/trayLayout.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeDiameterMm, getCoinRenderSizePx, getDrawerCoins, getTotalDrawers } from '../trayLayout'
+import type { TrayCoin } from '../trayLayout'
+
+describe('trayLayout', () => {
+  describe('normalizeDiameterMm', () => {
+    it('returns diameterMm when positive', () => {
+      expect(normalizeDiameterMm(25, 20)).toBe(25)
+      expect(normalizeDiameterMm(35, 20)).toBe(35)
+    })
+
+    it('returns default when null', () => {
+      expect(normalizeDiameterMm(null, 20)).toBe(20)
+    })
+
+    it('returns default when undefined', () => {
+      expect(normalizeDiameterMm(undefined, 20)).toBe(20)
+    })
+
+    it('returns default when zero', () => {
+      expect(normalizeDiameterMm(0, 20)).toBe(20)
+    })
+
+    it('returns default when negative', () => {
+      expect(normalizeDiameterMm(-5, 20)).toBe(20)
+    })
+  })
+
+  describe('getCoinRenderSizePx', () => {
+    const options = {
+      minCoinPx: 40,
+      maxCoinPx: 120,
+      defaultDiameterMm: 20,
+    }
+
+    it('scales small coins smaller than large coins', () => {
+      const allDiameters = [8, 20, 35]
+      const smallSize = getCoinRenderSizePx(8, allDiameters, options)
+      const largeSize = getCoinRenderSizePx(35, allDiameters, options)
+      expect(smallSize).toBeLessThan(largeSize)
+    })
+
+    it('clamps to minimum size', () => {
+      const allDiameters = [8, 20, 35]
+      const size = getCoinRenderSizePx(8, allDiameters, options)
+      expect(size).toBeGreaterThanOrEqual(options.minCoinPx)
+    })
+
+    it('clamps to maximum size', () => {
+      const allDiameters = [8, 20, 50]
+      const size = getCoinRenderSizePx(50, allDiameters, options)
+      expect(size).toBeLessThanOrEqual(options.maxCoinPx)
+    })
+
+    it('handles single coin', () => {
+      const allDiameters = [25]
+      const size = getCoinRenderSizePx(25, allDiameters, options)
+      expect(size).toBeGreaterThanOrEqual(options.minCoinPx)
+      expect(size).toBeLessThanOrEqual(options.maxCoinPx)
+    })
+
+    it('handles all coins same diameter', () => {
+      const allDiameters = [20, 20, 20]
+      const size = getCoinRenderSizePx(20, allDiameters, options)
+      expect(size).toBeGreaterThanOrEqual(options.minCoinPx)
+      expect(size).toBeLessThanOrEqual(options.maxCoinPx)
+    })
+
+    it('handles empty diameter array', () => {
+      const size = getCoinRenderSizePx(20, [], options)
+      expect(size).toBeGreaterThanOrEqual(options.minCoinPx)
+      expect(size).toBeLessThanOrEqual(options.maxCoinPx)
+    })
+
+    it('proportionally scales intermediate sizes', () => {
+      const allDiameters = [10, 20, 30]
+      const smallSize = getCoinRenderSizePx(10, allDiameters, options)
+      const mediumSize = getCoinRenderSizePx(20, allDiameters, options)
+      const largeSize = getCoinRenderSizePx(30, allDiameters, options)
+      
+      expect(mediumSize).toBeGreaterThan(smallSize)
+      expect(largeSize).toBeGreaterThan(mediumSize)
+      expect(mediumSize - smallSize).toBeCloseTo(largeSize - mediumSize, 0)
+    })
+  })
+
+  describe('getDrawerCoins', () => {
+    const coins: TrayCoin[] = Array.from({ length: 100 }, (_, i) => ({
+      id: i + 1,
+      name: `Coin ${i + 1}`,
+      diameterMm: 20,
+      images: [],
+    }))
+
+    it('returns first 50 coins for drawer 0', () => {
+      const drawerCoins = getDrawerCoins(coins, 0, 50)
+      expect(drawerCoins).toHaveLength(50)
+      expect(drawerCoins[0]?.id).toBe(1)
+      expect(drawerCoins[49]?.id).toBe(50)
+    })
+
+    it('returns second 50 coins for drawer 1', () => {
+      const drawerCoins = getDrawerCoins(coins, 1, 50)
+      expect(drawerCoins).toHaveLength(50)
+      expect(drawerCoins[0]?.id).toBe(51)
+      expect(drawerCoins[49]?.id).toBe(100)
+    })
+
+    it('returns partial drawer for last drawer with remainder', () => {
+      const coinsSmall: TrayCoin[] = Array.from({ length: 101 }, (_, i) => ({
+        id: i + 1,
+        name: `Coin ${i + 1}`,
+        diameterMm: 20,
+        images: [],
+      }))
+      const drawerCoins = getDrawerCoins(coinsSmall, 2, 50)
+      expect(drawerCoins).toHaveLength(1)
+      expect(drawerCoins[0]?.id).toBe(101)
+    })
+
+    it('returns empty array for out-of-bounds drawer index', () => {
+      const drawerCoins = getDrawerCoins(coins, 10, 50)
+      expect(drawerCoins).toHaveLength(0)
+    })
+
+    it('returns empty array for negative drawer index', () => {
+      const drawerCoins = getDrawerCoins(coins, -1, 50)
+      expect(drawerCoins).toHaveLength(0)
+    })
+
+    it('handles empty coin array', () => {
+      const drawerCoins = getDrawerCoins([], 0, 50)
+      expect(drawerCoins).toHaveLength(0)
+    })
+  })
+
+  describe('getTotalDrawers', () => {
+    it('returns 2 drawers for 100 coins with 50 per drawer', () => {
+      expect(getTotalDrawers(100, 50)).toBe(2)
+    })
+
+    it('returns 3 drawers for 101 coins with 50 per drawer', () => {
+      expect(getTotalDrawers(101, 50)).toBe(3)
+    })
+
+    it('returns 1 drawer for 25 coins with 50 per drawer', () => {
+      expect(getTotalDrawers(25, 50)).toBe(1)
+    })
+
+    it('returns 0 drawers for 0 coins', () => {
+      expect(getTotalDrawers(0, 50)).toBe(0)
+    })
+
+    it('handles single coin per drawer', () => {
+      expect(getTotalDrawers(5, 1)).toBe(5)
+    })
+  })
+})

--- a/src/web/src/utils/trayLayout.ts
+++ b/src/web/src/utils/trayLayout.ts
@@ -1,0 +1,81 @@
+import type { CoinImage } from '@/types'
+
+export interface TrayCoin {
+  id: number
+  name: string
+  diameterMm: number | null
+  images: readonly CoinImage[]
+}
+
+export interface TrayLayoutOptions {
+  minCoinPx: number
+  maxCoinPx: number
+  defaultDiameterMm: number
+}
+
+/**
+ * Normalizes diameter to a valid positive number, using default if missing or invalid
+ */
+export function normalizeDiameterMm(
+  diameterMm: number | null | undefined,
+  defaultDiameterMm: number
+): number {
+  if (diameterMm == null || diameterMm <= 0) {
+    return defaultDiameterMm
+  }
+  return diameterMm
+}
+
+/**
+ * Calculates render size in pixels for a coin based on its diameter relative to all coins
+ * Scales proportionally within min/max bounds
+ */
+export function getCoinRenderSizePx(
+  diameterMm: number,
+  allDiameters: number[],
+  options: TrayLayoutOptions
+): number {
+  const { minCoinPx, maxCoinPx } = options
+
+  // Handle edge cases: empty array or single value
+  if (allDiameters.length === 0) {
+    return minCoinPx + (maxCoinPx - minCoinPx) / 2
+  }
+
+  const minDiameter = Math.min(...allDiameters)
+  const maxDiameter = Math.max(...allDiameters)
+
+  // All coins same diameter
+  if (minDiameter === maxDiameter) {
+    return minCoinPx + (maxCoinPx - minCoinPx) / 2
+  }
+
+  // Scale proportionally
+  const normalized = (diameterMm - minDiameter) / (maxDiameter - minDiameter)
+  const size = minCoinPx + normalized * (maxCoinPx - minCoinPx)
+
+  // Clamp to bounds
+  return Math.max(minCoinPx, Math.min(maxCoinPx, size))
+}
+
+/**
+ * Returns the coins for a specific drawer (page of results)
+ */
+export function getDrawerCoins(
+  coins: TrayCoin[],
+  drawerIndex: number,
+  coinsPerDrawer: number
+): TrayCoin[] {
+  if (drawerIndex < 0) return []
+  const start = drawerIndex * coinsPerDrawer
+  const end = start + coinsPerDrawer
+  return coins.slice(start, end)
+}
+
+/**
+ * Calculates total number of drawers needed for pagination
+ */
+export function getTotalDrawers(totalCoins: number, coinsPerDrawer: number): number {
+  if (totalCoins === 0) return 0
+  return Math.ceil(totalCoins / coinsPerDrawer)
+}


### PR DESCRIPTION
## Summary
- Adds the Museum Tray View under Collection > Tray with drawer pagination and felt theme selection
- Scales coin wells by diameter and routes tray coin selection to the coin detail page
- Adds tray layout/preference utilities plus component/navigation regression coverage

## Constitution
- Principle IV + §17

## Validation
- npm test -- --run
- npm test -- trayLayout MuseumTrayWell --run
- npm run lint (passes with existing warnings only)
- npm run type-check
- npm run build
- git diff --check