### PR TITLE
Beta

### DIFF
--- a/src/agent/app/teams/coin_search.py
+++ b/src/agent/app/teams/coin_search.py
@@ -66,6 +66,7 @@ Structure each listing into this exact JSON schema:
     "material": "Gold|Silver|Bronze|Copper|Other",
     "denomination": "e.g. Denarius, Tetradrachm",
     "estPrice": "Listed price e.g. $150.00",
+    "availability": "Available|Sold|Unknown based only on listing text",
     "imageUrl": "",
     "sourceUrl": "The exact URL from the listing data — never fabricate",
     "sourceName": "Dealer or site name",
@@ -86,6 +87,8 @@ Rules:
 - sourceUrl MUST be copied exactly from the data. NEVER fabricate URLs.
 - Set imageUrl to "" (the frontend handles images)
 - Infer category, era, ruler, material, denomination from the listing text
+- Exclude listings that are clearly sold, sold out, unavailable, or no longer available
+- Set availability from explicit listing text only; use "Unknown" when the listing does not say
 - Add candidateReferences only when a catalog reference appears in the listing text
 - candidateReferences items require catalog and number; volume and uri are optional
 - If you cannot determine a field, use an empty string
@@ -402,6 +405,7 @@ def _candidate_from_suggestion(item: dict) -> AlertDiscoveryCandidate | None:
         return None
     source_name = str(item.get("sourceName") or item.get("source_name") or "").strip()
     price_text = str(item.get("estPrice") or item.get("price") or "").strip()
+    availability = str(item.get("availability") or item.get("status") or "").strip()
     observed_price, observed_currency = _parse_price(price_text)
     now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
     provenance = [
@@ -436,6 +440,18 @@ def _candidate_from_suggestion(item: dict) -> AlertDiscoveryCandidate | None:
                 notes="Price text came from fetched listing data.",
             )
         )
+    if availability:
+        provenance.append(
+            AlertDiscoveryProvenance(
+                field="availability",
+                value=availability,
+                source_url=source_url,
+                observed_at=now,
+                confidence="high",
+                verification_state="verified",
+                notes="Availability text came from fetched listing data.",
+            )
+        )
     return AlertDiscoveryCandidate(
         source_url=source_url,
         source_name=source_name,
@@ -450,6 +466,7 @@ def _candidate_from_suggestion(item: dict) -> AlertDiscoveryCandidate | None:
             "denomination": str(item.get("denomination") or ""),
             "material": str(item.get("material") or ""),
             "grade_or_condition": str(item.get("grade") or ""),
+            "availability": availability,
         },
         provenance=provenance,
     )

--- a/src/agent/tests/test_alert_discovery_contract.py
+++ b/src/agent/tests/test_alert_discovery_contract.py
@@ -5,7 +5,12 @@ from pydantic import ValidationError
 
 from app.models.requests import MAX_ALERT_CANDIDATES, AlertDiscoveryRequest
 from app.models.responses import AlertDiscoveryCandidate, AlertDiscoveryProvenance
-from app.teams.coin_search import _filter_allowed_fetch_urls, _trusted_alert_fetch_hosts, _url_matches_allowed_hosts
+from app.teams.coin_search import (
+    _candidate_from_suggestion,
+    _filter_allowed_fetch_urls,
+    _trusted_alert_fetch_hosts,
+    _url_matches_allowed_hosts,
+)
 
 
 def valid_request_payload() -> dict:
@@ -103,3 +108,19 @@ def test_alert_discovery_empty_fetch_allowlist_blocks_all_urls():
     assert _filter_allowed_fetch_urls(urls, None) == urls
     assert _filter_allowed_fetch_urls(urls, set()) == []
     assert _filter_allowed_fetch_urls(urls, {"vcoins.com"}) == ["https://vcoins.com/item"]
+
+
+def test_alert_discovery_candidate_preserves_availability_text():
+    candidate = _candidate_from_suggestion(
+        {
+            "sourceUrl": "https://www.vcoins.com/sold-item",
+            "name": "Aspendos AR Stater",
+            "estPrice": "US$ 680.00",
+            "availability": "Sold",
+            "material": "Silver",
+        }
+    )
+
+    assert candidate is not None
+    assert candidate.fields["availability"] == "Sold"
+    assert any(item.field == "availability" and item.value == "Sold" for item in candidate.provenance)

--- a/src/api/services/wishlist_search_alert_service.go
+++ b/src/api/services/wishlist_search_alert_service.go
@@ -337,6 +337,10 @@ func (s *WishlistSearchAlertService) ingestCandidates(run *models.AlertRun, aler
 	if resp == nil {
 		resp = &AlertDiscoveryProxyResponse{}
 	}
+	criteria, _, err := alertDiscoveryCriteriaFromSnapshot(run.CriteriaSnapshot)
+	if err != nil {
+		return nil, fmt.Errorf("read alert criteria snapshot: %w", err)
+	}
 	candidates := resp.Candidates
 	if len(candidates) > AlertResultCapMax {
 		candidates = candidates[:AlertResultCapMax]
@@ -350,6 +354,11 @@ func (s *WishlistSearchAlertService) ingestCandidates(run *models.AlertRun, aler
 			continue
 		}
 		candidate, provenance := buildCandidateFromProxy(run, alert, proxyCandidate)
+		if reason := candidateReviewExclusionReason(candidate, provenance, criteria); reason != "" {
+			resp.Warnings = append(resp.Warnings, reason)
+			resp.Partial = true
+			continue
+		}
 		matched := s.matchExistingWishlist(alert.UserID, candidate.SourceURL, candidate.CanonicalSourceURL)
 		if matched != nil {
 			candidate.MatchingWishlistCoinID = &matched.ID
@@ -630,6 +639,48 @@ func alertDiscoveryCriteriaFromSnapshot(snapshot string) (AlertDiscoveryCriteria
 		Keywords:         criteria.Keywords,
 		Notes:            criteria.Notes,
 	}, maxCandidates, nil
+}
+
+func candidateReviewExclusionReason(candidate *models.AlertCandidate, provenance []models.CandidateProvenance, criteria AlertDiscoveryCriteriaSnapshotProxy) string {
+	if candidateHasSoldSignal(candidate, provenance) {
+		return "One result was omitted because the source listing appears to be sold or unavailable."
+	}
+	if criteria.PriceMin != nil || criteria.PriceMax != nil {
+		if candidate.ObservedPrice == nil {
+			return "One result was omitted because it did not include a source-backed price for the alert range."
+		}
+		if criteria.Currency != "" && candidate.ObservedCurrency != "" && !strings.EqualFold(candidate.ObservedCurrency, criteria.Currency) {
+			return "One result was omitted because its currency did not match the alert price range currency."
+		}
+		if criteria.PriceMin != nil && *candidate.ObservedPrice < *criteria.PriceMin {
+			return "One result was omitted because its price was below the alert minimum."
+		}
+		if criteria.PriceMax != nil && *candidate.ObservedPrice > *criteria.PriceMax {
+			return "One result was omitted because its price exceeded the alert maximum."
+		}
+	}
+	return ""
+}
+
+var soldSignalPattern = regexp.MustCompile(`\b(sold|sold out|unavailable|no longer available)\b`)
+
+func candidateHasSoldSignal(candidate *models.AlertCandidate, provenance []models.CandidateProvenance) bool {
+	values := []string{
+		candidate.Title,
+		candidate.ReasonForMatch,
+	}
+	for key, value := range candidate.Fields {
+		values = append(values, key, value)
+	}
+	for _, item := range provenance {
+		values = append(values, item.Field, item.Value, item.Notes)
+	}
+	for _, value := range values {
+		if soldSignalPattern.MatchString(strings.ToLower(value)) {
+			return true
+		}
+	}
+	return false
 }
 
 func buildAlertFromInput(userID uint, existing *models.WishlistSearchAlert, input WishlistSearchAlertInput) (*models.WishlistSearchAlert, error) {

--- a/src/api/services/wishlist_search_alert_service_test.go
+++ b/src/api/services/wishlist_search_alert_service_test.go
@@ -227,6 +227,105 @@ func TestWishlistSearchAlertService_RunNowEnqueuesWithoutWaitingForAgent(t *test
 	}
 }
 
+func TestWishlistSearchAlertService_RunNowFiltersSoldAndOutOfRangeCandidates(t *testing.T) {
+	agent := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"candidates":[
+				{
+					"source_url":"https://www.vcoins.com/valid",
+					"source_name":"VCoins",
+					"title":"Aspendos AR Stater",
+					"observed_price":225.0,
+					"observed_currency":"USD",
+					"reason_for_match":"Title and price match the alert.",
+					"last_seen_at":"2026-06-29T17:00:10Z",
+					"provenance_status":"verified",
+					"fields":{"material":"Silver"},
+					"provenance":[{"field":"observed_price","value":"US$ 225.00","source_url":"https://www.vcoins.com/valid","observed_at":"2026-06-29T17:00:10Z","confidence":"high","verification_state":"verified"}]
+				},
+				{
+					"source_url":"https://www.vcoins.com/sold",
+					"source_name":"VCoins",
+					"title":"Aspendos AR Stater",
+					"observed_price":225.0,
+					"observed_currency":"USD",
+					"reason_for_match":"Title and price match the alert.",
+					"last_seen_at":"2026-06-29T17:00:10Z",
+					"provenance_status":"verified",
+					"fields":{"availability":"Sold"},
+					"provenance":[{"field":"availability","value":"Sold","source_url":"https://www.vcoins.com/sold","observed_at":"2026-06-29T17:00:10Z","confidence":"high","verification_state":"verified"}]
+				},
+				{
+					"source_url":"https://www.vcoins.com/too-expensive",
+					"source_name":"VCoins",
+					"title":"Aspendos AR Stater",
+					"observed_price":680.0,
+					"observed_currency":"USD",
+					"reason_for_match":"Title matches the alert.",
+					"last_seen_at":"2026-06-29T17:00:10Z",
+					"provenance_status":"verified",
+					"fields":{"material":"Silver"},
+					"provenance":[{"field":"observed_price","value":"US$ 680.00","source_url":"https://www.vcoins.com/too-expensive","observed_at":"2026-06-29T17:00:10Z","confidence":"high","verification_state":"verified"}]
+				},
+				{
+					"source_url":"https://www.vcoins.com/too-cheap",
+					"source_name":"VCoins",
+					"title":"Aspendos AR Stater",
+					"observed_price":25.0,
+					"observed_currency":"USD",
+					"reason_for_match":"Title matches the alert.",
+					"last_seen_at":"2026-06-29T17:00:10Z",
+					"provenance_status":"verified",
+					"fields":{"material":"Silver"},
+					"provenance":[{"field":"observed_price","value":"US$ 25.00","source_url":"https://www.vcoins.com/too-cheap","observed_at":"2026-06-29T17:00:10Z","confidence":"high","verification_state":"verified"}]
+				},
+				{
+					"source_url":"https://www.vcoins.com/no-price",
+					"source_name":"VCoins",
+					"title":"Aspendos AR Stater",
+					"reason_for_match":"Title matches the alert.",
+					"last_seen_at":"2026-06-29T17:00:10Z",
+					"provenance_status":"verified",
+					"fields":{"material":"Silver"},
+					"provenance":[{"field":"source_url","value":"https://www.vcoins.com/no-price","source_url":"https://www.vcoins.com/no-price","observed_at":"2026-06-29T17:00:10Z","confidence":"high","verification_state":"verified"}]
+				}
+			],
+			"warnings":[],
+			"partial":false
+		}`))
+	}
+	svc, _, cleanup := setupWishlistSearchAlertDiscoveryService(t, agent)
+	defer cleanup()
+	input := validAlertInput()
+	input.Criteria.PriceMin = alertFloatPtr(50)
+	input.Criteria.PriceMax = alertFloatPtr(350)
+	alert, err := svc.CreateAlert(1, input)
+	if err != nil {
+		t.Fatalf("create alert: %v", err)
+	}
+	queued, err := svc.RunNow(alert.ID, 1, RunAlertInput{MaxCandidates: 20})
+	if err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	if err := svc.ProcessRun(queued.RunID); err != nil {
+		t.Fatalf("process run: %v", err)
+	}
+	run, err := svc.GetRun(alert.ID, queued.RunID, 1)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if run.Status != models.AlertRunStatusPartial || run.NewCount != 1 || run.ResultCount != 1 {
+		t.Fatalf("expected only the valid candidate to persist as partial run, got %+v", run)
+	}
+	if len(run.Candidates) != 1 || run.Candidates[0].SourceURL != "https://www.vcoins.com/valid" {
+		t.Fatalf("unexpected persisted candidates: %+v", run.Candidates)
+	}
+	if len(run.PartialWarnings) != 4 {
+		t.Fatalf("expected four omission warnings, got %+v", run.PartialWarnings)
+	}
+}
+
 func TestWishlistSearchAlertService_RunNowRejectsDisabledAndRunningAlert(t *testing.T) {
 	svc, db, cleanup := setupWishlistSearchAlertDiscoveryService(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("agent should not be called")

--- a/src/web/src/components/wishlist-alerts/CandidateReviewCard.vue
+++ b/src/web/src/components/wishlist-alerts/CandidateReviewCard.vue
@@ -69,7 +69,11 @@
             <label>Material <input v-model.trim="coin.material" /></label>
             <label>Grade <input v-model.trim="coin.grade" /></label>
             <label>Price <input v-model.number="coin.purchasePrice" type="number" min="0" step="0.01" /></label>
-            <label>Source <input v-model.trim="coin.referenceUrl" /></label>
+            <div class="convert-source">
+              <span>Source</span>
+              <SafeExternalLink v-if="coin.referenceUrl" :href="coin.referenceUrl" class="source-link">{{ coin.referenceUrl }}</SafeExternalLink>
+              <span v-else class="muted">No source URL provided</span>
+            </div>
           </div>
           <p class="muted">Review missing or uncertain fields before saving. Only source-backed candidate fields are prefilled.</p>
           <p v-if="convertError" class="error-text">{{ convertError }}</p>
@@ -188,7 +192,8 @@ h3 { margin: 0.15rem 0 0; }
 .review-actions { border-top: 1px solid var(--border-subtle); padding-top: 0.75rem; display: grid; gap: 0.75rem; }
 select, input { border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); padding: 0.5rem; background: var(--bg-input); color: var(--text-primary); }
 .convert-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 0.75rem; margin-top: 0.75rem; }
-.convert-grid label { display: grid; gap: 0.25rem; color: var(--text-secondary); }
+.convert-grid label, .convert-source { display: grid; gap: 0.25rem; color: var(--text-secondary); }
+.convert-source a { overflow-wrap: anywhere; }
 .ack { display: flex; gap: 0.5rem; align-items: center; color: var(--text-secondary); margin-top: 0.75rem; }
 .error-text { color: var(--accent-bronze); margin: 0.75rem 0 0; }
 @media (max-width: 640px) { .candidate-header { flex-direction: column; } .dismiss-controls { align-items: stretch; } .dismiss-controls > * { width: 100%; } }

--- a/src/web/src/components/wishlist-alerts/__tests__/CandidateReviewCard.test.ts
+++ b/src/web/src/components/wishlist-alerts/__tests__/CandidateReviewCard.test.ts
@@ -1,0 +1,65 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import type { AlertCandidate } from '@/types'
+import CandidateReviewCard from '../CandidateReviewCard.vue'
+
+function candidate(overrides: Partial<AlertCandidate> = {}): AlertCandidate {
+  return {
+    id: 7,
+    userId: 1,
+    alertId: 2,
+    runId: 3,
+    sourceUrl: 'https://www.vcoins.com/en/stores/example/123',
+    canonicalSourceUrl: 'https://www.vcoins.com/en/stores/example/123',
+    sourceName: 'VCoins',
+    title: 'Pamphylia, Aspendos AR Stater',
+    observedPrice: 680,
+    observedCurrency: 'USD',
+    reasonForMatch: 'Matches the alert criteria.',
+    fields: {
+      material: 'Silver',
+      denomination: 'Stater',
+      category: 'Greek',
+      era: 'Ancient',
+    },
+    lastSeenAt: '2026-07-01T18:00:00Z',
+    firstSeenAt: '2026-07-01T18:00:00Z',
+    provenanceStatus: 'verified',
+    lifecycleState: 'active',
+    duplicateKey: 'duplicate-key',
+    duplicateOfCandidateId: null,
+    matchingWishlistCoinId: null,
+    convertedCoinId: null,
+    dismissalReason: '',
+    provenance: [],
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  }
+}
+
+describe('CandidateReviewCard', () => {
+  it('renders the conversion source as an external link while preserving the conversion payload URL', async () => {
+    const wrapper = mount(CandidateReviewCard, {
+      props: {
+        candidate: candidate(),
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    expect(wrapper.find('.convert-source input').exists()).toBe(false)
+
+    const sourceLink = wrapper.find('.convert-source a')
+    expect(sourceLink.exists()).toBe(true)
+    expect(sourceLink.attributes('href')).toBe('https://www.vcoins.com/en/stores/example/123')
+    expect(sourceLink.attributes('target')).toBe('_blank')
+
+    await wrapper.find('.actions-row .btn-primary').trigger('click')
+    const emitted = wrapper.emitted('convert')?.[0]
+    expect(emitted?.[1]).toMatchObject({ referenceUrl: 'https://www.vcoins.com/en/stores/example/123' })
+  })
+})


### PR DESCRIPTION
## Summary
<!-- 1-3 sentences: what changes and why -->

## Constitution self-check
- Principle(s) touched: <!-- e.g., I (Clear Layered Architecture), IV (Simple Complete Changes) -->
- Operational section(s): <!-- e.g., §17 Quality Gate, §21 DoD -->
- ADR added? <!-- yes/no — required for material design choices, §22 -->
- Principle IV check: <!-- simple, complete, proportional; note workflow/sibling paths tested -->
- Workflow contract(s): <!-- user workflow(s), API/UI/config contracts touched -->
- Blast radius / sibling workflows checked: <!-- e.g., Add Coin, Edit Coin, Admin settings, wishlist -->

## Linked work
- Issue: #
- Spec: `specs/NNN-*/spec.md`
- Tasks completed: <!-- specs/NNN-*/tasks.md line(s) -->

## Definition of Done (§21)
- [ ] 1. Code compiles (`go build ./...`, `npm run build`, `pip install -e ".[dev]"` as applicable)
- [ ] 2. Architecture tests green (`go test -run TestArchitecture ./...`)
- [ ] 3. Unit tests pass (`go test ./...`, `pytest tests/`)
- [ ] 4. Type checks pass (`vue-tsc --build`, Go compile)
- [ ] 5. Linters clean (`go vet`, `ruff check`)
- [ ] 6. Bug fixes include a targeted regression test for the exact failing user path, or document why automation is deferred
- [ ] 7. Shared workflow/config/API contract changes list blast radius and sibling workflows checked
- [ ] 8. User/admin-configured UI values are accepted by every API path the UI can submit them to, or blocked with a clear UI message
- [ ] 9. New service methods have ≥1 unit test
- [ ] 10. Public handlers have Swagger annotations
- [ ] 11. If API changed: `task openapi` run and `docs/openapi.json` updated
- [ ] 12. If material design choice: ADR added in `docs/adr/` *(when Phase 3 lands)*
- [ ] 13. Active `specs/NNN-*/tasks.md` items checked off
- [ ] 14. `.squad/decisions/inbox/` written if cross-cutting decision made
- [ ] 15. Simple Complete Changes self-check complete (Principle IV)
- [ ] 15a. If touched oversized module (see [#314](https://github.com/briandenicola/coin-collection-app/issues/314)): extraction seams reviewed + regression tests maintained
- [ ] 16. Secrets scan clean (no credentials in diff)
- [ ] 17. Conventional commit messages
- [ ] 18. `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer present when AI-assisted

## Notes for reviewer
<!-- Anything reviewer should pay special attention to -->
