### PR TITLE
feat: add investment valuation highlights

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11568,7 +11568,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns investment, current value, gain/loss, and confidence counts grouped by purchase month or material for the authenticated user's active collection.",
+                "description": "Returns investment, current value, gain/loss, confidence counts, top valuation movement, and stale valuations for the authenticated user's active collection.",
                 "produces": [
                     "application/json"
                 ],
@@ -14889,6 +14889,24 @@
                     "items": {
                         "$ref": "#/definitions/repository.InvestmentBreakdownSegment"
                     }
+                },
+                "staleValuations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.StaleValuationCoin"
+                    }
+                },
+                "topDrops": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.InvestmentMovementCoin"
+                    }
+                },
+                "topIncreases": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.InvestmentMovementCoin"
+                    }
                 }
             }
         },
@@ -17470,6 +17488,43 @@
                 },
                 "year": {
                     "type": "integer"
+                }
+            }
+        },
+        "repository.InvestmentMovementCoin": {
+            "type": "object",
+            "properties": {
+                "changeAmount": {
+                    "type": "number"
+                },
+                "changePct": {
+                    "type": "number"
+                },
+                "coinId": {
+                    "type": "integer"
+                },
+                "currentValue": {
+                    "type": "number"
+                },
+                "initialValue": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.StaleValuationCoin": {
+            "type": "object",
+            "properties": {
+                "coinId": {
+                    "type": "integer"
+                },
+                "lastValuationAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/src/api/docs/docs.go
+++ b/src/api/docs/docs.go
@@ -11575,7 +11575,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns investment, current value, gain/loss, and confidence counts grouped by purchase month or material for the authenticated user's active collection.",
+                "description": "Returns investment, current value, gain/loss, confidence counts, top valuation movement, and stale valuations for the authenticated user's active collection.",
                 "produces": [
                     "application/json"
                 ],
@@ -14896,6 +14896,24 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/repository.InvestmentBreakdownSegment"
                     }
+                },
+                "staleValuations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.StaleValuationCoin"
+                    }
+                },
+                "topDrops": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.InvestmentMovementCoin"
+                    }
+                },
+                "topIncreases": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.InvestmentMovementCoin"
+                    }
                 }
             }
         },
@@ -17477,6 +17495,43 @@ const docTemplate = `{
                 },
                 "year": {
                     "type": "integer"
+                }
+            }
+        },
+        "repository.InvestmentMovementCoin": {
+            "type": "object",
+            "properties": {
+                "changeAmount": {
+                    "type": "number"
+                },
+                "changePct": {
+                    "type": "number"
+                },
+                "coinId": {
+                    "type": "integer"
+                },
+                "currentValue": {
+                    "type": "number"
+                },
+                "initialValue": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.StaleValuationCoin": {
+            "type": "object",
+            "properties": {
+                "coinId": {
+                    "type": "integer"
+                },
+                "lastValuationAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/src/api/docs/swagger.json
+++ b/src/api/docs/swagger.json
@@ -11568,7 +11568,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns investment, current value, gain/loss, and confidence counts grouped by purchase month or material for the authenticated user's active collection.",
+                "description": "Returns investment, current value, gain/loss, confidence counts, top valuation movement, and stale valuations for the authenticated user's active collection.",
                 "produces": [
                     "application/json"
                 ],
@@ -14889,6 +14889,24 @@
                     "items": {
                         "$ref": "#/definitions/repository.InvestmentBreakdownSegment"
                     }
+                },
+                "staleValuations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.StaleValuationCoin"
+                    }
+                },
+                "topDrops": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.InvestmentMovementCoin"
+                    }
+                },
+                "topIncreases": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.InvestmentMovementCoin"
+                    }
                 }
             }
         },
@@ -17470,6 +17488,43 @@
                 },
                 "year": {
                     "type": "integer"
+                }
+            }
+        },
+        "repository.InvestmentMovementCoin": {
+            "type": "object",
+            "properties": {
+                "changeAmount": {
+                    "type": "number"
+                },
+                "changePct": {
+                    "type": "number"
+                },
+                "coinId": {
+                    "type": "integer"
+                },
+                "currentValue": {
+                    "type": "number"
+                },
+                "initialValue": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.StaleValuationCoin": {
+            "type": "object",
+            "properties": {
+                "coinId": {
+                    "type": "integer"
+                },
+                "lastValuationAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/src/api/docs/swagger.yaml
+++ b/src/api/docs/swagger.yaml
@@ -652,6 +652,18 @@ definitions:
         items:
           $ref: '#/definitions/repository.InvestmentBreakdownSegment'
         type: array
+      staleValuations:
+        items:
+          $ref: '#/definitions/repository.StaleValuationCoin'
+        type: array
+      topDrops:
+        items:
+          $ref: '#/definitions/repository.InvestmentMovementCoin'
+        type: array
+      topIncreases:
+        items:
+          $ref: '#/definitions/repository.InvestmentMovementCoin'
+        type: array
     type: object
   handlers.LinkEventRequest:
     properties:
@@ -2422,6 +2434,30 @@ definitions:
         type: integer
       year:
         type: integer
+    type: object
+  repository.InvestmentMovementCoin:
+    properties:
+      changeAmount:
+        type: number
+      changePct:
+        type: number
+      coinId:
+        type: integer
+      currentValue:
+        type: number
+      initialValue:
+        type: number
+      name:
+        type: string
+    type: object
+  repository.StaleValuationCoin:
+    properties:
+      coinId:
+        type: integer
+      lastValuationAt:
+        type: string
+      name:
+        type: string
     type: object
   services.AIJobSubmissionResponse:
     properties:
@@ -10315,9 +10351,9 @@ paths:
       - Health
   /stats/investment-breakdown:
     get:
-      description: Returns investment, current value, gain/loss, and confidence counts
-        grouped by purchase month or material for the authenticated user's active
-        collection.
+      description: Returns investment, current value, gain/loss, confidence counts,
+        top valuation movement, and stale valuations for the authenticated user's
+        active collection.
       parameters:
       - description: Breakdown dimension
         enum:

--- a/src/api/go.mod
+++ b/src/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/briandenicola/ancient-coins-api
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/coreos/go-oidc/v3 v3.19.0

--- a/src/api/handlers/coins.go
+++ b/src/api/handlers/coins.go
@@ -582,7 +582,7 @@ func (h *CoinHandler) Distribution(c *gin.Context) {
 // InvestmentBreakdown returns active-collection investment aggregates for charting.
 //
 //	@Summary		Get investment breakdown
-//	@Description	Returns investment, current value, gain/loss, and confidence counts grouped by purchase month or material for the authenticated user's active collection.
+//	@Description	Returns investment, current value, gain/loss, confidence counts, top valuation movement, and stale valuations for the authenticated user's active collection.
 //	@Tags			Coins
 //	@Produce		json
 //	@Param			dimension	query		string	true	"Breakdown dimension"	Enums(purchase-month, material)
@@ -607,7 +607,28 @@ func (h *CoinHandler) InvestmentBreakdown(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch investment breakdown"})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"dimension": dimension, "segments": segments})
+	topIncreases, err := h.repo.GetTopInvestmentIncreases(userID, 5)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch investment movement"})
+		return
+	}
+	topDrops, err := h.repo.GetTopInvestmentDrops(userID, 5)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch investment movement"})
+		return
+	}
+	staleValuations, err := h.repo.GetStaleValuationCoins(userID, 10)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch stale valuations"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"dimension":       dimension,
+		"segments":        segments,
+		"topIncreases":    topIncreases,
+		"topDrops":        topDrops,
+		"staleValuations": staleValuations,
+	})
 }
 
 // Suggestions returns distinct values for autocomplete fields.

--- a/src/api/handlers/swagger_types.go
+++ b/src/api/handlers/swagger_types.go
@@ -162,8 +162,11 @@ type StatsResponse struct {
 }
 
 type InvestmentBreakdownResponse struct {
-	Dimension string                                  `json:"dimension" example:"purchase-month"`
-	Segments  []repository.InvestmentBreakdownSegment `json:"segments"`
+	Dimension       string                                  `json:"dimension" example:"purchase-month"`
+	Segments        []repository.InvestmentBreakdownSegment `json:"segments"`
+	TopIncreases    []repository.InvestmentMovementCoin     `json:"topIncreases"`
+	TopDrops        []repository.InvestmentMovementCoin     `json:"topDrops"`
+	StaleValuations []repository.StaleValuationCoin         `json:"staleValuations"`
 }
 
 type CategoryCount struct {

--- a/src/api/repository/coin_repository.go
+++ b/src/api/repository/coin_repository.go
@@ -129,6 +129,23 @@ type InvestmentBreakdownSegment struct {
 	MissingPurchasePriceCount int64   `json:"missingPurchasePriceCount"`
 }
 
+// InvestmentMovementCoin holds one coin's valuation movement from the first recorded valuation to current value.
+type InvestmentMovementCoin struct {
+	CoinID       uint    `json:"coinId"`
+	Name         string  `json:"name"`
+	InitialValue float64 `json:"initialValue"`
+	CurrentValue float64 `json:"currentValue"`
+	ChangeAmount float64 `json:"changeAmount"`
+	ChangePct    float64 `json:"changePct"`
+}
+
+// StaleValuationCoin holds one active coin ordered by valuation age.
+type StaleValuationCoin struct {
+	CoinID          uint       `json:"coinId"`
+	Name            string     `json:"name"`
+	LastValuationAt *time.Time `json:"lastValuationAt"`
+}
+
 // CoinRepository encapsulates all coin-related database operations.
 type CoinRepository struct {
 	db *gorm.DB
@@ -795,6 +812,74 @@ func (r *CoinRepository) getInvestmentBreakdownByMaterial(userID uint) ([]Invest
 		Order("invested DESC, label ASC").
 		Scan(&segments).Error
 	return segments, err
+}
+
+// GetTopInvestmentIncreases returns active coins with the largest positive movement since first valuation.
+func (r *CoinRepository) GetTopInvestmentIncreases(userID uint, limit int) ([]InvestmentMovementCoin, error) {
+	return r.getInvestmentMovementCoins(userID, limit, true)
+}
+
+// GetTopInvestmentDrops returns active coins with the largest negative movement since first valuation.
+func (r *CoinRepository) GetTopInvestmentDrops(userID uint, limit int) ([]InvestmentMovementCoin, error) {
+	return r.getInvestmentMovementCoins(userID, limit, false)
+}
+
+func (r *CoinRepository) getInvestmentMovementCoins(userID uint, limit int, increases bool) ([]InvestmentMovementCoin, error) {
+	if limit < 1 {
+		limit = 5
+	}
+	comparison := "c.current_value > first_value.value"
+	order := "change_amount DESC, c.id ASC"
+	if !increases {
+		comparison = "c.current_value < first_value.value"
+		order = "change_amount ASC, c.id ASC"
+	}
+
+	var coins []InvestmentMovementCoin
+	err := r.db.Raw(fmt.Sprintf(`
+		SELECT
+			c.id AS coin_id,
+			c.name AS name,
+			first_value.value AS initial_value,
+			c.current_value AS current_value,
+			c.current_value - first_value.value AS change_amount,
+			CASE
+				WHEN first_value.value = 0 THEN 0
+				ELSE ((c.current_value - first_value.value) / first_value.value) * 100
+			END AS change_pct
+		FROM coins c
+		JOIN coin_value_histories first_value ON first_value.id = (
+			SELECT cvh.id
+			FROM coin_value_histories cvh
+			WHERE cvh.coin_id = c.id AND cvh.user_id = c.user_id
+			ORDER BY cvh.recorded_at ASC, cvh.id ASC
+			LIMIT 1
+		)
+		WHERE c.user_id = ?
+			AND c.is_wishlist = ?
+			AND c.is_sold = ?
+			AND c.current_value IS NOT NULL
+			AND %s
+		ORDER BY %s
+		LIMIT ?`, comparison, order), userID, false, false, limit).Scan(&coins).Error
+	return coins, err
+}
+
+// GetStaleValuationCoins returns active coins with missing or oldest valuation timestamps first.
+func (r *CoinRepository) GetStaleValuationCoins(userID uint, limit int) ([]StaleValuationCoin, error) {
+	if limit < 1 {
+		limit = 10
+	}
+	var coins []StaleValuationCoin
+	err := r.db.Model(&models.Coin{}).
+		Select("id AS coin_id, name, current_value_updated_at AS last_valuation_at").
+		Scopes(ActiveCollection(userID)).
+		Order("current_value_updated_at IS NOT NULL ASC").
+		Order("current_value_updated_at ASC").
+		Order("id ASC").
+		Limit(limit).
+		Scan(&coins).Error
+	return coins, err
 }
 
 // validSuggestionColumns is the allowlist of columns permitted in Suggestions queries.

--- a/src/api/repository/coin_repository_test.go
+++ b/src/api/repository/coin_repository_test.go
@@ -433,6 +433,106 @@ func TestCoinRepository_GetInvestmentBreakdown_PurchaseMonthAggregatesConfidence
 	}
 }
 
+func TestCoinRepository_GetInvestmentMovementStats(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewCoinRepository(db)
+	now := time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC)
+	old := now.AddDate(-1, 0, 0)
+
+	coins := []models.Coin{
+		{Name: "Big Gainer", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1, CurrentValue: ptrFloat(300), CurrentValueUpdatedAt: ptrTime(now)},
+		{Name: "Small Gainer", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1, CurrentValue: ptrFloat(150), CurrentValueUpdatedAt: ptrTime(now)},
+		{Name: "Big Drop", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1, CurrentValue: ptrFloat(50), CurrentValueUpdatedAt: ptrTime(now)},
+		{Name: "Small Drop", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1, CurrentValue: ptrFloat(90), CurrentValueUpdatedAt: ptrTime(now)},
+		{Name: "Wishlist Excluded", Category: models.CategoryRoman, UserID: 1, IsWishlist: true, CurrentValue: ptrFloat(999), CurrentValueUpdatedAt: ptrTime(now)},
+		{Name: "Sold Excluded", Category: models.CategoryRoman, UserID: 1, IsSold: true, CurrentValue: ptrFloat(999), CurrentValueUpdatedAt: ptrTime(now)},
+		{Name: "Other User Excluded", Category: models.CategoryRoman, UserID: 2, CurrentValue: ptrFloat(999), CurrentValueUpdatedAt: ptrTime(now)},
+		{Name: "No History Excluded", Category: models.CategoryRoman, UserID: 1, CurrentValue: ptrFloat(999), CurrentValueUpdatedAt: ptrTime(now)},
+	}
+	for i := range coins {
+		if err := db.Create(&coins[i]).Error; err != nil {
+			t.Fatalf("Create coin %q failed: %v", coins[i].Name, err)
+		}
+	}
+
+	history := []models.CoinValueHistory{
+		{CoinID: coins[0].ID, UserID: 1, Value: 100, Confidence: "medium", RecordedAt: old},
+		{CoinID: coins[0].ID, UserID: 1, Value: 250, Confidence: "high", RecordedAt: now.Add(-time.Hour)},
+		{CoinID: coins[1].ID, UserID: 1, Value: 125, Confidence: "medium", RecordedAt: old},
+		{CoinID: coins[2].ID, UserID: 1, Value: 200, Confidence: "medium", RecordedAt: old},
+		{CoinID: coins[3].ID, UserID: 1, Value: 100, Confidence: "medium", RecordedAt: old},
+		{CoinID: coins[4].ID, UserID: 1, Value: 1, Confidence: "medium", RecordedAt: old},
+		{CoinID: coins[5].ID, UserID: 1, Value: 1, Confidence: "medium", RecordedAt: old},
+		{CoinID: coins[6].ID, UserID: 2, Value: 1, Confidence: "medium", RecordedAt: old},
+	}
+	for i := range history {
+		if err := db.Create(&history[i]).Error; err != nil {
+			t.Fatalf("Create value history failed: %v", err)
+		}
+	}
+
+	increases, err := repo.GetTopInvestmentIncreases(1, 5)
+	if err != nil {
+		t.Fatalf("GetTopInvestmentIncreases failed: %v", err)
+	}
+	if len(increases) != 2 || increases[0].Name != "Big Gainer" || increases[1].Name != "Small Gainer" {
+		t.Fatalf("unexpected increases: %#v", increases)
+	}
+	assertFloatNear(t, increases[0].InitialValue, 100)
+	assertFloatNear(t, increases[0].CurrentValue, 300)
+	assertFloatNear(t, increases[0].ChangeAmount, 200)
+
+	drops, err := repo.GetTopInvestmentDrops(1, 5)
+	if err != nil {
+		t.Fatalf("GetTopInvestmentDrops failed: %v", err)
+	}
+	if len(drops) != 2 || drops[0].Name != "Big Drop" || drops[1].Name != "Small Drop" {
+		t.Fatalf("unexpected drops: %#v", drops)
+	}
+	assertFloatNear(t, drops[0].InitialValue, 200)
+	assertFloatNear(t, drops[0].CurrentValue, 50)
+	assertFloatNear(t, drops[0].ChangeAmount, -150)
+}
+
+func TestCoinRepository_GetStaleValuationCoins(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewCoinRepository(db)
+	now := time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC)
+	oldest := now.AddDate(-1, 0, 0)
+	recent := now.Add(-24 * time.Hour)
+
+	coins := []models.Coin{
+		{Name: "Never Valued", Category: models.CategoryRoman, UserID: 1},
+		{Name: "Oldest Valuation", Category: models.CategoryRoman, UserID: 1, CurrentValueUpdatedAt: ptrTime(oldest)},
+		{Name: "Recent Valuation", Category: models.CategoryRoman, UserID: 1, CurrentValueUpdatedAt: ptrTime(recent)},
+		{Name: "Wishlist Excluded", Category: models.CategoryRoman, UserID: 1, IsWishlist: true},
+		{Name: "Sold Excluded", Category: models.CategoryRoman, UserID: 1, IsSold: true},
+		{Name: "Other User Excluded", Category: models.CategoryRoman, UserID: 2},
+	}
+	for i := range coins {
+		if err := db.Create(&coins[i]).Error; err != nil {
+			t.Fatalf("Create coin %q failed: %v", coins[i].Name, err)
+		}
+	}
+
+	stale, err := repo.GetStaleValuationCoins(1, 10)
+	if err != nil {
+		t.Fatalf("GetStaleValuationCoins failed: %v", err)
+	}
+	wantNames := []string{"Never Valued", "Oldest Valuation", "Recent Valuation"}
+	if len(stale) != len(wantNames) {
+		t.Fatalf("expected %d stale coins, got %d: %#v", len(wantNames), len(stale), stale)
+	}
+	for i, want := range wantNames {
+		if stale[i].Name != want {
+			t.Fatalf("stale coin %d = %q, want %q", i, stale[i].Name, want)
+		}
+	}
+	if stale[0].LastValuationAt != nil {
+		t.Fatalf("expected never-valued coin to have nil last valuation, got %v", stale[0].LastValuationAt)
+	}
+}
+
 func TestCoinRepository_List_RandomSort(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewCoinRepository(db)

--- a/src/web/src/pages/StatsInvestmentBreakdownPage.vue
+++ b/src/web/src/pages/StatsInvestmentBreakdownPage.vue
@@ -22,6 +22,58 @@
       </div>
 
       <template v-else>
+        <section class="investment-highlights-grid" aria-label="Investment valuation highlights">
+          <article class="stats-section card investment-highlight-card">
+            <div class="highlight-header">
+              <p class="section-label">Top Increases</p>
+              <h2>Biggest Value Gains</h2>
+            </div>
+            <ol v-if="topIncreases.length" class="highlight-list">
+              <li v-for="coin in topIncreases" :key="coin.coinId" class="highlight-row">
+                <router-link class="coin-link" :to="`/coin/${coin.coinId}`">{{ coin.name }}</router-link>
+                <div class="valuation-pair">
+                  <span>{{ formatCurrency(coin.initialValue) }}</span>
+                  <span class="arrow">to</span>
+                  <span class="gold">{{ formatCurrency(coin.currentValue) }}</span>
+                </div>
+              </li>
+            </ol>
+            <p v-else class="empty-copy">No valuation increases are available yet.</p>
+          </article>
+
+          <article class="stats-section card investment-highlight-card">
+            <div class="highlight-header">
+              <p class="section-label">Top Drops</p>
+              <h2>Biggest Value Declines</h2>
+            </div>
+            <ol v-if="topDrops.length" class="highlight-list">
+              <li v-for="coin in topDrops" :key="coin.coinId" class="highlight-row">
+                <router-link class="coin-link" :to="`/coin/${coin.coinId}`">{{ coin.name }}</router-link>
+                <div class="valuation-pair">
+                  <span>{{ formatCurrency(coin.initialValue) }}</span>
+                  <span class="arrow">to</span>
+                  <span class="loss">{{ formatCurrency(coin.currentValue) }}</span>
+                </div>
+              </li>
+            </ol>
+            <p v-else class="empty-copy">No valuation declines are available yet.</p>
+          </article>
+
+          <article class="stats-section card investment-highlight-card stale-card">
+            <div class="highlight-header">
+              <p class="section-label">Stale Valuations</p>
+              <h2>Needs Refresh</h2>
+            </div>
+            <ol v-if="staleValuations.length" class="highlight-list">
+              <li v-for="coin in staleValuations" :key="coin.coinId" class="highlight-row stale-row">
+                <router-link class="coin-link" :to="`/coin/${coin.coinId}/actions`">{{ coin.name }}</router-link>
+                <span class="last-run">{{ formatLastValuation(coin.lastValuationAt) }}</span>
+              </li>
+            </ol>
+            <p v-else class="empty-copy">No stale valuations are available.</p>
+          </article>
+        </section>
+
         <StatsInvestmentBreakdownChart
           title="Purchase Year to Month"
           eyebrow="Acquisition Timing"
@@ -46,12 +98,21 @@ import { ArrowLeft } from 'lucide-vue-next'
 import { getInvestmentBreakdown } from '@/api/client'
 import PullToRefresh from '@/components/PullToRefresh.vue'
 import StatsInvestmentBreakdownChart from '@/components/stats/StatsInvestmentBreakdownChart.vue'
-import type { InvestmentBreakdownResponse, InvestmentBreakdownSegment } from '@/types'
+import { formatCurrency } from '@/utils/format'
+import type {
+  InvestmentBreakdownResponse,
+  InvestmentBreakdownSegment,
+  InvestmentMovementCoin,
+  StaleValuationCoin,
+} from '@/types'
 
 const isLoading = ref(true)
 const errorMessage = ref('')
 const purchaseMonthRows = ref<InvestmentBreakdownSegment[]>([])
 const materialRows = ref<InvestmentBreakdownSegment[]>([])
+const topIncreases = ref<InvestmentMovementCoin[]>([])
+const topDrops = ref<InvestmentMovementCoin[]>([])
+const staleValuations = ref<StaleValuationCoin[]>([])
 
 function normalizeBreakdown(data: InvestmentBreakdownResponse): InvestmentBreakdownSegment[] {
   const rows = Array.isArray(data) ? data : data.segments ?? []
@@ -61,6 +122,23 @@ function normalizeBreakdown(data: InvestmentBreakdownResponse): InvestmentBreakd
     month: row.month ?? null,
     gainLossPct: row.gainLossPct ?? null,
   }))
+}
+
+function applyHighlights(data: InvestmentBreakdownResponse) {
+  if (Array.isArray(data)) {
+    topIncreases.value = []
+    topDrops.value = []
+    staleValuations.value = []
+    return
+  }
+  topIncreases.value = data.topIncreases ?? []
+  topDrops.value = data.topDrops ?? []
+  staleValuations.value = data.staleValuations ?? []
+}
+
+function formatLastValuation(value: string | null): string {
+  if (!value) return 'Never valued'
+  return new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
 async function loadBreakdowns() {
@@ -73,6 +151,7 @@ async function loadBreakdowns() {
     ])
     purchaseMonthRows.value = normalizeBreakdown(purchaseMonthRes.data)
     materialRows.value = normalizeBreakdown(materialRes.data)
+    applyHighlights(purchaseMonthRes.data)
   } catch {
     errorMessage.value = 'Investment breakdown data could not be loaded.'
   } finally {
@@ -141,10 +220,103 @@ onMounted(loadBreakdowns)
   margin: 0;
 }
 
+.investment-highlights-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.investment-highlight-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.highlight-header h2 {
+  margin: 0.25rem 0 0;
+  font-size: 1.2rem;
+}
+
+.highlight-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.highlight-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.coin-link {
+  color: var(--accent-gold);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.coin-link:hover {
+  text-decoration: underline;
+}
+
+.valuation-pair,
+.stale-row {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.valuation-pair {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.arrow,
+.last-run,
+.empty-copy {
+  color: var(--text-muted);
+}
+
+.gold {
+  color: var(--accent-gold);
+}
+
+.loss {
+  color: var(--cat-byzantine);
+}
+
+.empty-copy {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
 @media (max-width: 640px) {
+  .investment-highlights-grid {
+    grid-template-columns: 1fr;
+  }
+
   .error-card {
     flex-direction: column;
     align-items: stretch;
+  }
+}
+
+@media (min-width: 641px) and (max-width: 1024px) {
+  .investment-highlights-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stale-card {
+    grid-column: 1 / -1;
   }
 }
 </style>

--- a/src/web/src/pages/__tests__/StatsInvestmentBreakdownPage.test.ts
+++ b/src/web/src/pages/__tests__/StatsInvestmentBreakdownPage.test.ts
@@ -35,7 +35,21 @@ describe('StatsInvestmentBreakdownPage', () => {
     mockGetInvestmentBreakdown.mockReset()
     mockGetInvestmentBreakdown.mockImplementation((dimension: string) => {
       if (dimension === 'purchase-month') {
-        return Promise.resolve({ data: [segment('2024-01', { year: 2024, month: 1 })] })
+        return Promise.resolve({
+          data: {
+            segments: [segment('2024-01', { year: 2024, month: 1 })],
+            topIncreases: [
+              { coinId: 11, name: 'Aureus of Hadrian', initialValue: 1000, currentValue: 1800, changeAmount: 800, changePct: 80 },
+            ],
+            topDrops: [
+              { coinId: 12, name: 'Denarius of Trajan', initialValue: 500, currentValue: 350, changeAmount: -150, changePct: -30 },
+            ],
+            staleValuations: [
+              { coinId: 13, name: 'Stale Sestertius', lastValuationAt: '2025-01-02T12:00:00Z' },
+              { coinId: 14, name: 'Never Valued Drachm', lastValuationAt: null },
+            ],
+          },
+        })
       }
       return Promise.resolve({ data: { segments: [segment('Silver')] } })
     })
@@ -54,6 +68,33 @@ describe('StatsInvestmentBreakdownPage', () => {
     expect(wrapper.text()).toContain('Material')
     expect(wrapper.text()).toContain('2024 Jan')
     expect(wrapper.text()).toContain('Silver')
+  })
+
+  it('renders valuation movement and stale valuation links', async () => {
+    const wrapper = mount(StatsInvestmentBreakdownPage, {
+      global: { stubs: defaultStubs },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Biggest Value Gains')
+    expect(wrapper.text()).toContain('Aureus of Hadrian')
+    expect(wrapper.text()).toContain('$1,000.00')
+    expect(wrapper.text()).toContain('$1,800.00')
+    expect(wrapper.find('a[href="/coin/11"]').exists()).toBe(true)
+
+    expect(wrapper.text()).toContain('Biggest Value Declines')
+    expect(wrapper.text()).toContain('Denarius of Trajan')
+    expect(wrapper.text()).toContain('$500.00')
+    expect(wrapper.text()).toContain('$350.00')
+    expect(wrapper.find('a[href="/coin/12"]').exists()).toBe(true)
+
+    expect(wrapper.text()).toContain('Needs Refresh')
+    expect(wrapper.text()).toContain('Stale Sestertius')
+    expect(wrapper.text()).toContain('Jan 2, 2025')
+    expect(wrapper.text()).toContain('Never Valued Drachm')
+    expect(wrapper.text()).toContain('Never valued')
+    expect(wrapper.find('a[href="/coin/13/actions"]').exists()).toBe(true)
+    expect(wrapper.find('a[href="/coin/14/actions"]').exists()).toBe(true)
   })
 
   it('renders confidence callouts from missing-value counts returned by the API', async () => {

--- a/src/web/src/types/index.ts
+++ b/src/web/src/types/index.ts
@@ -834,9 +834,30 @@ export interface InvestmentBreakdownSegment {
   missingPurchasePriceCount: number
 }
 
+export interface InvestmentMovementCoin {
+  coinId: number
+  name: string
+  initialValue: number
+  currentValue: number
+  changeAmount: number
+  changePct: number
+}
+
+export interface StaleValuationCoin {
+  coinId: number
+  name: string
+  lastValuationAt: string | null
+}
+
 export type InvestmentBreakdownResponse =
   | InvestmentBreakdownSegment[]
-  | { dimension?: InvestmentBreakdownDimension; segments: InvestmentBreakdownSegment[] }
+  | {
+      dimension?: InvestmentBreakdownDimension
+      segments: InvestmentBreakdownSegment[]
+      topIncreases?: InvestmentMovementCoin[]
+      topDrops?: InvestmentMovementCoin[]
+      staleValuations?: StaleValuationCoin[]
+    }
 
 export type HealthGrade = 'A' | 'B' | 'C' | 'D' | 'F'
 export type HealthTrendDirection = 'up' | 'flat' | 'down' | 'unavailable'


### PR DESCRIPTION
## Summary
- Add Investment Breakdown highlight cards for the 5 biggest valuation increases, 5 biggest valuation drops, and 10 stalest valuations.
- Extend /stats/investment-breakdown with 	opIncreases, 	opDrops, and staleValuations while preserving the existing segment response.
- Link movement rows to coin details and stale valuation rows to each coin's Actions page so valuation can be rerun.
- Regenerate OpenAPI docs for the expanded response contract.
- Update the Go API toolchain to 1.26.5 on beta to clear Govulncheck GO-2026-5856.

## Implementation details
- Movement rankings compare each active coin's current value against its first recorded coin_value_histories valuation.
- Stale valuation rankings use active collection coins only and order never-valued coins first, then oldest current_value_updated_at, matching the collection valuation scheduler priority.
- Excludes wishlist and sold coins from all three highlight lists.
- The explanatory one-sentence value-change text is intentionally deferred to #424 so it can be stored durably in valuation run history instead of inferred in the frontend.

## Validation
- go test ./... from src/api
- 
pm.cmd run type-check from src/web
- 
pm.cmd run test -- StatsInvestmentBreakdownPage.test.ts --run from src/web

## Constitution
- Principle IV + §17