### PR TITLE
feat: add auction watch bid digest

### DIFF
--- a/src/api/handlers/auction_lots.go
+++ b/src/api/handlers/auction_lots.go
@@ -913,7 +913,7 @@ func firstNonEmpty(values ...string) string {
 }
 
 func (h *AuctionLotHandler) decryptStoredCredential(userID uint, field string, stored string) (plain string, shouldMigrate bool, err error) {
-	plain, wasEncrypted, err := h.credentials.DecryptStringWithAAD(stored, auctionCredentialAAD(userID, field))
+	plain, wasEncrypted, err := h.credentials.DecryptStringWithAAD(stored, services.AuctionCredentialAAD(userID, field))
 	if err != nil {
 		return "", false, err
 	}
@@ -921,7 +921,7 @@ func (h *AuctionLotHandler) decryptStoredCredential(userID uint, field string, s
 }
 
 func (h *AuctionLotHandler) migrateStoredCredential(user *models.User, field string, plain string) {
-	encrypted, err := h.credentials.EncryptStringWithAAD(plain, auctionCredentialAAD(user.ID, field))
+	encrypted, err := h.credentials.EncryptStringWithAAD(plain, services.AuctionCredentialAAD(user.ID, field))
 	if err != nil {
 		h.warn("Failed to encrypt legacy auction credential for user %d: %v", user.ID, err)
 		return

--- a/src/api/handlers/credential_encryption_test.go
+++ b/src/api/handlers/credential_encryption_test.go
@@ -94,7 +94,7 @@ func TestAuctionLotHandlerLazyMigratesLegacyAuctionCredentials(t *testing.T) {
 	if stored.NumisBidsPassword == "legacy-nb" || !strings.HasPrefix(stored.NumisBidsPassword, "enc:v1:") {
 		t.Fatalf("legacy NumisBids credential was not migrated: %q", stored.NumisBidsPassword)
 	}
-	decrypted, wasEncrypted, err := credentialSvc.DecryptStringWithAAD(stored.NumisBidsPassword, auctionCredentialAAD(user.ID, "numis_bids_password"))
+	decrypted, wasEncrypted, err := credentialSvc.DecryptStringWithAAD(stored.NumisBidsPassword, services.AuctionCredentialAAD(user.ID, "numis_bids_password"))
 	if err != nil {
 		t.Fatalf("decrypt migrated credential: %v", err)
 	}

--- a/src/api/handlers/user.go
+++ b/src/api/handlers/user.go
@@ -293,7 +293,7 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 		updates["numis_bids_username"] = strings.TrimSpace(*req.NumisBidsUsername)
 	}
 	if req.NumisBidsPassword != nil {
-		encrypted, err := h.credentials.EncryptStringWithAAD(*req.NumisBidsPassword, auctionCredentialAAD(user.ID, "numis_bids_password"))
+		encrypted, err := h.credentials.EncryptStringWithAAD(*req.NumisBidsPassword, services.AuctionCredentialAAD(user.ID, "numis_bids_password"))
 		if err != nil {
 			respondError(c, http.StatusInternalServerError, "Failed to protect NumisBids credentials", err)
 			return
@@ -304,7 +304,7 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 		updates["cng_username"] = strings.TrimSpace(*req.CNGUsername)
 	}
 	if req.CNGPassword != nil {
-		encrypted, err := h.credentials.EncryptStringWithAAD(*req.CNGPassword, auctionCredentialAAD(user.ID, "cng_password"))
+		encrypted, err := h.credentials.EncryptStringWithAAD(*req.CNGPassword, services.AuctionCredentialAAD(user.ID, "cng_password"))
 		if err != nil {
 			respondError(c, http.StatusInternalServerError, "Failed to protect CNG credentials", err)
 			return
@@ -361,10 +361,6 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 		"pushoverEnabled":     user.PushoverEnabled,
 		"coinOfDayEnabled":    user.CoinOfDayEnabled,
 	})
-}
-
-func auctionCredentialAAD(userID uint, field string) []byte {
-	return []byte(fmt.Sprintf("auction-credential:%d:%s", userID, field))
 }
 
 // UploadAvatar uploads a profile avatar image for the authenticated user.

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -205,7 +205,10 @@ func main() {
 	// Create schedulers before routes so they can be passed to admin handlers
 	availScheduler := services.NewAvailabilityScheduler(availSvc, coinRepo, availRepo, settingsSvc, logger)
 	valScheduler := services.NewValuationScheduler(valSvc, coinRepo, valRepo, settingsSvc, logger)
-	auctionEndingScheduler := services.NewAuctionEndingScheduler(auctionLotRepo, auctionEndingRepo, userRepoForVal, pushoverSvc, settingsSvc, logger)
+	nbWatchSyncSvc := services.NewNumisBidsService(logger)
+	cngWatchSyncSvc := services.NewCNGAuctionService(logger)
+	auctionWatchlistSyncSvc := services.NewAuctionWatchlistSyncService(auctionLotRepo, userRepoForVal, nbWatchSyncSvc, cngWatchSyncSvc, credentialEncryptionSvc, logger)
+	auctionEndingScheduler := services.NewAuctionEndingScheduler(auctionLotRepo, auctionEndingRepo, userRepoForVal, pushoverSvc, settingsSvc, logger).WithWatchlistSync(auctionWatchlistSyncSvc)
 	healthScheduler := services.NewCollectionHealthScheduler(healthSvc, settingsSvc, logger)
 	featuredCoinRepo := repository.NewFeaturedCoinRepository(database.DB)
 	coinOfDayScheduler := services.NewCoinOfDayScheduler(featuredCoinRepo, userRepoForVal, coinRepo, notifSvc, settingsSvc, logger)

--- a/src/api/repository/auction_lot_repository.go
+++ b/src/api/repository/auction_lot_repository.go
@@ -388,6 +388,28 @@ func (r *AuctionLotRepository) GetEndingSoon() ([]models.AuctionLot, error) {
 	return lots, err
 }
 
+// GetActiveWatchBidDigestLots returns watched or bidding lots that have not reached their known auction end date.
+func (r *AuctionLotRepository) GetActiveWatchBidDigestLots() ([]models.AuctionLot, error) {
+	var lots []models.AuctionLot
+	now := time.Now()
+	statuses := []string{
+		string(models.AuctionStatusWatching),
+		string(models.AuctionStatusBidding),
+	}
+
+	err := r.db.Where("LOWER(status) IN ? AND ("+
+		"(auction_end_time IS NOT NULL AND auction_end_time > ?) OR "+
+		"(auction_end_time IS NULL AND sale_date IS NOT NULL AND sale_date > ?)"+
+		")",
+		statuses,
+		now, now).
+		Order("user_id ASC").
+		Order("COALESCE(auction_end_time, sale_date) ASC").
+		Order("lot_number ASC").
+		Find(&lots).Error
+	return lots, err
+}
+
 // AuctionLotDebugInfo holds enriched lot data for debugging date/status issues.
 type AuctionLotDebugInfo struct {
 	ID             uint       `json:"id"`

--- a/src/api/repository/auction_lot_repository_test.go
+++ b/src/api/repository/auction_lot_repository_test.go
@@ -265,6 +265,86 @@ func TestAuctionLotRepository_GetEndingSoon_MultipleUsers(t *testing.T) {
 	}
 }
 
+func TestAuctionLotRepository_GetActiveWatchBidDigestLots(t *testing.T) {
+	db := setupAuctionTestDB(t)
+	repo := NewAuctionLotRepository(db)
+
+	now := time.Now()
+	in12Hours := now.Add(12 * time.Hour)
+	in48Hours := now.Add(48 * time.Hour)
+	ended := now.Add(-1 * time.Hour)
+	bid := 300.0
+
+	lots := []models.AuctionLot{
+		{
+			NumisBidsURL: "https://example.com/watching-future",
+			Title:        "Watching Future",
+			Status:       models.AuctionStatusWatching,
+			SaleDate:     &in12Hours,
+			CurrentBid:   &bid,
+			LotNumber:    1,
+			UserID:       1,
+		},
+		{
+			NumisBidsURL:   "https://example.com/bidding-future",
+			Title:          "Bidding Future",
+			Status:         models.AuctionStatusBidding,
+			AuctionEndTime: &in48Hours,
+			CurrentBid:     &bid,
+			LotNumber:      2,
+			UserID:         1,
+		},
+		{
+			NumisBidsURL: "https://example.com/ended",
+			Title:        "Ended",
+			Status:       models.AuctionStatusWatching,
+			SaleDate:     &ended,
+			CurrentBid:   &bid,
+			LotNumber:    3,
+			UserID:       1,
+		},
+		{
+			NumisBidsURL: "https://example.com/passed",
+			Title:        "Passed",
+			Status:       models.AuctionStatusPassed,
+			SaleDate:     &in12Hours,
+			CurrentBid:   &bid,
+			LotNumber:    4,
+			UserID:       1,
+		},
+		{
+			NumisBidsURL: "https://example.com/no-date",
+			Title:        "No Date",
+			Status:       models.AuctionStatusWatching,
+			CurrentBid:   &bid,
+			LotNumber:    5,
+			UserID:       1,
+		},
+	}
+	for i := range lots {
+		if err := repo.Create(&lots[i]); err != nil {
+			t.Fatalf("create lot %d: %v", i, err)
+		}
+	}
+
+	got, err := repo.GetActiveWatchBidDigestLots()
+	if err != nil {
+		t.Fatalf("GetActiveWatchBidDigestLots: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d lots, want 2: %#v", len(got), got)
+	}
+	found := map[string]bool{}
+	for _, lot := range got {
+		found[lot.NumisBidsURL] = true
+	}
+	for _, url := range []string{"https://example.com/watching-future", "https://example.com/bidding-future"} {
+		if !found[url] {
+			t.Fatalf("expected active digest lot %s", url)
+		}
+	}
+}
+
 func TestAuctionLotRepository_CountAllAndCountAllByStatus(t *testing.T) {
 	db := setupAuctionTestDB(t)
 	repo := NewAuctionLotRepository(db)
@@ -379,6 +459,40 @@ func TestAuctionLotRepository_UpsertUsesSourceURL(t *testing.T) {
 	}
 	if found.Title != "CNG Lot Updated" {
 		t.Fatalf("CNG title = %q, want updated title", found.Title)
+	}
+}
+
+func TestAuctionLotRepository_UpsertRefreshesCurrentBid(t *testing.T) {
+	db := setupAuctionTestDB(t)
+	repo := NewAuctionLotRepository(db)
+
+	originalBid := 125.0
+	lot := &models.AuctionLot{
+		NumisBidsURL: "https://example.com/bid-refresh",
+		Source:       models.AuctionSourceNumisBids,
+		SourceURL:    "https://example.com/bid-refresh",
+		Title:        "Tracked Lot",
+		Status:       models.AuctionStatusWatching,
+		CurrentBid:   &originalBid,
+		LotNumber:    30,
+		UserID:       1,
+	}
+	if _, err := repo.Upsert(lot); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+
+	refreshedBid := 300.0
+	lot.CurrentBid = &refreshedBid
+	if _, err := repo.Upsert(lot); err != nil {
+		t.Fatalf("refresh upsert: %v", err)
+	}
+
+	found, err := repo.GetBySourceURL(models.AuctionSourceNumisBids, lot.SourceURL, 1)
+	if err != nil {
+		t.Fatalf("GetBySourceURL: %v", err)
+	}
+	if found.CurrentBid == nil || *found.CurrentBid != refreshedBid {
+		t.Fatalf("CurrentBid = %v, want %v", found.CurrentBid, refreshedBid)
 	}
 }
 

--- a/src/api/repository/user_repository.go
+++ b/src/api/repository/user_repository.go
@@ -81,3 +81,13 @@ func (r *UserRepository) ListCoinOfDayEnabled() ([]models.User, error) {
 	err := r.db.Where("coin_of_day_enabled = ?", true).Find(&users).Error
 	return users, err
 }
+
+// ListAuctionWatchDigestEligible returns users who can receive scheduled auction watch bid digests.
+func (r *UserRepository) ListAuctionWatchDigestEligible() ([]models.User, error) {
+	var users []models.User
+	err := r.db.
+		Where("pushover_enabled = ? AND pushover_user_key <> ''", true).
+		Where("(numis_bids_username <> '' AND numis_bids_password <> '') OR (cng_username <> '' AND cng_password <> '')").
+		Find(&users).Error
+	return users, err
+}

--- a/src/api/services/auction_ending_scheduler.go
+++ b/src/api/services/auction_ending_scheduler.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,6 +17,7 @@ type AuctionEndingScheduler struct {
 	auctionEndingRepo *repository.AuctionEndingRepository
 	userRepo          *repository.UserRepository
 	pushoverSvc       *PushoverService
+	watchlistSyncSvc  *AuctionWatchlistSyncService
 	settingsSvc       *SettingsService
 	logger            *Logger
 	stopCh            chan struct{}
@@ -45,6 +47,12 @@ func NewAuctionEndingScheduler(
 		stopCh:            make(chan struct{}),
 		lastNotified:      make(map[uint]string),
 	}
+}
+
+// WithWatchlistSync refreshes stored watchlist lots before each digest cycle.
+func (s *AuctionEndingScheduler) WithWatchlistSync(syncSvc *AuctionWatchlistSyncService) *AuctionEndingScheduler {
+	s.watchlistSyncSvc = syncSvc
+	return s
 }
 
 // Start begins the periodic check loop. Call from a goroutine.
@@ -194,10 +202,15 @@ func (s *AuctionEndingScheduler) runCycleWithTrigger(triggerType string, trigger
 		return nil, err
 	}
 
-	// Execute the check
-	lots, err := s.auctionRepo.GetEndingSoon()
+	if s.watchlistSyncSvc != nil {
+		stats := s.watchlistSyncSvc.SyncDigestEligibleUsers()
+		s.logger.Info("scheduler", "Auction watchlist sync complete — %d users checked, %d lots synced, %d errors", stats.UsersChecked, stats.LotsSynced, stats.Errors)
+	}
+
+	// Execute the digest from active watched lots after refreshing provider data.
+	lots, err := s.auctionRepo.GetActiveWatchBidDigestLots()
 	if err != nil {
-		s.logger.Error("scheduler", "Failed to fetch auction lots ending soon: %s", err)
+		s.logger.Error("scheduler", "Failed to fetch active auction watch lots: %s", err)
 		now := time.Now()
 		run.Status = "error"
 		run.ErrorMessage = fmt.Sprintf("Failed to fetch lots: %v", err)
@@ -210,7 +223,7 @@ func (s *AuctionEndingScheduler) runCycleWithTrigger(triggerType string, trigger
 	run.LotsChecked = len(lots)
 
 	if len(lots) == 0 {
-		s.logger.Info("scheduler", "No auction lots ending soon")
+		s.logger.Info("scheduler", "No active auction watch lots")
 		now := time.Now()
 		run.Status = "success"
 		run.CompletedAt = &now
@@ -225,7 +238,7 @@ func (s *AuctionEndingScheduler) runCycleWithTrigger(triggerType string, trigger
 		userLots[lot.UserID] = append(userLots[lot.UserID], lot)
 	}
 
-	s.logger.Info("scheduler", "Found %d lots ending soon across %d users", len(lots), len(userLots))
+	s.logger.Info("scheduler", "Found %d active auction watch lots across %d users", len(lots), len(userLots))
 
 	today := time.Now().Format("2006-01-02")
 	alertsSent := 0
@@ -253,7 +266,7 @@ func (s *AuctionEndingScheduler) runCycleWithTrigger(triggerType string, trigger
 
 	run.AlertsSent = alertsSent
 
-	s.logger.Info("scheduler", "%s auction ending check cycle complete — %d lots checked, %d alerts sent", triggerType, run.LotsChecked, run.AlertsSent)
+	s.logger.Info("scheduler", "%s auction watch bid digest cycle complete — %d lots checked, %d alerts sent", triggerType, run.LotsChecked, run.AlertsSent)
 
 	now := time.Now()
 	run.Status = "success"
@@ -264,7 +277,7 @@ func (s *AuctionEndingScheduler) runCycleWithTrigger(triggerType string, trigger
 	return run, nil
 }
 
-// notifyUser sends a consolidated Pushover notification to one user for their ending auctions.
+// notifyUser sends a consolidated Pushover notification to one user for their active watched auctions.
 // Returns true if a notification was sent, false otherwise.
 func (s *AuctionEndingScheduler) notifyUser(userID uint, lots []models.AuctionLot) bool {
 	user, err := s.userRepo.FindByID(userID)
@@ -278,9 +291,9 @@ func (s *AuctionEndingScheduler) notifyUser(userID uint, lots []models.AuctionLo
 		return false
 	}
 
-	// Build consolidated message
-	title := "Auctions Ending Soon"
-	message := fmt.Sprintf("%d auction(s) you are bidding on end within 24 hours:\n\n", len(lots))
+	title := "Auction Watch Bid Digest"
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("%d watched auction lot(s):\n\n", len(lots)))
 
 	for _, lot := range lots {
 		auctionHouse := lot.AuctionHouse
@@ -291,16 +304,28 @@ func (s *AuctionEndingScheduler) notifyUser(userID uint, lots []models.AuctionLo
 		if saleName == "" {
 			saleName = "Sale"
 		}
-		message += fmt.Sprintf("• %s - %s (Lot %d)\n", auctionHouse, saleName, lot.LotNumber)
+		builder.WriteString(fmt.Sprintf("- %s - %s (Lot %d): %s\n", auctionHouse, saleName, lot.LotNumber, formatAuctionBid(lot.CurrentBid, lot.Currency)))
 	}
+	message := builder.String()
 
 	// Send notification
 	sent := false
 	if err := s.pushoverSvc.SendNotification(user.PushoverUserKey, title, message, ""); err != nil {
 		s.logger.Error("pushover", "Failed to send auction ending notification to user %d: %v", userID, err)
 	} else {
-		s.logger.Info("scheduler", "Notified user %d of %d ending auctions", userID, len(lots))
+		s.logger.Info("scheduler", "Notified user %d of %d watched auction bids", userID, len(lots))
 		sent = true
 	}
 	return sent
+}
+
+func formatAuctionBid(bid *float64, currency string) string {
+	if bid == nil {
+		return "current high bid unavailable"
+	}
+	currency = strings.TrimSpace(currency)
+	if currency == "" {
+		currency = "USD"
+	}
+	return fmt.Sprintf("current high bid %.2f %s", *bid, currency)
 }

--- a/src/api/services/auction_ending_scheduler_test.go
+++ b/src/api/services/auction_ending_scheduler_test.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,5 +108,67 @@ func TestAuctionEndingTimeUntilNextRun_IgnoresManualRuns(t *testing.T) {
 	wait := s.timeUntilNextRun()
 	if wait < 1*time.Hour+55*time.Minute || wait > 2*time.Hour+5*time.Minute {
 		t.Fatalf("expected ~2h wait when only manual runs exist, got %v", wait)
+	}
+}
+
+func TestAuctionEndingNotifyUserIncludesCurrentHighBids(t *testing.T) {
+	db := setupAuctionEndingSchedulerDB(t)
+	if err := db.AutoMigrate(&models.User{}); err != nil {
+		t.Fatalf("failed to migrate users: %v", err)
+	}
+
+	user := models.User{
+		Username:        "bidder",
+		Email:           "bidder@example.com",
+		PasswordHash:    "hash",
+		PushoverEnabled: true,
+		PushoverUserKey: "user-key",
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	var captured url.Values
+	pushoverSvc, cleanup := newTestPushoverService(t, &captured)
+	defer cleanup()
+
+	settingsSvc := NewSettingsService(repository.NewSettingsRepository(db))
+	scheduler := NewAuctionEndingScheduler(
+		nil,
+		repository.NewAuctionEndingRepository(db),
+		repository.NewUserRepository(db),
+		pushoverSvc,
+		settingsSvc,
+		NewLogger(100),
+	)
+
+	bidOne := 125.5
+	bidTwo := 300.0
+	sent := scheduler.notifyUser(user.ID, []models.AuctionLot{
+		{AuctionHouse: "The Coin Cabinet", SaleName: "Ancients Auction 35", LotNumber: 30, CurrentBid: &bidOne, Currency: "GBP"},
+		{AuctionHouse: "Classical Numismatic Group", SaleName: "Keystone 17", LotNumber: 95, CurrentBid: &bidTwo, Currency: "USD"},
+	})
+	if !sent {
+		t.Fatal("notifyUser returned false")
+	}
+
+	if got := captured.Get("title"); got != "Auction Watch Bid Digest" {
+		t.Fatalf("title = %q, want Auction Watch Bid Digest", got)
+	}
+	message := captured.Get("message")
+	for _, want := range []string{
+		"2 watched auction lot(s):",
+		"The Coin Cabinet - Ancients Auction 35 (Lot 30): current high bid 125.50 GBP",
+		"Classical Numismatic Group - Keystone 17 (Lot 95): current high bid 300.00 USD",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("message %q missing %q", message, want)
+		}
+	}
+}
+
+func TestFormatAuctionBidHandlesMissingBid(t *testing.T) {
+	if got := formatAuctionBid(nil, "USD"); got != "current high bid unavailable" {
+		t.Fatalf("formatAuctionBid(nil) = %q", got)
 	}
 }

--- a/src/api/services/auction_watchlist_sync_service.go
+++ b/src/api/services/auction_watchlist_sync_service.go
@@ -1,0 +1,251 @@
+package services
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/briandenicola/ancient-coins-api/models"
+	"github.com/briandenicola/ancient-coins-api/repository"
+)
+
+type AuctionWatchlistSyncStats struct {
+	UsersChecked int
+	LotsSynced   int
+	Errors       int
+}
+
+type AuctionWatchlistSyncService struct {
+	auctionRepo *repository.AuctionLotRepository
+	userRepo    *repository.UserRepository
+	nbSvc       *NumisBidsService
+	cngSvc      *CNGAuctionService
+	credentials *CredentialEncryptionService
+	logger      *Logger
+}
+
+func NewAuctionWatchlistSyncService(
+	auctionRepo *repository.AuctionLotRepository,
+	userRepo *repository.UserRepository,
+	nbSvc *NumisBidsService,
+	cngSvc *CNGAuctionService,
+	credentials *CredentialEncryptionService,
+	logger *Logger,
+) *AuctionWatchlistSyncService {
+	if credentials == nil {
+		credentials = NewDisabledCredentialEncryptionService()
+	}
+	return &AuctionWatchlistSyncService{
+		auctionRepo: auctionRepo,
+		userRepo:    userRepo,
+		nbSvc:       nbSvc,
+		cngSvc:      cngSvc,
+		credentials: credentials,
+		logger:      logger,
+	}
+}
+
+func (s *AuctionWatchlistSyncService) SyncDigestEligibleUsers() AuctionWatchlistSyncStats {
+	stats := AuctionWatchlistSyncStats{}
+	users, err := s.userRepo.ListAuctionWatchDigestEligible()
+	if err != nil {
+		s.warn("Failed to list auction digest users: %v", err)
+		stats.Errors++
+		return stats
+	}
+
+	for i := range users {
+		stats.UsersChecked++
+		synced, err := s.SyncUser(&users[i])
+		stats.LotsSynced += synced
+		if err != nil {
+			stats.Errors++
+			s.warn("Scheduled auction watchlist sync failed for user %d: %v", users[i].ID, err)
+		}
+	}
+	return stats
+}
+
+func (s *AuctionWatchlistSyncService) SyncUser(user *models.User) (int, error) {
+	if user == nil {
+		return 0, fmt.Errorf("user is required")
+	}
+
+	total := 0
+	var errs []string
+	if user.NumisBidsUsername != "" && user.NumisBidsPassword != "" {
+		synced, err := s.syncNumisBids(user)
+		total += synced
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("numisbids: %v", err))
+		}
+	}
+	if user.CNGUsername != "" && user.CNGPassword != "" {
+		synced, err := s.syncCNG(user)
+		total += synced
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("cng: %v", err))
+		}
+	}
+	if len(errs) > 0 {
+		return total, fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+	return total, nil
+}
+
+func (s *AuctionWatchlistSyncService) syncNumisBids(user *models.User) (int, error) {
+	password, err := s.decryptStoredCredential(user, "numis_bids_password", user.NumisBidsPassword)
+	if err != nil {
+		return 0, err
+	}
+	client, err := s.nbSvc.Login(user.NumisBidsUsername, password)
+	if err != nil {
+		return 0, err
+	}
+	raw, err := s.nbSvc.FetchWatchlist(client)
+	if err != nil {
+		return 0, err
+	}
+
+	now := time.Now()
+	synced := 0
+	for _, wl := range s.nbSvc.ParseWatchlist(raw) {
+		if details, err := s.nbSvc.ScrapeLotPage(wl.URL); err == nil {
+			if details.ImageURL != "" {
+				wl.ImageURL = details.ImageURL
+			}
+			wl.AuctionHouse = details.AuctionHouse
+			wl.SaleName = details.SaleName
+			wl.SaleDate = details.SaleDate
+			wl.Description = details.Description
+			wl.CurrentBid = details.CurrentBid
+			if details.Currency != "" {
+				wl.Currency = details.Currency
+			}
+			if details.LotNumber > 0 {
+				wl.LotNumber = details.LotNumber
+			}
+		} else {
+			s.warn("Could not refresh NumisBids lot page for scheduled sync user %d url=%s: %v", user.ID, wl.URL, err)
+		}
+
+		status := models.AuctionStatusWatching
+		saleDate := ParseSaleDate(wl.SaleDate)
+		if saleDate != nil && saleDate.Before(now) {
+			status = models.AuctionStatusPassed
+		}
+		lot := models.AuctionLot{
+			NumisBidsURL: wl.URL,
+			Source:       models.AuctionSourceNumisBids,
+			SourceURL:    wl.URL,
+			SourceSaleID: wl.SourceSaleID,
+			SaleID:       wl.SaleID,
+			LotNumber:    wl.LotNumber,
+			Title:        wl.Title,
+			Description:  wl.Description,
+			ImageURL:     wl.ImageURL,
+			Estimate:     wl.Estimate,
+			CurrentBid:   wl.CurrentBid,
+			Currency:     firstNonBlank(wl.Currency, "USD"),
+			AuctionHouse: wl.AuctionHouse,
+			SaleName:     wl.SaleName,
+			SaleDate:     saleDate,
+			Status:       status,
+			UserID:       user.ID,
+		}
+		if _, err := s.auctionRepo.UpsertWithCalendarEvent(&lot); err != nil {
+			return synced, err
+		}
+		synced++
+	}
+
+	s.auctionRepo.MarkPastAuctionsAsPassed(user.ID, now)
+	return synced, nil
+}
+
+func (s *AuctionWatchlistSyncService) syncCNG(user *models.User) (int, error) {
+	password, err := s.decryptStoredCredential(user, "cng_password", user.CNGPassword)
+	if err != nil {
+		return 0, err
+	}
+	client, err := s.cngSvc.Login(user.CNGUsername, password)
+	if err != nil {
+		return 0, err
+	}
+	lots, err := s.cngSvc.FetchWatchlistLots(client)
+	if err != nil {
+		return 0, err
+	}
+
+	now := time.Now()
+	synced := 0
+	for _, wl := range lots {
+		status := models.AuctionStatusWatching
+		auctionEndTime := ParseCNGDate(wl.SaleDate)
+		if auctionEndTime != nil && auctionEndTime.Before(now) {
+			status = models.AuctionStatusPassed
+		}
+		lot := models.AuctionLot{
+			NumisBidsURL:   strings.TrimSpace(wl.URL),
+			Source:         models.AuctionSourceCNG,
+			SourceURL:      strings.TrimSpace(wl.URL),
+			SourceLotID:    wl.SourceLotID,
+			SourceSaleID:   firstNonBlank(wl.SourceSaleID, wl.SaleID),
+			SaleID:         wl.SaleID,
+			LotNumber:      wl.LotNumber,
+			Title:          wl.Title,
+			Description:    wl.Description,
+			ImageURL:       wl.ImageURL,
+			Estimate:       wl.Estimate,
+			CurrentBid:     wl.CurrentBid,
+			Currency:       firstNonBlank(wl.Currency, "USD"),
+			AuctionHouse:   wl.AuctionHouse,
+			SaleName:       wl.SaleName,
+			AuctionEndTime: auctionEndTime,
+			Status:         status,
+			UserID:         user.ID,
+		}
+		if _, err := s.auctionRepo.UpsertWithCalendarEvent(&lot); err != nil {
+			return synced, err
+		}
+		synced++
+	}
+
+	s.auctionRepo.MarkPastAuctionsAsPassed(user.ID, now)
+	return synced, nil
+}
+
+func (s *AuctionWatchlistSyncService) decryptStoredCredential(user *models.User, field string, stored string) (string, error) {
+	plain, wasEncrypted, err := s.credentials.DecryptStringWithAAD(stored, AuctionCredentialAAD(user.ID, field))
+	if err != nil {
+		return "", err
+	}
+	if s.credentials.Enabled() && !wasEncrypted && stored != "" {
+		encrypted, err := s.credentials.EncryptStringWithAAD(plain, AuctionCredentialAAD(user.ID, field))
+		if err != nil {
+			s.warn("Failed to encrypt legacy auction credential for user %d: %v", user.ID, err)
+			return plain, nil
+		}
+		if encrypted != plain {
+			if err := s.userRepo.UpdateField(user, field, encrypted); err != nil {
+				s.warn("Failed to save encrypted legacy auction credential for user %d: %v", user.ID, err)
+			}
+		}
+	}
+	return plain, nil
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func (s *AuctionWatchlistSyncService) warn(format string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Warn("auction-watch-sync", format, args...)
+	}
+}

--- a/src/api/services/credential_encryption_service.go
+++ b/src/api/services/credential_encryption_service.go
@@ -103,6 +103,10 @@ func (s *CredentialEncryptionService) DecryptStringWithAAD(stored string, aad []
 	return string(decrypted), true, nil
 }
 
+func AuctionCredentialAAD(userID uint, field string) []byte {
+	return []byte(fmt.Sprintf("auction-credential:%d:%s", userID, field))
+}
+
 func parseCredentialEncryptionKey(rawKey string) ([]byte, error) {
 	rawKey = strings.TrimSpace(rawKey)
 	if rawKey == "" {


### PR DESCRIPTION
## Summary
- refresh NumisBids/CNG watchlists during the existing auction scheduler before building the digest
- persist refreshed `current_bid` values so the Auctions page reflects the latest high bid
- send one aggregated Pushover digest per user listing all active watched lots and current high bids

## Validation
- `go test -v ./repository -run "TestAuctionLotRepository_UpsertRefreshesCurrentBid|TestAuctionLotRepository_GetActiveWatchBidDigestLots"`
- `go test -v ./services -run "TestAuctionEndingNotifyUserIncludesCurrentHighBids|TestFormatAuctionBidHandlesMissingBid|TestAuctionEndingTimeUntilNextRun"`
- `go test -v ./handlers -run "TestUserHandlerUpdateProfileEncryptsAuctionCredentials|TestAuctionLotHandlerLazyMigratesLegacyAuctionCredentials"`
- `go test ./...`
- `go vet ./...`

## Constitution self-check
- Principle I: kept provider sync and digest behavior in services/repositories with thin route wiring
- Principle IV: reused the existing auction scheduler instead of adding a parallel job
- §17: targeted workflow regression coverage added for bid refresh persistence and digest output