### PR TITLE
feat: streamline auction filters

### DIFF
--- a/.squad/agents/aurelia/history.md
+++ b/.squad/agents/aurelia/history.md
@@ -410,3 +410,5 @@ Investigated production 429s on collection browsing. App mount makes expected da
   - **Migration:** Existing NumisBids lots backfilled by backend (provider='numisbids'); no frontend breaking change.
   - **Implementation roadmap:** 5 phases, ~10 turns total. Phase 1 (1 turn) and Phases 2–3 can proceed in parallel with Cassius backend work.
   - **Orchestration log:** .squad/orchestration-log/2026-06-30T22-43-42Z-aurelia.md.
+
+- **2026-07-01:** Auctions filter toolbar now keeps source chips visible in the primary row and moves status filters behind a right-aligned lucide menu button. This preserves the existing `activeStatus` / `activeSource` query behavior while reducing stacked filter rows on PWA/mobile.

--- a/src/web/src/components/auction/AuctionStatusFilter.vue
+++ b/src/web/src/components/auction/AuctionStatusFilter.vue
@@ -1,12 +1,28 @@
 <template>
-  <div class="filter-bar">
-    <div class="status-filters">
+  <div class="status-filter-menu" @keydown.esc="menuOpen = false">
+    <button
+      type="button"
+      class="btn btn-sm btn-ghost menu-button"
+      :class="{ active: modelValue }"
+      aria-label="Auction status filters"
+      aria-haspopup="menu"
+      :aria-expanded="menuOpen"
+      title="Status filters"
+      @click="menuOpen = !menuOpen"
+    >
+      <Menu :size="18" />
+    </button>
+
+    <div v-if="menuOpen" class="status-menu" role="menu" aria-label="Auction status filters">
       <button
         v-for="s in statuses"
         :key="s.value"
-        class="filter-btn"
+        type="button"
+        class="chip status-option"
         :class="{ active: modelValue === s.value }"
-        @click="$emit('update:modelValue', s.value)"
+        role="menuitemradio"
+        :aria-checked="modelValue === s.value"
+        @click="selectStatus(s.value)"
       >
         {{ s.label }}
         <span v-if="counts[s.value]" class="count-badge">{{ counts[s.value] }}</span>
@@ -16,14 +32,19 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
+import { Menu } from 'lucide-vue-next'
+
 defineProps<{
   modelValue: string
   counts: Record<string, number>
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   'update:modelValue': [value: string]
 }>()
+
+const menuOpen = ref(false)
 
 const statuses = [
   { value: '', label: 'All' },
@@ -33,42 +54,52 @@ const statuses = [
   { value: 'lost', label: 'Lost' },
   { value: 'passed', label: 'Passed' },
 ]
+
+function selectStatus(value: string) {
+  emit('update:modelValue', value)
+  menuOpen.value = false
+}
 </script>
 
 <style scoped>
-.filter-bar {
-  margin-bottom: 1.25rem;
-}
-
-.status-filters {
+.status-filter-menu {
+  position: relative;
   display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
-.filter-btn {
-  padding: 0.4rem 0.9rem;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-full);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 0.82rem;
-  cursor: pointer;
-  transition: all var(--transition-fast);
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
+.menu-button {
+  justify-content: center;
+  padding-inline: 0.75rem;
 }
 
-.filter-btn:hover {
-  border-color: var(--accent-gold-dim);
-  color: var(--text-primary);
-}
-
-.filter-btn.active {
+.menu-button.active {
   background: var(--accent-gold-glow);
-  border-color: var(--accent-gold-dim);
+  border-color: var(--accent-gold);
   color: var(--accent-gold);
+}
+
+.status-menu {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.35rem;
+  min-width: 9rem;
+  padding: 0.5rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-card);
+}
+
+.status-option {
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
 }
 
 .count-badge {

--- a/src/web/src/components/auction/__tests__/AuctionStatusFilter.test.ts
+++ b/src/web/src/components/auction/__tests__/AuctionStatusFilter.test.ts
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import AuctionStatusFilter from '../AuctionStatusFilter.vue'
+
+describe('AuctionStatusFilter', () => {
+  it('keeps status filters hidden behind the menu button and emits selected status', async () => {
+    const wrapper = mount(AuctionStatusFilter, {
+      props: {
+        modelValue: 'bidding',
+        counts: { bidding: 2, won: 1 },
+      },
+    })
+
+    expect(wrapper.find('.status-menu').exists()).toBe(false)
+
+    await wrapper.get('.menu-button').trigger('click')
+
+    expect(wrapper.find('.status-menu').exists()).toBe(true)
+    expect(wrapper.text()).toContain('All')
+    expect(wrapper.text()).toContain('Watching')
+    expect(wrapper.text()).toContain('Bidding')
+    expect(wrapper.text()).toContain('Won')
+    expect(wrapper.text()).toContain('Lost')
+    expect(wrapper.text()).toContain('Passed')
+
+    const wonButton = wrapper.findAll('.status-option').find(button => button.text().includes('Won'))
+    if (!wonButton) throw new Error('Won status option not found')
+    await wonButton.trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['won']])
+    expect(wrapper.find('.status-menu').exists()).toBe(false)
+  })
+})

--- a/src/web/src/pages/AuctionsPage.vue
+++ b/src/web/src/pages/AuctionsPage.vue
@@ -30,18 +30,19 @@
 
       <div v-if="syncMessage" class="sync-toast">{{ syncMessage }}</div>
 
-      <AuctionStatusFilter v-model="activeStatus" :counts="statusCounts" />
-
-      <div class="source-filter" aria-label="Auction source filter">
-        <button
-          v-for="source in sourceOptions"
-          :key="source.value"
-          class="chip"
-          :class="{ active: activeSource === source.value }"
-          @click="activeSource = source.value"
-        >
-          {{ source.label }}
-        </button>
+      <div class="auction-filter-toolbar">
+        <div class="source-filter" aria-label="Auction source filter">
+          <button
+            v-for="source in sourceOptions"
+            :key="source.value"
+            class="chip"
+            :class="{ active: activeSource === source.value }"
+            @click="activeSource = source.value"
+          >
+            {{ source.label }}
+          </button>
+        </div>
+        <AuctionStatusFilter v-model="activeStatus" :counts="statusCounts" />
       </div>
 
       <div v-if="selectMode" class="select-controls">
@@ -297,11 +298,26 @@ fetchAllCounts()
   animation: fadeIn 0.2s ease;
 }
 
+.auction-filter-toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: nowrap;
+  margin-bottom: 1rem;
+}
+
 .source-filter {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
-  margin-bottom: 1rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.auction-filter-toolbar :deep(.status-filter-menu) {
+  flex: 0 0 auto;
+  margin-left: auto;
 }
 
 .import-first-btn {


### PR DESCRIPTION
## Summary
- Keeps auction source filters visible as one left-aligned row: All, NumisBids, CNG
- Moves status filters into a right-aligned menu button with All, Watching, Bidding, Won, Lost, Passed
- Preserves existing source/status query behavior and adds a targeted status menu component test

## Validation
- npm.cmd run test -- src/components/auction/__tests__/AuctionStatusFilter.test.ts
- npm.cmd run type-check
- npm.cmd run build

## Constitution
- Principle VI: keeps Auctions UI consistent with existing chip/menu patterns
- Section 17: frontend quality gate validation completed