### PR TITLE
fix: sync only configured auction providers

### DIFF
--- a/src/web/src/pages/AuctionsPage.vue
+++ b/src/web/src/pages/AuctionsPage.vue
@@ -232,6 +232,11 @@ async function syncWatchlist() {
   syncMessage.value = ''
   try {
     const providers = configuredAuctionProviders()
+    if (!providers.length) {
+      syncMessage.value = 'Configure auction provider credentials in Settings before syncing'
+      setTimeout(() => { syncMessage.value = '' }, 5000)
+      return
+    }
     const results = await Promise.allSettled(providers.map((source) => syncNumisBidsWatchlist(source)))
     const synced = results.reduce((total, result) => total + (result.status === 'fulfilled' ? result.value.data?.synced ?? 0 : 0), 0)
     const failed = results.filter((result) => result.status === 'rejected')
@@ -255,7 +260,7 @@ function configuredAuctionProviders(): string[] {
   const providers: string[] = []
   if (auth.user?.numisBidsConfigured) providers.push('numisbids')
   if (auth.user?.cngConfigured) providers.push('cng')
-  return providers.length ? providers : ['numisbids']
+  return providers
 }
 
 function providerName(source: string): string {

--- a/src/web/src/pages/__tests__/AuctionsPage.test.ts
+++ b/src/web/src/pages/__tests__/AuctionsPage.test.ts
@@ -1,0 +1,103 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import AuctionsPage from '../AuctionsPage.vue'
+import { getAuctionLotCounts, getAuctionLots, syncNumisBidsWatchlist } from '@/api/client'
+import { useAuthStore } from '@/stores/auth'
+
+vi.mock('@/api/client', () => ({
+  getAuctionLots: vi.fn(),
+  getAuctionLotCounts: vi.fn(),
+  syncNumisBidsWatchlist: vi.fn(),
+  listCalendarEvents: vi.fn(),
+  bulkLinkAuctionLotEvent: vi.fn(),
+  onTokenRefreshed: vi.fn(),
+}))
+
+vi.mock('@/composables/usePwa', () => ({
+  usePwa: () => ({ isPwa: false }),
+}))
+
+function mountPage() {
+  return mount(AuctionsPage, {
+    global: {
+      stubs: {
+        AuctionBulkActionBar: true,
+        AuctionLotCard: true,
+        AuctionLotDetailModal: true,
+        AuctionStatusFilter: true,
+        CheckSquare: true,
+        CirclePlus: true,
+        ExternalLink: true,
+        ImportLotModal: true,
+        Plus: true,
+        PullToRefresh: { template: '<div><slot /></div>' },
+        RefreshCw: true,
+        SafeExternalLink: { template: '<a><slot /></a>' },
+      },
+    },
+  })
+}
+
+describe('AuctionsPage', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(getAuctionLots).mockReset()
+    vi.mocked(getAuctionLotCounts).mockReset()
+    vi.mocked(syncNumisBidsWatchlist).mockReset()
+    vi.mocked(getAuctionLots).mockResolvedValue({ data: { lots: [], total: 0, page: 1, limit: 50 } } as Awaited<ReturnType<typeof getAuctionLots>>)
+    vi.mocked(getAuctionLotCounts).mockResolvedValue({ data: { counts: {} } } as Awaited<ReturnType<typeof getAuctionLotCounts>>)
+    vi.mocked(syncNumisBidsWatchlist).mockResolvedValue({ data: { synced: 3, lots: [] } } as Awaited<ReturnType<typeof syncNumisBidsWatchlist>>)
+  })
+
+  it('syncs only CNG when only CNG credentials are configured', async () => {
+    const auth = useAuthStore()
+    auth.user = {
+      id: 1,
+      username: 'collector',
+      role: 'user',
+      email: 'collector@example.com',
+      avatarPath: '',
+      isPublic: false,
+      bio: '',
+      zipCode: '',
+      numisBidsConfigured: false,
+      cngConfigured: true,
+    }
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    await wrapper.get('.header-actions .btn-secondary').trigger('click')
+    await flushPromises()
+
+    expect(syncNumisBidsWatchlist).toHaveBeenCalledTimes(1)
+    expect(syncNumisBidsWatchlist).toHaveBeenCalledWith('cng')
+    expect(wrapper.text()).toContain('Synced 3 lots from CNG Auctions')
+  })
+
+  it('does not sync any provider when no auction credentials are configured', async () => {
+    const auth = useAuthStore()
+    auth.user = {
+      id: 1,
+      username: 'collector',
+      role: 'user',
+      email: 'collector@example.com',
+      avatarPath: '',
+      isPublic: false,
+      bio: '',
+      zipCode: '',
+      numisBidsConfigured: false,
+      cngConfigured: false,
+    }
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    await wrapper.get('.header-actions .btn-secondary').trigger('click')
+    await flushPromises()
+
+    expect(syncNumisBidsWatchlist).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Configure auction provider credentials in Settings before syncing')
+  })
+})


### PR DESCRIPTION
## Summary
- sync only auction providers with configured credentials
- show a settings message when no auction providers are configured
- add Auctions page regression coverage for CNG-only and no-provider sync

## Constitution
Principle V + §17

## Validation
- npm.cmd run test -- src/pages/__tests__/AuctionsPage.test.ts
- npm.cmd run type-check
- npm.cmd run build