### PR TITLE
feat: run wishlist search alerts asynchronously

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13423,7 +13423,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Manually runs a saved discovery alert and stores candidates separately from availability checks.",
+                "description": "Queues a saved discovery alert run and stores candidates separately from availability checks when processing completes.",
                 "consumes": [
                     "application/json"
                 ],
@@ -13452,8 +13452,8 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "202": {
+                        "description": "Accepted",
                         "schema": {
                             "$ref": "#/definitions/handlers.WishlistSearchAlertRunResponse"
                         }

--- a/src/api/docs/docs.go
+++ b/src/api/docs/docs.go
@@ -13430,7 +13430,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Manually runs a saved discovery alert and stores candidates separately from availability checks.",
+                "description": "Queues a saved discovery alert run and stores candidates separately from availability checks when processing completes.",
                 "consumes": [
                     "application/json"
                 ],
@@ -13459,8 +13459,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "202": {
+                        "description": "Accepted",
                         "schema": {
                             "$ref": "#/definitions/handlers.WishlistSearchAlertRunResponse"
                         }

--- a/src/api/docs/swagger.json
+++ b/src/api/docs/swagger.json
@@ -13423,7 +13423,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Manually runs a saved discovery alert and stores candidates separately from availability checks.",
+                "description": "Queues a saved discovery alert run and stores candidates separately from availability checks when processing completes.",
                 "consumes": [
                     "application/json"
                 ],
@@ -13452,8 +13452,8 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "202": {
+                        "description": "Accepted",
                         "schema": {
                             "$ref": "#/definitions/handlers.WishlistSearchAlertRunResponse"
                         }

--- a/src/api/docs/swagger.yaml
+++ b/src/api/docs/swagger.yaml
@@ -11480,8 +11480,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Manually runs a saved discovery alert and stores candidates separately
-        from availability checks.
+      description: Queues a saved discovery alert run and stores candidates separately
+        from availability checks when processing completes.
       parameters:
       - description: Alert ID
         in: path
@@ -11496,8 +11496,8 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "202":
+          description: Accepted
           schema:
             $ref: '#/definitions/handlers.WishlistSearchAlertRunResponse'
         "400":

--- a/src/api/handlers/wishlist_search_alerts.go
+++ b/src/api/handlers/wishlist_search_alerts.go
@@ -160,16 +160,16 @@ func (h *WishlistSearchAlertHandler) Delete(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// RunNow runs an active alert immediately and persists auditable results.
+// RunNow queues an active alert for asynchronous discovery and persists auditable results.
 //
 //	@Summary		Run wishlist search alert
-//	@Description	Manually runs a saved discovery alert and stores candidates separately from availability checks.
+//	@Description	Queues a saved discovery alert run and stores candidates separately from availability checks when processing completes.
 //	@Tags			Wishlist Search Alerts
 //	@Accept			json
 //	@Produce		json
 //	@Param			alertId	path	int						true	"Alert ID"
 //	@Param			body	body	WishlistSearchAlertRunRequest	false	"Run request"
-//	@Success		200		{object}	WishlistSearchAlertRunResponse
+//	@Success		202		{object}	WishlistSearchAlertRunResponse
 //	@Failure		400		{object}	ErrorResponse
 //	@Failure		401		{object}	ErrorResponse
 //	@Failure		404		{object}	ErrorResponse
@@ -190,7 +190,7 @@ func (h *WishlistSearchAlertHandler) RunNow(c *gin.Context) {
 		respondWishlistSearchAlertError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, result)
+	c.JSON(http.StatusAccepted, result)
 }
 
 // ListRuns lists run history for one alert.

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -194,6 +194,7 @@ func main() {
 	notifSvc := services.NewNotificationService(notifRepo, socialRepo, userRepoForVal, pushoverSvc, logger)
 	availSvc := services.NewAvailabilityService(coinRepo, availRepo, agentProxy, notifSvc, pushoverSvc, userRepoForVal, settingsSvc, logger)
 	wishlistSearchAlertSvc := services.NewWishlistSearchAlertService(wishlistSearchAlertRepo).WithDiscovery(agentProxy, settingsSvc)
+	wishlistSearchAlertSvc.StartWorkers(1)
 	valSvc := services.NewValuationService(coinRepo, valRepo, agentProxy, userRepoForVal, pushoverSvc, notifSvc, settingsSvc, logger)
 	aiJobRepo := repository.NewAIJobRepository(database.DB)
 	aiJobSvc := services.NewAIJobService(aiJobRepo, agentProxy, userRepoForVal, settingsSvc, notifSvc, logger)

--- a/src/api/repository/wishlist_search_alert_repository.go
+++ b/src/api/repository/wishlist_search_alert_repository.go
@@ -103,7 +103,7 @@ func (r *WishlistSearchAlertRepository) CreateManualRunIfAvailable(run *models.A
 	err := r.db.Transaction(func(tx *gorm.DB) error {
 		var count int64
 		if err := tx.Model(&models.AlertRun{}).
-			Where("alert_id = ? AND user_id = ? AND status = ? AND started_at >= ?", run.AlertID, run.UserID, models.AlertRunStatusRunning, runningSince).
+			Where("alert_id = ? AND user_id = ? AND status IN ? AND started_at >= ?", run.AlertID, run.UserID, []models.AlertRunStatus{models.AlertRunStatusQueued, models.AlertRunStatusRunning}, runningSince).
 			Count(&count).Error; err != nil {
 			return err
 		}
@@ -119,8 +119,56 @@ func (r *WishlistSearchAlertRepository) CreateManualRunIfAvailable(run *models.A
 	return acquired, err
 }
 
+func (r *WishlistSearchAlertRepository) ClaimQueuedRun(runID uint) (*models.AlertRun, bool, error) {
+	now := time.Now()
+	var run models.AlertRun
+	claimed := false
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		result := tx.Model(&models.AlertRun{}).
+			Where("id = ? AND status = ?", runID, models.AlertRunStatusQueued).
+			Updates(map[string]interface{}{
+				"status":            models.AlertRunStatusRunning,
+				"started_at":        now,
+				"completed_at":      nil,
+				"duration_ms":       0,
+				"error_message":     "",
+				"rate_limit_status": "ok",
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return nil
+		}
+		claimed = true
+		return tx.First(&run, runID).Error
+	})
+	return &run, claimed, err
+}
+
 func (r *WishlistSearchAlertRepository) UpdateRun(run *models.AlertRun) error {
 	return r.db.Save(run).Error
+}
+
+func (r *WishlistSearchAlertRepository) RecoverStaleAlertRuns(timeout time.Duration) ([]uint, error) {
+	cutoff := time.Now().Add(-timeout)
+	if err := r.db.Model(&models.AlertRun{}).
+		Where("status = ? AND started_at < ?", models.AlertRunStatusRunning, cutoff).
+		Updates(map[string]interface{}{
+			"status":            models.AlertRunStatusQueued,
+			"completed_at":      nil,
+			"duration_ms":       0,
+			"error_message":     "",
+			"rate_limit_status": "ok",
+		}).Error; err != nil {
+		return nil, err
+	}
+	var ids []uint
+	err := r.db.Model(&models.AlertRun{}).
+		Where("status = ?", models.AlertRunStatusQueued).
+		Order("created_at ASC").
+		Pluck("id", &ids).Error
+	return ids, err
 }
 
 func (r *WishlistSearchAlertRepository) ListRuns(alertID, userID uint, page, limit int) ([]models.AlertRun, int64, error) {

--- a/src/api/services/wishlist_search_alert_service.go
+++ b/src/api/services/wishlist_search_alert_service.go
@@ -38,6 +38,7 @@ var (
 const (
 	AlertResultCapDefault          = 20
 	AlertResultCapMax              = 50
+	wishlistAlertRunQueueSize      = 100
 	wishlistAlertDiscoveryTimeout  = 5 * time.Minute
 	wishlistAlertRunningLockWindow = wishlistAlertDiscoveryTimeout
 )
@@ -71,10 +72,11 @@ type WishlistSearchAlertService struct {
 	agentProxy *AgentProxy
 	settings   *SettingsService
 	coinSvc    *CoinService
+	queue      chan uint
 }
 
 func NewWishlistSearchAlertService(repo *repository.WishlistSearchAlertRepository) *WishlistSearchAlertService {
-	return &WishlistSearchAlertService{repo: repo}
+	return &WishlistSearchAlertService{repo: repo, queue: make(chan uint, wishlistAlertRunQueueSize)}
 }
 
 func (s *WishlistSearchAlertService) WithDiscovery(agentProxy *AgentProxy, settings *SettingsService) *WishlistSearchAlertService {
@@ -86,6 +88,20 @@ func (s *WishlistSearchAlertService) WithDiscovery(agentProxy *AgentProxy, setti
 func (s *WishlistSearchAlertService) WithCoinCreation(coinSvc *CoinService) *WishlistSearchAlertService {
 	s.coinSvc = coinSvc
 	return s
+}
+
+func (s *WishlistSearchAlertService) StartWorkers(workerCount int) {
+	if workerCount < 1 {
+		workerCount = 1
+	}
+	if ids, err := s.repo.RecoverStaleAlertRuns(wishlistAlertDiscoveryTimeout); err == nil {
+		for _, id := range ids {
+			s.enqueueRunID(id)
+		}
+	}
+	for i := 0; i < workerCount; i++ {
+		go s.worker()
+	}
 }
 
 type RunAlertInput struct {
@@ -216,7 +232,7 @@ func (s *WishlistSearchAlertService) RunNow(alertID, userID uint, input RunAlert
 		AlertID:          alert.ID,
 		UserID:           userID,
 		TriggerType:      models.AlertRunTriggerManual,
-		Status:           models.AlertRunStatusRunning,
+		Status:           models.AlertRunStatusQueued,
 		StartedAt:        time.Now(),
 		CriteriaSnapshot: snapshot,
 		RateLimitStatus:  "ok",
@@ -228,52 +244,81 @@ func (s *WishlistSearchAlertService) RunNow(alertID, userID uint, input RunAlert
 	if !acquired {
 		return nil, ErrWishlistSearchAlertRunLimited
 	}
+	s.enqueueRunID(run.ID)
+	return runResult(run, nil), nil
+}
+
+func (s *WishlistSearchAlertService) enqueueRunID(runID uint) {
+	select {
+	case s.queue <- runID:
+	default:
+		go func() { s.queue <- runID }()
+	}
+}
+
+func (s *WishlistSearchAlertService) worker() {
+	for runID := range s.queue {
+		_ = s.ProcessRun(runID)
+	}
+}
+
+func (s *WishlistSearchAlertService) ProcessRun(runID uint) error {
+	run, claimed, err := s.repo.ClaimQueuedRun(runID)
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return nil
+	}
+	return s.processClaimedRun(run)
+}
+
+func (s *WishlistSearchAlertService) processClaimedRun(run *models.AlertRun) error {
+	alert, err := s.GetAlert(run.AlertID, run.UserID)
+	if err != nil {
+		_, failErr := s.failRun(run, "Search alert is unavailable.", err)
+		return failErr
+	}
 	if s.agentProxy == nil || s.settings == nil {
-		return s.failRun(run, "Discovery service is unavailable.", ErrWishlistSearchAlertAgent)
+		_, failErr := s.failRun(run, "Discovery service is unavailable.", ErrWishlistSearchAlertAgent)
+		return failErr
 	}
 	llmConfig, err := s.settings.ResolveLLMConfig()
 	if err != nil {
-		return s.failRun(run, "Discovery service is not configured.", ErrWishlistSearchAlertAgent)
+		_, failErr := s.failRun(run, "Discovery service is not configured.", ErrWishlistSearchAlertAgent)
+		return failErr
+	}
+	criteria, maxCandidates, err := alertDiscoveryCriteriaFromSnapshot(run.CriteriaSnapshot)
+	if err != nil {
+		_, failErr := s.failRun(run, "Unable to read alert criteria snapshot.", err)
+		return failErr
 	}
 	proxyReq := AlertDiscoveryProxyRequest{
 		LLM: llmConfig,
 		Alert: AlertDiscoveryRequestDetail{
-			AlertID: alert.ID,
-			CriteriaSnapshot: AlertDiscoveryCriteriaSnapshotProxy{
-				Name:             alert.Name,
-				RulerOrIssuer:    alert.RulerOrIssuer,
-				CoinType:         alert.CoinType,
-				DateFrom:         alert.DateFrom,
-				DateTo:           alert.DateTo,
-				Mint:             alert.Mint,
-				Material:         alert.Material,
-				GradeOrCondition: alert.GradeOrCondition,
-				PriceMin:         alert.PriceMin,
-				PriceMax:         alert.PriceMax,
-				Currency:         alert.Currency,
-				DealerPreference: alert.DealerPreference,
-				SourceFilters:    []string(alert.SourceFilters),
-				Keywords:         alert.Keywords,
-				Notes:            alert.Notes,
-			},
-			MaxCandidates: maxCandidates,
+			AlertID:          alert.ID,
+			CriteriaSnapshot: criteria,
+			MaxCandidates:    maxCandidates,
 		},
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), wishlistAlertDiscoveryTimeout)
 	resp, err := s.agentProxy.DiscoverAlertCandidates(ctx, proxyReq)
 	cancel()
 	if err != nil {
-		return s.failRun(run, "Discovery service is unavailable.", ErrWishlistSearchAlertAgent)
+		_, failErr := s.failRun(run, "Discovery service is unavailable.", ErrWishlistSearchAlertAgent)
+		return failErr
 	}
-	result, err := s.ingestCandidates(run, alert, resp)
+	_, err = s.ingestCandidates(run, alert, resp)
 	if err != nil {
-		return s.failRun(run, "Unable to save discovered candidates.", err)
+		_, failErr := s.failRun(run, "Unable to save discovered candidates.", err)
+		return failErr
 	}
 	alert.LastRunAt = &run.StartedAt
 	if err := s.repo.UpdateAlert(alert); err != nil {
-		return s.failRun(run, "Unable to save alert run metadata.", err)
+		_, failErr := s.failRun(run, "Unable to save alert run metadata.", err)
+		return failErr
 	}
-	return result, nil
+	return nil
 }
 
 func (s *WishlistSearchAlertService) failRun(run *models.AlertRun, message string, retErr error) (*AlertRunResult, error) {
@@ -541,6 +586,50 @@ func (s *WishlistSearchAlertService) CriteriaSnapshot(alert *models.WishlistSear
 	}
 	b, err := json.Marshal(snapshot)
 	return string(b), err
+}
+
+type alertRunCriteriaSnapshot struct {
+	Name             string   `json:"name"`
+	RulerOrIssuer    string   `json:"rulerOrIssuer"`
+	CoinType         string   `json:"coinType"`
+	DateFrom         *int     `json:"dateFrom"`
+	DateTo           *int     `json:"dateTo"`
+	Mint             string   `json:"mint"`
+	Material         string   `json:"material"`
+	GradeOrCondition string   `json:"gradeOrCondition"`
+	PriceMin         *float64 `json:"priceMin"`
+	PriceMax         *float64 `json:"priceMax"`
+	Currency         string   `json:"currency"`
+	DealerPreference string   `json:"dealerPreference"`
+	SourceFilters    []string `json:"sourceFilters"`
+	Keywords         string   `json:"keywords"`
+	Notes            string   `json:"notes"`
+	MaxCandidates    int      `json:"maxCandidates"`
+}
+
+func alertDiscoveryCriteriaFromSnapshot(snapshot string) (AlertDiscoveryCriteriaSnapshotProxy, int, error) {
+	var criteria alertRunCriteriaSnapshot
+	if err := json.Unmarshal([]byte(snapshot), &criteria); err != nil {
+		return AlertDiscoveryCriteriaSnapshotProxy{}, 0, err
+	}
+	maxCandidates := normalizeMaxCandidates(criteria.MaxCandidates)
+	return AlertDiscoveryCriteriaSnapshotProxy{
+		Name:             criteria.Name,
+		RulerOrIssuer:    criteria.RulerOrIssuer,
+		CoinType:         criteria.CoinType,
+		DateFrom:         criteria.DateFrom,
+		DateTo:           criteria.DateTo,
+		Mint:             criteria.Mint,
+		Material:         criteria.Material,
+		GradeOrCondition: criteria.GradeOrCondition,
+		PriceMin:         criteria.PriceMin,
+		PriceMax:         criteria.PriceMax,
+		Currency:         criteria.Currency,
+		DealerPreference: criteria.DealerPreference,
+		SourceFilters:    criteria.SourceFilters,
+		Keywords:         criteria.Keywords,
+		Notes:            criteria.Notes,
+	}, maxCandidates, nil
 }
 
 func buildAlertFromInput(userID uint, existing *models.WishlistSearchAlert, input WishlistSearchAlertInput) (*models.WishlistSearchAlert, error) {

--- a/src/api/services/wishlist_search_alert_service_test.go
+++ b/src/api/services/wishlist_search_alert_service_test.go
@@ -142,9 +142,19 @@ func TestWishlistSearchAlertService_RunNowPersistsCandidatesAndSuppressesDuplica
 	if err := db.Create(&savedCoin).Error; err != nil {
 		t.Fatalf("seed saved wishlist coin: %v", err)
 	}
-	first, err := svc.RunNow(alert.ID, 1, RunAlertInput{MaxCandidates: 20})
+	firstQueued, err := svc.RunNow(alert.ID, 1, RunAlertInput{MaxCandidates: 20})
 	if err != nil {
-		t.Fatalf("first run: %v", err)
+		t.Fatalf("queue first run: %v", err)
+	}
+	if firstQueued.Status != models.AlertRunStatusQueued || firstQueued.ResultCount != 0 {
+		t.Fatalf("first run should return queued before agent processing: %+v", firstQueued)
+	}
+	if err := svc.ProcessRun(firstQueued.RunID); err != nil {
+		t.Fatalf("process first run: %v", err)
+	}
+	first, err := svc.GetRun(alert.ID, firstQueued.RunID, 1)
+	if err != nil {
+		t.Fatalf("load first run: %v", err)
 	}
 	if first.Status != models.AlertRunStatusCompleted || first.NewCount != 1 || first.DuplicateCount != 0 {
 		t.Fatalf("unexpected first run: %+v", first)
@@ -159,15 +169,22 @@ func TestWishlistSearchAlertService_RunNowPersistsCandidatesAndSuppressesDuplica
 		t.Fatalf("first run did not preserve source-backed fields: %+v", first.Candidates[0].Fields)
 	}
 	var storedRun models.AlertRun
-	if err := db.First(&storedRun, first.RunID).Error; err != nil {
+	if err := db.First(&storedRun, firstQueued.RunID).Error; err != nil {
 		t.Fatalf("load stored run: %v", err)
 	}
 	if storedRun.CriteriaSnapshot == "" || storedRun.CompletedAt == nil {
 		t.Fatalf("run missing audit metadata: %+v", storedRun)
 	}
-	second, err := svc.RunNow(alert.ID, 1, RunAlertInput{MaxCandidates: 20})
+	secondQueued, err := svc.RunNow(alert.ID, 1, RunAlertInput{MaxCandidates: 20})
 	if err != nil {
-		t.Fatalf("second run: %v", err)
+		t.Fatalf("queue second run: %v", err)
+	}
+	if err := svc.ProcessRun(secondQueued.RunID); err != nil {
+		t.Fatalf("process second run: %v", err)
+	}
+	second, err := svc.GetRun(alert.ID, secondQueued.RunID, 1)
+	if err != nil {
+		t.Fatalf("load second run: %v", err)
 	}
 	if second.NewCount != 0 || second.DuplicateCount != 1 {
 		t.Fatalf("duplicate was not suppressed: %+v", second)
@@ -184,6 +201,29 @@ func TestWishlistSearchAlertService_RunNowPersistsCandidatesAndSuppressesDuplica
 	}
 	if after.ListingStatus != "available" || after.ListingCheckedAt != nil || after.ListingCheckReason != "seeded" {
 		t.Fatalf("alert run mutated listing status fields: %+v", after)
+	}
+}
+
+func TestWishlistSearchAlertService_RunNowEnqueuesWithoutWaitingForAgent(t *testing.T) {
+	agentCalled := false
+	svc, _, cleanup := setupWishlistSearchAlertDiscoveryService(t, func(w http.ResponseWriter, r *http.Request) {
+		agentCalled = true
+		t.Fatal("agent should not be called until a worker processes the queued run")
+	})
+	defer cleanup()
+	alert, err := svc.CreateAlert(1, validAlertInput())
+	if err != nil {
+		t.Fatalf("create alert: %v", err)
+	}
+	result, err := svc.RunNow(alert.ID, 1, RunAlertInput{})
+	if err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	if result.Status != models.AlertRunStatusQueued || result.CompletedAt != nil {
+		t.Fatalf("expected queued run response, got %+v", result)
+	}
+	if agentCalled {
+		t.Fatal("agent was called synchronously during RunNow")
 	}
 }
 

--- a/src/web/src/pages/WishlistAlertsPage.vue
+++ b/src/web/src/pages/WishlistAlertsPage.vue
@@ -118,7 +118,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { Search, Pencil, Trash2, Play } from 'lucide-vue-next'
 import AlertCriteriaSummary from '@/components/wishlist-alerts/AlertCriteriaSummary.vue'
 import AlertForm from '@/components/wishlist-alerts/AlertForm.vue'
@@ -164,6 +164,8 @@ const provenanceStatus = ref<CandidateProvenanceStatus | ''>('')
 const candidateBusyId = ref<number | null>(null)
 const duplicateWarnings = ref<Record<number, string[]>>({})
 const { isPwa } = usePwa()
+const RUN_POLL_INTERVAL_MS = 3000
+let runPollTimer: ReturnType<typeof setTimeout> | null = null
 
 const selectedAlert = computed(() => alerts.value.find((alert) => alert.id === selectedAlertId.value) ?? null)
 
@@ -193,6 +195,8 @@ function closeEditor() { creating.value = false; editing.value = null }
 function noop() {}
 
 function clearReviewState() {
+  clearRunPollTimer()
+  running.value = false
   selectedRun.value = null
   runs.value = []
   runsError.value = ''
@@ -208,6 +212,7 @@ function clearSelection() {
 }
 
 async function selectAlert(alert: WishlistSearchAlert) {
+  clearRunPollTimer()
   selectedAlertId.value = alert.id
   clearReviewState()
   await loadSelectedData()
@@ -250,15 +255,19 @@ async function runNow() {
   running.value = true
   runMessage.value = ''
   error.value = ''
+  let queued = false
   try {
+    const alertId = selectedAlert.value.id
     const res = await runWishlistSearchAlert(selectedAlert.value.id, 20)
-    runMessage.value = runResultMessage(res.data.status, res.data.resultCount, res.data.duplicateCount)
-    await Promise.all([load(), loadRuns(), loadCandidates()])
-    if (res.data.runId) await loadRunDetail(res.data.runId)
+    queued = true
+    runMessage.value = 'Search alert run queued. You can leave this page; results will appear in run history.'
+    await Promise.all([load(), loadRuns()])
+    if (res.data.runId) await pollAlertRun(alertId, res.data.runId)
   } catch (err) {
     error.value = getApiErrorMessage(err) || 'Search alert discovery failed. Try again later.'
-  } finally {
     running.value = false
+  } finally {
+    if (!queued) running.value = false
   }
 }
 
@@ -269,7 +278,13 @@ async function loadRuns() {
   try {
     const res = await listWishlistSearchAlertRuns(selectedAlertId.value, { page: 1, limit: 20 })
     runs.value = res.data.runs
-    if (!selectedRun.value && runs.value[0]) await loadRunDetail(runs.value[0].id)
+    if (!selectedRun.value && runs.value[0]) {
+      const run = await loadRunDetail(runs.value[0].id)
+      if (run && !isTerminalRunStatus(run.status)) {
+        running.value = true
+        scheduleRunPoll(run.alertId, run.id)
+      }
+    }
   } catch (err) {
     runsError.value = getApiErrorMessage(err) || 'Failed to load run history.'
   } finally {
@@ -278,9 +293,10 @@ async function loadRuns() {
 }
 
 async function loadRunDetail(runId: number) {
-  if (!selectedAlertId.value) return
+  if (!selectedAlertId.value) return null
   const res = await getWishlistSearchAlertRun(selectedAlertId.value, runId)
   selectedRun.value = res.data
+  return res.data
 }
 
 async function loadCandidates() {
@@ -374,13 +390,56 @@ function toInputCriteria(alert: WishlistSearchAlert): WishlistSearchAlertInput['
 }
 
 function runResultMessage(status: string, count: number, duplicates: number) {
+  if (status === 'queued' || status === 'running') return 'Run is still processing. Results will appear when discovery finishes.'
   if (status === 'failed') return 'Run failed with a stored, sanitized error. Review run history for details.'
   if (status === 'rate_limited') return 'Run was rate limited. Review run history before retrying.'
   if (count === 0) return 'Run completed with no candidates. Consider broadening criteria.'
   return `Run ${status.replace(/_/g, ' ')} with ${count} candidates and ${duplicates} duplicates.`
 }
 
+async function pollAlertRun(alertId: number, runId: number) {
+  if (selectedAlertId.value !== alertId) return
+  try {
+    const res = await getWishlistSearchAlertRun(alertId, runId)
+    selectedRun.value = res.data
+    if (isTerminalRunStatus(res.data.status)) {
+      await finishAlertRun(res.data)
+      return
+    }
+  } catch {
+    // Keep polling; transient network errors should not lose the backend-owned run.
+  }
+  scheduleRunPoll(alertId, runId)
+}
+
+function scheduleRunPoll(alertId: number, runId: number) {
+  clearRunPollTimer()
+  runPollTimer = setTimeout(() => {
+    void pollAlertRun(alertId, runId)
+  }, RUN_POLL_INTERVAL_MS)
+}
+
+async function finishAlertRun(run: AlertRun) {
+  clearRunPollTimer()
+  running.value = false
+  runMessage.value = runResultMessage(run.status, run.resultCount, run.duplicateCount)
+  await Promise.all([load(), loadRuns(), loadCandidates()])
+  await loadRunDetail(run.id)
+}
+
+function isTerminalRunStatus(status: AlertRun['status']) {
+  return ['completed', 'failed', 'partial', 'rate_limited', 'cancelled'].includes(status)
+}
+
+function clearRunPollTimer() {
+  if (runPollTimer) {
+    clearTimeout(runPollTimer)
+    runPollTimer = null
+  }
+}
+
 onMounted(load)
+onBeforeUnmount(clearRunPollTimer)
 </script>
 
 <style scoped>

--- a/src/web/src/pages/__tests__/WishlistAlertsPage.test.ts
+++ b/src/web/src/pages/__tests__/WishlistAlertsPage.test.ts
@@ -1,0 +1,135 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import WishlistAlertsPage from '../WishlistAlertsPage.vue'
+
+const mocks = vi.hoisted(() => ({
+  adjustWishlistSearchAlertCriteria: vi.fn(),
+  convertWishlistSearchAlertCandidate: vi.fn(),
+  createWishlistSearchAlert: vi.fn(),
+  deleteWishlistSearchAlert: vi.fn(),
+  dismissWishlistSearchAlertCandidate: vi.fn(),
+  getApiErrorMessage: vi.fn(() => ''),
+  getWishlistSearchAlertRun: vi.fn(),
+  listWishlistSearchAlertCandidates: vi.fn(),
+  listWishlistSearchAlertRuns: vi.fn(),
+  listWishlistSearchAlerts: vi.fn(),
+  restoreWishlistSearchAlertCandidate: vi.fn(),
+  runWishlistSearchAlert: vi.fn(),
+  updateWishlistSearchAlert: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => mocks)
+
+vi.mock('@/composables/usePwa', () => ({
+  usePwa: () => ({ isPwa: false }),
+}))
+
+const alert = {
+  id: 1,
+  userId: 1,
+  name: 'Domitian denarius',
+  rulerOrIssuer: 'Domitian',
+  coinType: 'Denarius',
+  dateFrom: null,
+  dateTo: null,
+  mint: '',
+  material: 'Silver',
+  gradeOrCondition: '',
+  priceMin: null,
+  priceMax: 300,
+  currency: 'USD',
+  dealerPreference: '',
+  sourceFilters: [],
+  keywords: '',
+  notes: '',
+  cadence: 'manual',
+  isActive: true,
+  lastRunAt: null,
+  createdAt: '',
+  updatedAt: '',
+}
+
+function alertRun(status: string) {
+  return {
+    id: 7,
+    alertId: 1,
+    userId: 1,
+    triggerType: 'manual',
+    status,
+    startedAt: '',
+    completedAt: status === 'completed' ? '2026-07-01T18:20:00Z' : null,
+    durationMs: 0,
+    criteriaSnapshot: '{}',
+    resultCount: status === 'completed' ? 2 : 0,
+    newCount: status === 'completed' ? 2 : 0,
+    duplicateCount: 0,
+    dismissedCount: 0,
+    partialWarnings: [],
+    errorMessage: '',
+    rateLimitStatus: 'ok',
+    createdAt: '',
+  }
+}
+
+describe('WishlistAlertsPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    mocks.listWishlistSearchAlerts.mockResolvedValue({ data: { alerts: [alert], total: 1, page: 1, limit: 100 } })
+    mocks.listWishlistSearchAlertRuns.mockResolvedValue({ data: { runs: [], total: 0, page: 1, limit: 20 } })
+    mocks.listWishlistSearchAlertCandidates.mockResolvedValue({ data: { candidates: [], total: 0, page: 1, limit: 50 } })
+    mocks.runWishlistSearchAlert.mockResolvedValue({
+      data: {
+        runId: 7,
+        alertId: 1,
+        status: 'queued',
+        startedAt: '',
+        completedAt: null,
+        resultCount: 0,
+        newCount: 0,
+        duplicateCount: 0,
+        dismissedCount: 0,
+        partialWarnings: [],
+        rateLimitStatus: 'ok',
+      },
+    })
+    mocks.getWishlistSearchAlertRun
+      .mockResolvedValueOnce({ data: alertRun('queued') })
+      .mockResolvedValueOnce({ data: alertRun('completed') })
+      .mockResolvedValue({ data: alertRun('completed') })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('queues Run Now and polls run detail until completion', async () => {
+    const wrapper = mount(WishlistAlertsPage, {
+      global: {
+        stubs: {
+          AlertCriteriaSummary: true,
+          AlertForm: true,
+          AlertRunHistory: true,
+          CandidateReviewCard: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    await wrapper.find('.select-alert').trigger('click')
+    await flushPromises()
+    await wrapper.find('.selected-summary .btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(mocks.runWishlistSearchAlert).toHaveBeenCalledWith(1, 20)
+    expect(mocks.getWishlistSearchAlertRun).toHaveBeenCalledWith(1, 7)
+    expect(wrapper.text()).toContain('Search alert run queued')
+
+    await vi.advanceTimersByTimeAsync(3000)
+    await flushPromises()
+
+    expect(mocks.getWishlistSearchAlertRun).toHaveBeenCalledTimes(3)
+    expect(wrapper.text()).toContain('Run completed with 2 candidates and 0 duplicates.')
+    expect(mocks.listWishlistSearchAlertCandidates).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Convert Wishlist Search Alerts Run Now into an AlertRun-backed async worker flow.
- Return 202 immediately, recover stale queued/running runs on startup, and block duplicate queued/running runs.
- Update the Wishlist Search Alerts UI to poll run detail until terminal status and refresh history/candidates.
- Regenerate OpenAPI docs for the Run Now 202 response contract.

## Validation
- go test ./... from src/api
- 
pm.cmd run type-check from src/web
- 
pm.cmd run test -- src/pages/__tests__/WishlistAlertsPage.test.ts src/pages/__tests__/WishlistPage.test.ts from src/web

## Constitution
- Principle IV: simple, complete, proportional async conversion for the long-running Run Now workflow.
- §17: backend/frontend regression coverage and OpenAPI regeneration completed.
