### PR TITLE
fix: apply tray UI follow-ups

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -250,6 +250,19 @@ All chips use `border-radius: var(--radius-full)`. Active state: `background: va
 - Chip/tag gaps: `0.35rem`
 - Card internal padding: `0.75rem` (info cards), `1rem` (feature cards), `1.5rem` (page cards)
 
+#### UI Pattern Recipes
+
+Before implementing UI, identify the closest existing page or component pattern and reuse it unless the user explicitly approves a new pattern. Do not fall back to generic layouts when a local pattern exists.
+
+| Pattern | Use | Required shape |
+|---|---|---|
+| Page header | Standalone feature pages | `header.page-header` row with the title on the left and any back action as a compact icon/link on the right. Avoid long intro copy unless the page truly needs explanation. |
+| Sidebar submenus | Related alternate views under one domain | Keep the parent item expandable/collapsible and start collapsed. Put related views under the parent as subitems instead of adding extra top-level menu items. |
+| Summary metric row | A page has one primary count/value | Use one compact horizontal label/value row, e.g. `Mapped Coins:` left and value right. Do not create a large card or stacked label/value block for a single metric. |
+| Pagination controls | Previous/next navigation | Keep controls in one row: `< Previous` then current label then `Next >`. Do not stack Previous and Next on mobile unless the viewport is too narrow to preserve usable tap targets. |
+| Stats subviews | Health, value trends, timeline, map | Each subview is its own route/page under the Stats submenu; the Stats landing page stays summary-card focused. |
+| Collection subviews | Gallery and Tray | Keep Gallery and Tray under the Collection submenu; the Collection parent starts collapsed like Stats. |
+
 #### Rules for New UI Components
 
 1. **Never hardcode** `border-radius`, colors, or spacing — always use tokens

--- a/src/web/src/__tests__/ui-patterns.test.ts
+++ b/src/web/src/__tests__/ui-patterns.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..')
+const SRC_DIR = join(REPO_ROOT, 'src', 'web', 'src')
+const COPILOT_INSTRUCTIONS = join(REPO_ROOT, '.github', 'copilot-instructions.md')
+
+function readRepoFile(pathFromSrc: string): string {
+  return readFileSync(join(SRC_DIR, pathFromSrc), 'utf-8')
+}
+
+function extractCssBlock(content: string, selector: string): string {
+  const start = content.indexOf(`${selector} {`)
+  if (start === -1) return ''
+  const bodyStart = content.indexOf('{', start)
+  const bodyEnd = content.indexOf('}', bodyStart)
+  return content.slice(bodyStart + 1, bodyEnd)
+}
+
+describe('UI pattern recipes', () => {
+  it('documents reusable UI recipes for future agents', () => {
+    const instructions = readFileSync(COPILOT_INSTRUCTIONS, 'utf-8')
+
+    expect(instructions).toContain('#### UI Pattern Recipes')
+    expect(instructions).toContain('identify the closest existing page or component pattern')
+    expect(instructions).toContain('Keep controls in one row: `< Previous` then current label then `Next >`')
+    expect(instructions).toContain('Keep Gallery and Tray under the Collection submenu')
+  })
+
+  it('keeps tray pagination in one Previous, drawer label, Next row', () => {
+    const trayControls = readRepoFile(join('components', 'tray', 'TrayControls.vue'))
+    const drawerNavigation = extractCssBlock(trayControls, '.drawer-navigation')
+    const drawerLabel = extractCssBlock(trayControls, '.drawer-label')
+
+    expect(trayControls).toContain('&lt; Previous')
+    expect(trayControls).toContain('Drawer {{ drawerIndex + 1 }} of {{ totalDrawers }}')
+    expect(trayControls).toContain('Next &gt;')
+    expect(drawerNavigation).toContain('flex-wrap: nowrap')
+    expect(drawerNavigation).not.toContain('flex-direction: column')
+    expect(drawerLabel).not.toContain('order: -1')
+  })
+
+  it('keeps Stats and Collection sidebar parents collapsed with submenu children', () => {
+    const app = readRepoFile('App.vue')
+
+    expect(app).toContain("const statsExpanded = ref(false)")
+    expect(app).toContain("const collectionExpanded = ref(false)")
+    expect(app).toContain("id: 'collection'")
+    expect(app).toContain("label: 'Gallery'")
+    expect(app).toContain("label: 'Tray'")
+    expect(app).toContain("id: 'stats'")
+    expect(app).toContain("label: 'Timeline'")
+    expect(app).toContain("label: 'Map'")
+  })
+})

--- a/src/web/src/components/__tests__/TrayControls.test.ts
+++ b/src/web/src/components/__tests__/TrayControls.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TrayControls from '../tray/TrayControls.vue'
+
+describe('TrayControls', () => {
+  it('renders drawer navigation in Previous, label, Next order', () => {
+    const wrapper = mount(TrayControls, {
+      props: {
+        drawerIndex: 1,
+        totalDrawers: 5,
+        feltTheme: 'red',
+      },
+    })
+
+    const navigation = wrapper.find('.drawer-navigation')
+    const items = navigation.element.children
+
+    expect(items).toHaveLength(3)
+    expect(items[0]?.textContent?.trim()).toBe('< Previous')
+    expect(items[1]?.textContent?.trim()).toBe('Drawer 2 of 5')
+    expect(items[2]?.textContent?.trim()).toBe('Next >')
+  })
+})

--- a/src/web/src/components/tray/TrayControls.vue
+++ b/src/web/src/components/tray/TrayControls.vue
@@ -6,8 +6,7 @@
         :disabled="drawerIndex === 0"
         @click="emit('prev')"
       >
-        <ChevronLeft :size="16" />
-        Previous
+        &lt; Previous
       </button>
       <span class="drawer-label">
         Drawer {{ drawerIndex + 1 }} of {{ totalDrawers }}
@@ -17,8 +16,7 @@
         :disabled="drawerIndex >= totalDrawers - 1"
         @click="emit('next')"
       >
-        Next
-        <ChevronRight :size="16" />
+        Next &gt;
       </button>
     </div>
     <div class="felt-theme-selector">
@@ -54,7 +52,6 @@
 </template>
 
 <script setup lang="ts">
-import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import type { FeltColor } from '@/composables/useTrayPreference'
 
 interface Props {
@@ -83,12 +80,18 @@ const emit = defineEmits<{
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: nowrap;
   gap: 1rem;
+}
+
+.drawer-navigation .btn {
+  white-space: nowrap;
 }
 
 .drawer-label {
   font-size: 0.9rem;
   color: var(--text-primary);
+  flex: 0 0 auto;
   min-width: 120px;
   text-align: center;
 }
@@ -153,17 +156,11 @@ const emit = defineEmits<{
   .tray-controls {
     gap: 0.75rem;
   }
-  
+
   .drawer-navigation {
-    flex-direction: column;
     gap: 0.5rem;
   }
-  
-  .drawer-label {
-    order: -1;
-    margin-bottom: 0.25rem;
-  }
-  
+
   .felt-theme-selector {
     flex-direction: column;
     gap: 0.5rem;


### PR DESCRIPTION
## Summary
- Keeps Museum Tray pagination controls inline as < Previous / Drawer x of y / Next >
- Adds a TrayControls regression test
- Documents reusable UI pattern recipes and adds UI pattern enforcement tests

## Constitution
- Principle VI + §17

## Validation
- npm test -- ui-patterns TrayControls --run
- npm run lint (passes with existing warnings only)
- npm run type-check
- npm run build
- git diff --check