### PR TITLE
fix: merge auction calendar dedupe and movable agent FAB

### DIFF
--- a/src/api/repository/auction_lot_repository.go
+++ b/src/api/repository/auction_lot_repository.go
@@ -222,15 +222,15 @@ func (r *AuctionLotRepository) upsert(lot *models.AuctionLot, autoCreateEvent bo
 			}
 			result.Created = true
 			if autoCreateEvent && shouldAutoCreateCalendarEvent(lot) {
-				event := auctionEventFromLot(lot)
-				if err := tx.Create(&event).Error; err != nil {
+				event, created, err := txRepo.findOrCreateCalendarEventForLot(lot)
+				if err != nil {
 					return err
 				}
 				if err := tx.Model(lot).Update("event_id", event.ID).Error; err != nil {
 					return err
 				}
 				lot.EventID = &event.ID
-				result.EventCreated = true
+				result.EventCreated = created
 				result.EventID = &event.ID
 			}
 			return nil
@@ -267,6 +267,32 @@ func shouldAutoCreateCalendarEvent(lot *models.AuctionLot) bool {
 	return lot.Status == models.AuctionStatusWatching || lot.Status == models.AuctionStatusBidding
 }
 
+func (r *AuctionLotRepository) findOrCreateCalendarEventForLot(lot *models.AuctionLot) (*models.AuctionEvent, bool, error) {
+	sourceSaleID := strings.TrimSpace(lot.SourceSaleID)
+	if sourceSaleID != "" {
+		var linkedLot models.AuctionLot
+		err := r.db.
+			Where("user_id = ? AND source = ? AND source_sale_id = ? AND event_id IS NOT NULL", lot.UserID, lot.Source, sourceSaleID).
+			First(&linkedLot).Error
+		if err == nil {
+			var existing models.AuctionEvent
+			if err := r.db.First(&existing, *linkedLot.EventID).Error; err != nil {
+				return nil, false, err
+			}
+			return &existing, false, nil
+		}
+		if !IsRecordNotFound(err) {
+			return nil, false, err
+		}
+	}
+
+	event := auctionEventFromLot(lot)
+	if err := r.db.Create(&event).Error; err != nil {
+		return nil, false, err
+	}
+	return &event, true, nil
+}
+
 func auctionEventFromLot(lot *models.AuctionLot) models.AuctionEvent {
 	eventDate := lot.AuctionEndTime
 	if eventDate == nil {
@@ -286,6 +312,10 @@ func auctionEventFromLot(lot *models.AuctionLot) models.AuctionEvent {
 }
 
 func auctionEventTitle(lot *models.AuctionLot) string {
+	if saleName := strings.TrimSpace(lot.SaleName); saleName != "" {
+		return saleName
+	}
+
 	title := strings.TrimSpace(lot.Title)
 	if title == "" {
 		title = "Auction lot"

--- a/src/api/repository/auction_lot_repository_test.go
+++ b/src/api/repository/auction_lot_repository_test.go
@@ -536,7 +536,7 @@ func TestAuctionLotRepository_UpsertWithCalendarEventCreatesOnlyForNewWatchableL
 	if err := db.First(&event, *result.EventID).Error; err != nil {
 		t.Fatalf("reload event: %v", err)
 	}
-	if event.UserID != 7 || event.Title != "Lot 100 - Aurelian Antoninianus" || event.AuctionHouse != "Numis House" {
+	if event.UserID != 7 || event.Title != "Summer Sale" || event.AuctionHouse != "Numis House" {
 		t.Fatalf("unexpected event fields: %#v", event)
 	}
 	if event.StartDate == nil || !event.StartDate.Equal(endTime) || event.EndDate == nil || !event.EndDate.Equal(endTime) {
@@ -661,6 +661,65 @@ func TestAuctionLotRepository_UpsertWithCalendarEventSkipsPassedAndExistingLots(
 	}
 }
 
+func TestAuctionLotRepository_UpsertWithCalendarEventReusesSourceSaleEvent(t *testing.T) {
+	db := setupAuctionTestDB(t)
+	repo := NewAuctionLotRepository(db)
+	firstLot := &models.AuctionLot{
+		NumisBidsURL: "https://www.numisbids.com/n.php?p=lot&sid=11&lot=1",
+		Source:       models.AuctionSourceNumisBids,
+		SourceURL:    "https://www.numisbids.com/n.php?p=lot&sid=11&lot=1",
+		SourceSaleID: "sale-11",
+		Title:        "First lot title",
+		SaleName:     "Numis Sale 11",
+		Status:       models.AuctionStatusWatching,
+		UserID:       10,
+	}
+	firstResult, err := repo.UpsertWithCalendarEvent(firstLot)
+	if err != nil {
+		t.Fatalf("upsert first lot: %v", err)
+	}
+	if !firstResult.Created || !firstResult.EventCreated || firstResult.EventID == nil {
+		t.Fatalf("first result = %#v, want created lot and event", firstResult)
+	}
+
+	secondLot := &models.AuctionLot{
+		NumisBidsURL: "https://www.numisbids.com/n.php?p=lot&sid=11&lot=2",
+		Source:       models.AuctionSourceNumisBids,
+		SourceURL:    "https://www.numisbids.com/n.php?p=lot&sid=11&lot=2",
+		SourceSaleID: "sale-11",
+		Title:        "Second lot title",
+		SaleName:     "Numis Sale 11",
+		Status:       models.AuctionStatusBidding,
+		UserID:       10,
+	}
+	secondResult, err := repo.UpsertWithCalendarEvent(secondLot)
+	if err != nil {
+		t.Fatalf("upsert second lot: %v", err)
+	}
+	if !secondResult.Created || secondResult.EventCreated || secondResult.EventID == nil {
+		t.Fatalf("second result = %#v, want created lot linked to existing event", secondResult)
+	}
+	if *secondResult.EventID != *firstResult.EventID {
+		t.Fatalf("second event id = %d, want %d", *secondResult.EventID, *firstResult.EventID)
+	}
+
+	reloadedSecond, err := repo.GetBySourceURL(models.AuctionSourceNumisBids, secondLot.SourceURL, 10)
+	if err != nil {
+		t.Fatalf("reload second lot: %v", err)
+	}
+	if reloadedSecond.EventID == nil || *reloadedSecond.EventID != *firstResult.EventID {
+		t.Fatalf("second lot event id = %v, want %d", reloadedSecond.EventID, *firstResult.EventID)
+	}
+
+	var eventCount int64
+	if err := db.Model(&models.AuctionEvent{}).Count(&eventCount).Error; err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if eventCount != 1 {
+		t.Fatalf("event count = %d, want 1 shared sale event", eventCount)
+	}
+}
+
 func TestAuctionLotRepository_UpsertWithCalendarEventIsSourceAwareForCNG(t *testing.T) {
 	db := setupAuctionTestDB(t)
 	repo := NewAuctionLotRepository(db)
@@ -671,7 +730,9 @@ func TestAuctionLotRepository_UpsertWithCalendarEventIsSourceAwareForCNG(t *test
 			NumisBidsURL: sharedURL,
 			Source:       models.AuctionSourceNumisBids,
 			SourceURL:    sharedURL,
+			SourceSaleID: "numis-sale-1",
 			Title:        "NumisBids Shared Lot",
+			SaleName:     "Shared Sale",
 			Status:       models.AuctionStatusWatching,
 			UserID:       9,
 		},
@@ -680,7 +741,9 @@ func TestAuctionLotRepository_UpsertWithCalendarEventIsSourceAwareForCNG(t *test
 			Source:         models.AuctionSourceCNG,
 			SourceURL:      sharedURL,
 			SourceLotID:    "4-CNGLOT",
+			SourceSaleID:   "cng-sale-1",
 			Title:          "CNG Shared Lot",
+			SaleName:       "Shared Sale",
 			Status:         models.AuctionStatusBidding,
 			AuctionEndTime: &cngEndTime,
 			UserID:         9,

--- a/src/web/src/App.vue
+++ b/src/web/src/App.vue
@@ -126,7 +126,12 @@
       <button
         v-if="isPwa && auth.isAuthenticated && !showChat && !bulkSelectActive"
         class="agent-fab"
-        @click="showChat = true"
+        :style="fabPositionStyle"
+        @click="handleAgentFabClick"
+        @pointerdown="startAgentFabDrag"
+        @pointermove="moveAgentFabDrag"
+        @pointerup="stopAgentFabDrag"
+        @pointercancel="stopAgentFabDrag"
         aria-label="Open AI Agent"
       >
         <Bot :size="22" />
@@ -218,6 +223,15 @@ const { unreadCount, startPolling, stopPolling } = useNotifications()
 const { bulkSelectActive } = useBulkSelect()
 const statsExpanded = ref(false)
 const collectionExpanded = ref(false)
+const agentFabPosition = ref<{ x: number; y: number } | null>(null)
+const isDraggingAgentFab = ref(false)
+const agentFabSuppressClick = ref(false)
+const agentFabPointerId = ref<number | null>(null)
+const agentFabPointerOffset = ref({ x: 0, y: 0 })
+const agentFabDragStart = ref({ x: 0, y: 0 })
+
+const AGENT_FAB_SIZE = 52
+const AGENT_FAB_VIEWPORT_MARGIN = 8
 
 const isCollectionPage = computed(() => route.name === 'collection')
 const showCollectionActions = computed(() => isCollectionPage.value && !isPwa)
@@ -297,6 +311,16 @@ const orderedNavItems = computed(() => {
   return items.filter(item => item.visible)
 })
 
+const fabPositionStyle = computed<Record<string, string> | undefined>(() => {
+  if (!agentFabPosition.value) return undefined
+  return {
+    left: `${agentFabPosition.value.x}px`,
+    top: `${agentFabPosition.value.y}px`,
+    right: 'auto',
+    bottom: 'auto',
+  }
+})
+
 // Full order including hidden items for persistence
 const fullOrder = computed(() => {
   return navOrder.value.length ? applyOrder(navOrder.value).map(i => i.id) : defaultNavItems.map(i => i.id)
@@ -330,6 +354,70 @@ function toggleEditMode() {
 
 function toggleCollectionSelectMode() {
   bulkSelectActive.value = !bulkSelectActive.value
+}
+
+function clampAgentFabPosition(x: number, y: number): { x: number; y: number } {
+  const maxX = Math.max(AGENT_FAB_VIEWPORT_MARGIN, window.innerWidth - AGENT_FAB_SIZE - AGENT_FAB_VIEWPORT_MARGIN)
+  const maxY = Math.max(AGENT_FAB_VIEWPORT_MARGIN, window.innerHeight - AGENT_FAB_SIZE - AGENT_FAB_VIEWPORT_MARGIN)
+  return {
+    x: Math.min(Math.max(x, AGENT_FAB_VIEWPORT_MARGIN), maxX),
+    y: Math.min(Math.max(y, AGENT_FAB_VIEWPORT_MARGIN), maxY),
+  }
+}
+
+function startAgentFabDrag(event: PointerEvent) {
+  if (event.pointerType === 'mouse' && event.button !== 0) return
+  const target = event.currentTarget
+  if (!(target instanceof HTMLElement)) return
+  const rect = target.getBoundingClientRect()
+  agentFabPointerId.value = event.pointerId
+  agentFabPointerOffset.value = { x: event.clientX - rect.left, y: event.clientY - rect.top }
+  agentFabDragStart.value = { x: event.clientX, y: event.clientY }
+  isDraggingAgentFab.value = false
+  target.setPointerCapture(event.pointerId)
+}
+
+function moveAgentFabDrag(event: PointerEvent) {
+  if (agentFabPointerId.value !== event.pointerId) return
+  const moved = Math.hypot(event.clientX - agentFabDragStart.value.x, event.clientY - agentFabDragStart.value.y) > 4
+  if (moved) {
+    isDraggingAgentFab.value = true
+  }
+  if (!isDraggingAgentFab.value) return
+  const next = clampAgentFabPosition(
+    event.clientX - agentFabPointerOffset.value.x,
+    event.clientY - agentFabPointerOffset.value.y,
+  )
+  agentFabPosition.value = next
+}
+
+function stopAgentFabDrag(event: PointerEvent) {
+  if (agentFabPointerId.value !== event.pointerId) return
+  const target = event.currentTarget
+  if (target instanceof HTMLElement && target.hasPointerCapture(event.pointerId)) {
+    target.releasePointerCapture(event.pointerId)
+  }
+  agentFabPointerId.value = null
+  if (isDraggingAgentFab.value) {
+    agentFabSuppressClick.value = true
+    window.setTimeout(() => {
+      agentFabSuppressClick.value = false
+    }, 0)
+  }
+}
+
+function handleAgentFabClick(event: MouseEvent) {
+  if (agentFabSuppressClick.value) {
+    event.preventDefault()
+    event.stopPropagation()
+    return
+  }
+  showChat.value = true
+}
+
+function handleAgentFabViewportResize() {
+  if (!agentFabPosition.value) return
+  agentFabPosition.value = clampAgentFabPosition(agentFabPosition.value.x, agentFabPosition.value.y)
 }
 
 function initSortable() {
@@ -387,6 +475,7 @@ watch(sidebarOpen, (open) => {
 })
 
 onMounted(async () => {
+  window.addEventListener('resize', handleAgentFabViewportResize)
   if (auth.isAuthenticated) {
     startPolling()
     try {
@@ -452,6 +541,7 @@ function handleLogout() {
 }
 
 onUnmounted(() => {
+  window.removeEventListener('resize', handleAgentFabViewportResize)
   destroySortable()
   stopPolling()
 })

--- a/src/web/src/__tests__/ui-patterns.test.ts
+++ b/src/web/src/__tests__/ui-patterns.test.ts
@@ -129,10 +129,15 @@ describe('UI pattern recipes', () => {
 
     expect(app).toContain('<Teleport to="body">')
     expect(app).toContain('class="agent-fab"')
+    expect(app).toContain(':style="fabPositionStyle"')
+    expect(app).toContain('@pointerdown="startAgentFabDrag"')
+    expect(app).toContain('@pointermove="moveAgentFabDrag"')
+    expect(app).toContain('@pointerup="stopAgentFabDrag"')
     expect(app).not.toContain('.agent-fab {')
     expect(agentFabCss).toContain('position: fixed')
     expect(agentFabCss).toContain('bottom: calc(24px + env(safe-area-inset-bottom))')
     expect(agentFabCss).toContain('right: calc(24px + env(safe-area-inset-right))')
+    expect(agentFabCss).toContain('touch-action: none')
   })
 
   it('keeps the agent chat overlay above tray pagination controls', () => {

--- a/src/web/src/assets/styles/main.css
+++ b/src/web/src/assets/styles/main.css
@@ -451,6 +451,8 @@ a:hover {
   box-shadow: var(--shadow-card);
   z-index: 1250;
   transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+  touch-action: none;
+  user-select: none;
 }
 
 .agent-fab:active {


### PR DESCRIPTION
## Summary
- Merge corrected auction calendar sale-event dedupe for #404
- Merge movable PWA Agent FAB for #405
- PR #404 was adjusted to dedupe through linked lots by `user_id + source + source_sale_id`, with same-name cross-source coverage and no package-lock churn
- PR #406 behavior is included as an in-memory drag position that resets on reload

## Validation
- `go test ./...` from `src/api`
- `npm.cmd run build` from `src/web`
- `npm.cmd test -- ui-patterns.test.ts` from `src/web`

## Constitution self-check
- Principle I + Principle IV + Principle VI + §17

Closes #404
Closes #405