### PR TITLE
fix: clarify value trend snapshots

### DIFF
--- a/src/api/repository/coin_repository.go
+++ b/src/api/repository/coin_repository.go
@@ -917,16 +917,22 @@ func (r *CoinRepository) CreateJournalEntry(entry *models.CoinJournal) error {
 // RecordValueSnapshot captures the current total value, invested amount,
 // and coin count for a user.
 func (r *CoinRepository) RecordValueSnapshot(userID uint) error {
+	return recordActiveCollectionValueSnapshot(r.db, userID)
+}
+
+func recordActiveCollectionValueSnapshot(db *gorm.DB, userID uint) error {
 	type result struct {
 		TotalValue    float64
 		TotalInvested float64
 		CoinCount     int64
 	}
 	var res result
-	r.db.Model(&models.Coin{}).
+	if err := db.Model(&models.Coin{}).
 		Select("COALESCE(SUM(current_value), 0) as total_value, COALESCE(SUM(purchase_price), 0) as total_invested, COUNT(*) as coin_count").
-		Where("user_id = ? AND is_wishlist = ?", userID, false).
-		Scan(&res)
+		Scopes(ActiveCollection(userID)).
+		Scan(&res).Error; err != nil {
+		return err
+	}
 
 	snapshot := models.ValueSnapshot{
 		UserID:        userID,
@@ -935,5 +941,5 @@ func (r *CoinRepository) RecordValueSnapshot(userID uint) error {
 		CoinCount:     res.CoinCount,
 		RecordedAt:    time.Now(),
 	}
-	return r.db.Create(&snapshot).Error
+	return db.Create(&snapshot).Error
 }

--- a/src/api/repository/coin_repository_test.go
+++ b/src/api/repository/coin_repository_test.go
@@ -287,6 +287,11 @@ func TestCoinRepository_RecordValueSnapshot(t *testing.T) {
 		Name: "Wishlist", Category: models.CategoryRoman, UserID: 1,
 		IsWishlist: true, PurchasePrice: ptrFloat(9999.0),
 	})
+	// Sold coin should be excluded so snapshots match active collection stats
+	db.Create(&models.Coin{
+		Name: "Sold", Category: models.CategoryRoman, UserID: 1,
+		IsSold: true, PurchasePrice: ptrFloat(50.0), CurrentValue: ptrFloat(5000.0),
+	})
 
 	if err := repo.RecordValueSnapshot(1); err != nil {
 		t.Fatalf("RecordValueSnapshot failed: %v", err)

--- a/src/api/repository/quick_capture_repository.go
+++ b/src/api/repository/quick_capture_repository.go
@@ -300,25 +300,5 @@ func (r *QuickCaptureRepository) PromoteDraftTransaction(
 }
 
 func recordValueSnapshotInTx(tx *gorm.DB, userID uint) error {
-	type result struct {
-		TotalValue    float64
-		TotalInvested float64
-		CoinCount     int64
-	}
-	var res result
-	if err := tx.Model(&models.Coin{}).
-		Select("COALESCE(SUM(current_value), 0) as total_value, COALESCE(SUM(purchase_price), 0) as total_invested, COUNT(*) as coin_count").
-		Where("user_id = ? AND is_wishlist = ?", userID, false).
-		Scan(&res).Error; err != nil {
-		return err
-	}
-
-	snapshot := models.ValueSnapshot{
-		UserID:        userID,
-		TotalValue:    res.TotalValue,
-		TotalInvested: res.TotalInvested,
-		CoinCount:     res.CoinCount,
-		RecordedAt:    time.Now(),
-	}
-	return tx.Create(&snapshot).Error
+	return recordActiveCollectionValueSnapshot(tx, userID)
 }

--- a/src/web/src/components/stats/StatsValueOverTime.vue
+++ b/src/web/src/components/stats/StatsValueOverTime.vue
@@ -4,6 +4,9 @@
       <div>
         <p class="section-label">Portfolio Trajectory</p>
         <h2>Value Over Time</h2>
+        <p class="chart-subtitle">
+          Active collection value movement between the first and latest snapshot in this timeframe.
+        </p>
       </div>
     </div>
 
@@ -128,7 +131,7 @@
       <!-- Side panel -->
       <div class="chart-side-panel">
         <div class="panel-roi">
-          <p class="section-label">Portfolio Change</p>
+          <p class="section-label">Period Value Change</p>
           <span class="panel-roi-number" :class="changeAmount >= 0 ? 'positive' : 'negative'">
             <template v-if="changePercent !== null">
               {{ changePercent >= 0 ? '+' : '' }}{{ changePercent.toFixed(1) }}%
@@ -145,7 +148,7 @@
 
         <div class="chart-summary-strip" aria-label="Value history summary">
           <div class="summary-pill">
-            <span class="summary-label">Latest Value</span>
+            <span class="summary-label">Latest Snapshot</span>
             <strong>{{ formatCurrency(latestValue) }}</strong>
           </div>
           <div class="summary-pill">
@@ -153,7 +156,7 @@
             <strong>{{ formatCurrency(latestInvested) }}</strong>
           </div>
           <div class="summary-pill">
-            <span class="summary-label">Change</span>
+            <span class="summary-label">Period Change</span>
             <strong :class="changeAmount >= 0 ? 'positive' : 'negative'">
               {{ changeAmount >= 0 ? '+' : '' }}{{ formatCurrency(changeAmount) }}
             </strong>
@@ -310,6 +313,12 @@ function formatShortDate(dateStr: string) {
 .chart-card-header h2 {
   margin: 0.15rem 0 0;
   font-size: 1.5rem;
+}
+
+.chart-subtitle {
+  margin: 0.35rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
 }
 
 /* Main two-column layout: chart left, side panel right */

--- a/src/web/src/components/stats/__tests__/StatsValueOverTime.test.ts
+++ b/src/web/src/components/stats/__tests__/StatsValueOverTime.test.ts
@@ -51,10 +51,12 @@ describe('StatsValueOverTime', () => {
     expect(wrapper.findAll('.chart-grid-line').length).toBeGreaterThan(0)
   })
 
-  it('shows Portfolio Trajectory label and Value Over Time heading', () => {
+  it('shows Portfolio Trajectory label, Value Over Time heading, and timeframe explanation', () => {
     const wrapper = mount(StatsValueOverTime, { props: { history: [jan2024, feb2024] } })
     expect(wrapper.text()).toContain('Portfolio Trajectory')
     expect(wrapper.text()).toContain('Value Over Time')
+    expect(wrapper.text()).toContain('Active collection value movement')
+    expect(wrapper.text()).toContain('Period Value Change')
   })
 
   it('shows legend items for Current Value and Invested', () => {
@@ -68,7 +70,7 @@ describe('StatsValueOverTime', () => {
   it('summary strip first pill shows latest total value', () => {
     const wrapper = mount(StatsValueOverTime, { props: { history: [jan2024, feb2024] } })
     const pills = wrapper.findAll('.summary-pill')
-    // First pill: "Latest Value" with feb2024.totalValue = 1350
+    expect(pills[0]?.text()).toContain('Latest Snapshot')
     expect(pills[0]?.text()).toContain('$1,350')
   })
 
@@ -112,5 +114,6 @@ describe('StatsValueOverTime', () => {
     expect(wrapper.find('.chart-side-panel').exists()).toBe(true)
     expect(wrapper.find('.panel-roi-number').exists()).toBe(true)
     expect(wrapper.findAll('.summary-pill')).toHaveLength(3)
+    expect(wrapper.text()).toContain('Period Change')
   })
 })


### PR DESCRIPTION
## Summary
- align value history snapshots with active collection stats by excluding sold coins
- share the snapshot helper between normal coin writes and quick capture promotions
- clarify Value Over Time labels as period value movement instead of ROI

## Constitution / Quality Gate
- Principle I: shared repository-layer snapshot rule
- Principle VI: clearer value trend UX
- Principle IX + §17: regression coverage and local Quality Gate checks

## Checks
- go test ./...
- npm.cmd test -- StatsValueOverTime.test.ts StatsValueTrendsPage.test.ts
- npm.cmd run type-check
- npm.cmd run build