### PR TITLE
Fix PWA coin analysis action layout

### DIFF
--- a/src/web/src/components/coin/CoinAIAnalysis.vue
+++ b/src/web/src/components/coin/CoinAIAnalysis.vue
@@ -5,26 +5,29 @@
         <button
           class="btn btn-primary btn-sm ai-action-btn"
           :disabled="busy || !hasObverse || !aiAvailable"
+          aria-label="Analyze obverse"
           :title="!aiAvailable ? aiMessage : !hasObverse ? 'No obverse image' : ''"
           @click="handleAnalyze('obverse')"
         >
-          {{ analyzingSide === 'obverse' ? 'Analyzing...' : 'Analyze Obverse' }}
+          {{ analyzingSide === 'obverse' ? 'Analyzing...' : 'Obverse' }}
         </button>
         <button
           class="btn btn-primary btn-sm ai-action-btn"
           :disabled="busy || !hasReverse || !aiAvailable"
+          aria-label="Analyze reverse"
           :title="!aiAvailable ? aiMessage : !hasReverse ? 'No reverse image' : ''"
           @click="handleAnalyze('reverse')"
         >
-          {{ analyzingSide === 'reverse' ? 'Analyzing...' : 'Analyze Reverse' }}
+          {{ analyzingSide === 'reverse' ? 'Analyzing...' : 'Reverse' }}
         </button>
         <button
           class="btn btn-primary btn-sm ai-action-btn"
           :disabled="busy || !canGradeCoin || !aiAvailable"
+          aria-label="Grade coin"
           :title="gradingDisabledTitle"
           @click="handleGradeCoin"
         >
-          {{ grading ? 'Grading...' : 'Grade Coin' }}
+          {{ grading ? 'Grading...' : 'Grade' }}
         </button>
       </div>
       <p v-if="!aiAvailable" class="ai-unavailable">{{ aiMessage || 'AI unavailable — configure a provider in Admin → AI Configuration' }}</p>
@@ -506,9 +509,9 @@ function capitalize(value: string) {
 
 .ai-action-btn {
   min-width: 0;
-  min-height: 3.25rem;
+  min-height: 2.75rem;
   justify-content: center;
-  white-space: normal;
+  white-space: nowrap;
   line-height: 1.25;
 }
 

--- a/src/web/src/components/coin/CoinAIAnalysis.vue
+++ b/src/web/src/components/coin/CoinAIAnalysis.vue
@@ -3,7 +3,7 @@
     <div class="ai-analysis-content">
       <div class="ai-buttons">
         <button
-          class="btn btn-primary btn-sm"
+          class="btn btn-primary btn-sm ai-action-btn"
           :disabled="busy || !hasObverse || !aiAvailable"
           :title="!aiAvailable ? aiMessage : !hasObverse ? 'No obverse image' : ''"
           @click="handleAnalyze('obverse')"
@@ -11,7 +11,7 @@
           {{ analyzingSide === 'obverse' ? 'Analyzing...' : 'Analyze Obverse' }}
         </button>
         <button
-          class="btn btn-primary btn-sm"
+          class="btn btn-primary btn-sm ai-action-btn"
           :disabled="busy || !hasReverse || !aiAvailable"
           :title="!aiAvailable ? aiMessage : !hasReverse ? 'No reverse image' : ''"
           @click="handleAnalyze('reverse')"
@@ -19,7 +19,7 @@
           {{ analyzingSide === 'reverse' ? 'Analyzing...' : 'Analyze Reverse' }}
         </button>
         <button
-          class="btn btn-secondary btn-sm"
+          class="btn btn-primary btn-sm ai-action-btn"
           :disabled="busy || !canGradeCoin || !aiAvailable"
           :title="gradingDisabledTitle"
           @click="handleGradeCoin"
@@ -498,9 +498,18 @@ function capitalize(value: string) {
 }
 
 .ai-buttons {
-  display: flex;
-  gap: 0.4rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
   margin-bottom: 0.75rem;
+}
+
+.ai-action-btn {
+  min-width: 0;
+  min-height: 3.25rem;
+  justify-content: center;
+  white-space: normal;
+  line-height: 1.25;
 }
 
 .ai-result-section {

--- a/src/web/src/components/coin/__tests__/CoinAIAnalysis.test.ts
+++ b/src/web/src/components/coin/__tests__/CoinAIAnalysis.test.ts
@@ -90,7 +90,7 @@ describe('CoinAIAnalysis', () => {
 
     const wrapper = mountAnalysis()
     await flushPromises()
-    await wrapper.findAll('button').find((button) => button.text().includes('Analyze Obverse'))!.trigger('click')
+    await findActionButton(wrapper, 'Analyze obverse').trigger('click')
     await flushPromises()
 
     expect(mocks.showAlert).toHaveBeenCalledWith(
@@ -110,7 +110,7 @@ describe('CoinAIAnalysis', () => {
 
     const wrapper = mountAnalysis()
     await flushPromises()
-    await wrapper.findAll('button').find((button) => button.text().includes('Analyze Obverse'))!.trigger('click')
+    await findActionButton(wrapper, 'Analyze obverse').trigger('click')
     await flushPromises()
 
     expect(mocks.showAlert).toHaveBeenCalledWith(
@@ -157,7 +157,7 @@ describe('CoinAIAnalysis', () => {
 
     const wrapper = mountAnalysis()
     await flushPromises()
-    await wrapper.findAll('button').find((button) => button.text().includes('Analyze Obverse'))!.trigger('click')
+    await findActionButton(wrapper, 'Analyze obverse').trigger('click')
     await flushPromises()
 
     expect(mocks.analyzeCoin).toHaveBeenCalledWith(42, 'obverse')
@@ -175,7 +175,7 @@ describe('CoinAIAnalysis', () => {
     const wrapper = mountAnalysis({ hasObverse: false, hasReverse: false })
     await flushPromises()
 
-    const gradeButton = wrapper.findAll('button').find((button) => button.text().includes('Grade Coin'))!
+    const gradeButton = findActionButton(wrapper, 'Grade coin')
 
     expect(gradeButton.attributes('disabled')).toBeDefined()
     expect(gradeButton.attributes('title')).toBe('Add coin photos before requesting grading')
@@ -208,7 +208,7 @@ describe('CoinAIAnalysis', () => {
     const wrapper = mountAnalysis({ hasReverse: false })
     await flushPromises()
 
-    const gradeButton = wrapper.findAll('button').find((button) => button.text().includes('Grade Coin'))!
+    const gradeButton = findActionButton(wrapper, 'Grade coin')
     expect(gradeButton.attributes('disabled')).toBeUndefined()
     await gradeButton.trigger('click')
     await flushPromises()
@@ -254,7 +254,7 @@ describe('CoinAIAnalysis', () => {
 
     const wrapper = mountAnalysis()
     await flushPromises()
-    await wrapper.findAll('button').find((button) => button.text().includes('Grade Coin'))!.trigger('click')
+    await findActionButton(wrapper, 'Grade coin').trigger('click')
     await flushPromises()
 
     expect(mocks.gradeCoin).toHaveBeenCalledWith(42)
@@ -332,7 +332,7 @@ describe('CoinAIAnalysis', () => {
 
     const wrapper = mountAnalysis()
     await flushPromises()
-    await wrapper.findAll('button').find((button) => button.text().includes('Grade Coin'))!.trigger('click')
+    await findActionButton(wrapper, 'Grade coin').trigger('click')
     await flushPromises()
 
     expect(wrapper.text()).toContain('Coin images are required for grading')
@@ -365,7 +365,7 @@ describe('CoinAIAnalysis', () => {
 
     const wrapper = mountAnalysis()
     await flushPromises()
-    await wrapper.findAll('button').find((button) => button.text().includes('Analyze Reverse'))!.trigger('click')
+    await findActionButton(wrapper, 'Analyze reverse').trigger('click')
     await flushPromises()
 
     expect(mocks.showAlert).toHaveBeenCalledWith('Analysis could not complete', { title: 'Analysis Failed' })
@@ -397,7 +397,7 @@ describe('CoinAIAnalysis', () => {
 
     const wrapper = mountAnalysis()
     await flushPromises()
-    await wrapper.findAll('button').find((button) => button.text().includes('Analyze Obverse'))!.trigger('click')
+    await findActionButton(wrapper, 'Analyze obverse').trigger('click')
     await flushPromises()
 
     expect(mocks.getAIJob).toHaveBeenCalledTimes(1)
@@ -420,4 +420,10 @@ function mountAnalysis(propOverrides: Partial<InstanceType<typeof CoinAIAnalysis
       ...propOverrides,
     },
   })
+}
+
+function findActionButton(wrapper: ReturnType<typeof mountAnalysis>, label: string) {
+  const button = wrapper.findAll('button').find((candidate) => candidate.attributes('aria-label') === label)
+  if (!button) throw new Error(`Missing action button: ${label}`)
+  return button
 }


### PR DESCRIPTION
## Summary
- Makes the AI Analysis action row use three equal-width buttons in PWA/mobile layouts.
- Gives Grade Coin the same primary button treatment as Analyze Obverse and Analyze Reverse.
- Keeps labels wrapping inside buttons instead of creating a cramped two-row button layout.

## Quality Gate
- `npm.cmd test -- CoinAIAnalysis.test.ts`
- `npm.cmd run type-check`
- `npm.cmd run build`

## Constitution
- Principle VI + §17