### PR TITLE
fix: persist auction max bid updates

### DIFF
--- a/src/api/handlers/auction_lots.go
+++ b/src/api/handlers/auction_lots.go
@@ -346,28 +346,44 @@ func (h *AuctionLotHandler) UpdateStatus(c *gin.Context) {
 	}
 
 	newStatus := models.AuctionLotStatus(req.Status)
-	if err := h.svc.UpdateStatus(uint(id), userID, newStatus); err != nil {
-		if errors.Is(err, services.ErrAuctionLotNotFound) {
+	lot, err := h.repo.GetByID(uint(id), userID)
+	if err != nil {
+		if repository.IsRecordNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Auction lot not found"})
-			return
-		}
-		if errors.Is(err, services.ErrInvalidStatus) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid status transition"})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update status"})
 		return
 	}
 
-	// Save max bid if provided (typically when transitioning to "bidding")
-	if req.MaxBid != nil {
-		lot, _ := h.repo.GetByID(uint(id), userID)
-		if lot != nil {
-			h.repo.UpdateFields(lot, map[string]interface{}{"max_bid": req.MaxBid})
+	if lot.Status != newStatus {
+		if err := h.svc.UpdateStatus(uint(id), userID, newStatus); err != nil {
+			if errors.Is(err, services.ErrAuctionLotNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "Auction lot not found"})
+				return
+			}
+			if errors.Is(err, services.ErrInvalidStatus) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid status transition"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update status"})
+			return
 		}
 	}
 
-	lot, _ := h.repo.GetByID(uint(id), userID)
+	if req.MaxBid != nil {
+		lot, err = h.repo.GetByID(uint(id), userID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update status"})
+			return
+		}
+		if err := h.repo.UpdateFields(lot, map[string]interface{}{"max_bid": *req.MaxBid}); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update max bid"})
+			return
+		}
+	}
+
+	lot, _ = h.repo.GetByID(uint(id), userID)
 	c.JSON(http.StatusOK, lot)
 }
 

--- a/src/api/handlers/auction_lots_status_test.go
+++ b/src/api/handlers/auction_lots_status_test.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/briandenicola/ancient-coins-api/models"
+	"github.com/briandenicola/ancient-coins-api/repository"
+	"github.com/briandenicola/ancient-coins-api/services"
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestAuctionLotHandlerUpdateStatusPersistsChangedMaxBidWithoutStatusChange(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.AuctionLot{}); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	initialMaxBid := 100.0
+	lot := models.AuctionLot{
+		Title:        "CNG test lot",
+		NumisBidsURL: "https://auctions.cngcoins.com/lots/view/4-LOT/test",
+		Source:       models.AuctionSourceCNG,
+		SourceURL:    "https://auctions.cngcoins.com/lots/view/4-LOT/test",
+		Status:       models.AuctionStatusBidding,
+		MaxBid:       &initialMaxBid,
+		UserID:       42,
+	}
+	if err := db.Create(&lot).Error; err != nil {
+		t.Fatalf("create lot: %v", err)
+	}
+
+	auctionRepo := repository.NewAuctionLotRepository(db)
+	handler := NewAuctionLotHandler(auctionRepo, services.NewAuctionLotService(auctionRepo, nil), nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodPut, "/auctions/1/status", bytes.NewBufferString(`{"status":"bidding","maxBid":150}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	c.Params = gin.Params{{Key: "id", Value: "1"}}
+	c.Set("userId", uint(42))
+
+	handler.UpdateStatus(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateStatus status = %d body=%s", w.Code, w.Body.String())
+	}
+
+	var updated models.AuctionLot
+	if err := db.First(&updated, lot.ID).Error; err != nil {
+		t.Fatalf("reload lot: %v", err)
+	}
+	if updated.Status != models.AuctionStatusBidding {
+		t.Fatalf("status = %q, want bidding", updated.Status)
+	}
+	if updated.MaxBid == nil || *updated.MaxBid != 150 {
+		t.Fatalf("max bid = %v, want 150", updated.MaxBid)
+	}
+}

--- a/src/web/src/components/auction/AuctionLotDetailModal.vue
+++ b/src/web/src/components/auction/AuctionLotDetailModal.vue
@@ -132,7 +132,7 @@
             <option value="lost">Lost</option>
             <option value="passed">Passed</option>
           </select>
-          <button class="btn btn-secondary" @click="changeStatus" :disabled="newStatus === lot.status">
+          <button class="btn btn-secondary" @click="changeStatus" :disabled="!hasPendingStatusUpdate">
             Update Status
           </button>
         </div>
@@ -211,6 +211,9 @@ const lotImageSource = computed(() => props.lot.imageUrl ?? '')
 const { proxiedImageUrl } = useProxiedImage(lotImageSource)
 const providerLabel = computed(() => props.lot.source === 'cng' ? 'CNG' : 'NumisBids')
 const externalUrl = computed(() => props.lot.sourceUrl || props.lot.numisBidsUrl)
+const normalizedMaxBidInput = computed(() => typeof maxBidInput.value === 'number' && !Number.isNaN(maxBidInput.value) ? maxBidInput.value : null)
+const maxBidChanged = computed(() => newStatus.value === 'bidding' && normalizedMaxBidInput.value !== null && normalizedMaxBidInput.value !== (props.lot.maxBid ?? null))
+const hasPendingStatusUpdate = computed(() => newStatus.value !== props.lot.status || maxBidChanged.value)
 
 function formatDate(dateStr: string) {
   return new Date(dateStr).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
@@ -356,7 +359,7 @@ async function linkEvent() {
 
 async function changeStatus() {
   try {
-    const bid = newStatus.value === 'bidding' ? maxBidInput.value : undefined
+    const bid = maxBidChanged.value ? normalizedMaxBidInput.value : undefined
     await updateAuctionLotStatus(props.lot.id, newStatus.value, bid)
 
     if (newStatus.value === 'won') {

--- a/src/web/src/components/auction/__tests__/AuctionLotDetailModal.test.ts
+++ b/src/web/src/components/auction/__tests__/AuctionLotDetailModal.test.ts
@@ -1,0 +1,95 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import AuctionLotDetailModal from '../AuctionLotDetailModal.vue'
+import type { AuctionLot } from '@/types'
+
+const mocks = vi.hoisted(() => ({
+  updateAuctionLotStatus: vi.fn(),
+  updateAuctionLot: vi.fn(),
+  convertAuctionLotToCoin: vi.fn(),
+  deleteAuctionLot: vi.fn(),
+  listCalendarEvents: vi.fn(),
+  linkAuctionLotEvent: vi.fn(),
+  push: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => ({
+  updateAuctionLotStatus: mocks.updateAuctionLotStatus,
+  updateAuctionLot: mocks.updateAuctionLot,
+  convertAuctionLotToCoin: mocks.convertAuctionLotToCoin,
+  deleteAuctionLot: mocks.deleteAuctionLot,
+  listCalendarEvents: mocks.listCalendarEvents,
+  linkAuctionLotEvent: mocks.linkAuctionLotEvent,
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: mocks.push }),
+}))
+
+vi.mock('@/composables/useProxiedImage', () => ({
+  useProxiedImage: () => ({ proxiedImageUrl: { value: '' } }),
+}))
+
+const safeExternalLinkStub = {
+  props: ['href'],
+  template: '<a :href="href"><slot /></a>',
+}
+
+describe('AuctionLotDetailModal', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach(mock => mock.mockReset())
+    mocks.listCalendarEvents.mockResolvedValue({ data: { events: [] } })
+    mocks.updateAuctionLotStatus.mockResolvedValue({ data: buildAuctionLot() })
+  })
+
+  it('persists a max bid change when the status stays bidding', async () => {
+    const wrapper = mount(AuctionLotDetailModal, {
+      props: { lot: buildAuctionLot({ status: 'bidding', maxBid: 100 }) },
+      global: {
+        stubs: {
+          SafeExternalLink: safeExternalLinkStub,
+        },
+      },
+    })
+
+    const updateButton = wrapper.findAll('button').find(button => button.text().includes('Update Status'))
+    expect(updateButton?.attributes('disabled')).toBeDefined()
+
+    await wrapper.find('input.bid-input').setValue('150')
+    expect(updateButton?.attributes('disabled')).toBeUndefined()
+    await updateButton!.trigger('click')
+
+    expect(mocks.updateAuctionLotStatus).toHaveBeenCalledWith(7, 'bidding', 150)
+  })
+})
+
+function buildAuctionLot(overrides: Partial<AuctionLot> = {}): AuctionLot {
+  return {
+    id: 7,
+    numisBidsUrl: 'https://auctions.cngcoins.com/lots/view/4-LOT/test',
+    source: 'cng',
+    sourceUrl: 'https://auctions.cngcoins.com/lots/view/4-LOT/test',
+    saleId: '4',
+    lotNumber: 1,
+    auctionHouse: 'CNG',
+    saleName: 'Electronic Auction',
+    saleDate: null,
+    auctionEndTime: null,
+    title: 'CNG test lot',
+    description: '',
+    notes: '',
+    category: 'Roman',
+    estimate: null,
+    currentBid: null,
+    maxBid: 100,
+    currency: 'USD',
+    status: 'bidding',
+    imageUrl: '',
+    coinId: null,
+    eventId: null,
+    userId: 1,
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+    ...overrides,
+  }
+}


### PR DESCRIPTION
## Summary
- Persists auction max bid changes even when the lot status is unchanged
- Enables the auction detail modal Update Status action when only the max bid changed
- Adds backend and frontend regression coverage for the reported auction bidding bug

## Validation
- go test ./handlers -run TestAuctionLotHandlerUpdateStatusPersistsChangedMaxBidWithoutStatusChange -v
- go test ./...
- npm.cmd run test -- src/components/auction/__tests__/AuctionLotDetailModal.test.ts
- npm.cmd run type-check

## Constitution
- Principle IV: simple complete proportional fix
- Principle VI: preserves auction bidding UX expectations
- Section 17: quality gate validation completed