### PR TITLE
feat: simplify investment breakdown layouts

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11579,7 +11579,7 @@
                 "parameters": [
                     {
                         "enum": [
-                            "purchase-month",
+                            "purchase-year",
                             "material"
                         ],
                         "type": "string",
@@ -14882,7 +14882,7 @@
             "properties": {
                 "dimension": {
                     "type": "string",
-                    "example": "purchase-month"
+                    "example": "purchase-year"
                 },
                 "segments": {
                     "type": "array",

--- a/src/api/docs/docs.go
+++ b/src/api/docs/docs.go
@@ -11586,7 +11586,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "enum": [
-                            "purchase-month",
+                            "purchase-year",
                             "material"
                         ],
                         "type": "string",
@@ -14889,7 +14889,7 @@ const docTemplate = `{
             "properties": {
                 "dimension": {
                     "type": "string",
-                    "example": "purchase-month"
+                    "example": "purchase-year"
                 },
                 "segments": {
                     "type": "array",

--- a/src/api/docs/swagger.json
+++ b/src/api/docs/swagger.json
@@ -11579,7 +11579,7 @@
                 "parameters": [
                     {
                         "enum": [
-                            "purchase-month",
+                            "purchase-year",
                             "material"
                         ],
                         "type": "string",
@@ -14882,7 +14882,7 @@
             "properties": {
                 "dimension": {
                     "type": "string",
-                    "example": "purchase-month"
+                    "example": "purchase-year"
                 },
                 "segments": {
                     "type": "array",

--- a/src/api/docs/swagger.yaml
+++ b/src/api/docs/swagger.yaml
@@ -646,7 +646,7 @@ definitions:
   handlers.InvestmentBreakdownResponse:
     properties:
       dimension:
-        example: purchase-month
+        example: purchase-year
         type: string
       segments:
         items:
@@ -10357,7 +10357,7 @@ paths:
       parameters:
       - description: Breakdown dimension
         enum:
-        - purchase-month
+        - purchase-year
         - material
         in: query
         name: dimension

--- a/src/api/handlers/coin_handler_test.go
+++ b/src/api/handlers/coin_handler_test.go
@@ -1485,7 +1485,7 @@ func TestCoinHandler_Unauthenticated(t *testing.T) {
 
 // --- Investment breakdown ---
 
-func TestCoinHandler_InvestmentBreakdown_PurchaseMonth(t *testing.T) {
+func TestCoinHandler_InvestmentBreakdown_PurchaseYear(t *testing.T) {
 	router, db := setupCoinHandlerRouter(t)
 	createTestUser(t, db, 1, "investor")
 	createTestUser(t, db, 2, "other")
@@ -1506,7 +1506,7 @@ func TestCoinHandler_InvestmentBreakdown_PurchaseMonth(t *testing.T) {
 		t.Fatalf("failed to seed investment coins: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/stats/investment-breakdown?dimension=purchase-month", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/stats/investment-breakdown?dimension=purchase-year", nil)
 	req.Header.Set("Authorization", authHeader(1))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -1521,14 +1521,14 @@ func TestCoinHandler_InvestmentBreakdown_PurchaseMonth(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if resp.Dimension != repository.InvestmentBreakdownPurchaseMonth {
+	if resp.Dimension != repository.InvestmentBreakdownPurchaseYear {
 		t.Fatalf("unexpected dimension %q", resp.Dimension)
 	}
 	if len(resp.Segments) != 1 {
-		t.Fatalf("expected 1 purchase-month segment, got %d: %#v", len(resp.Segments), resp.Segments)
+		t.Fatalf("expected 1 purchase-year segment, got %d: %#v", len(resp.Segments), resp.Segments)
 	}
 	segment := resp.Segments[0]
-	if segment.Label != "Jan 2024" || segment.Year == nil || *segment.Year != 2024 || segment.Month == nil || *segment.Month != 1 {
+	if segment.Label != "2024" || segment.Year == nil || *segment.Year != 2024 || segment.Month != nil {
 		t.Fatalf("unexpected purchase label/date fields: %#v", segment)
 	}
 	if segment.CoinCount != 2 || segment.MissingCurrentValueCount != 1 || segment.MissingPurchasePriceCount != 0 {

--- a/src/api/handlers/coins.go
+++ b/src/api/handlers/coins.go
@@ -585,7 +585,7 @@ func (h *CoinHandler) Distribution(c *gin.Context) {
 //	@Description	Returns investment, current value, gain/loss, confidence counts, top valuation movement, and stale valuations for the authenticated user's active collection.
 //	@Tags			Coins
 //	@Produce		json
-//	@Param			dimension	query		string	true	"Breakdown dimension"	Enums(purchase-month, material)
+//	@Param			dimension	query		string	true	"Breakdown dimension"	Enums(purchase-year, material)
 //	@Success		200			{object}	InvestmentBreakdownResponse
 //	@Failure		400			{object}	ErrorResponse
 //	@Failure		401			{object}	ErrorResponse
@@ -596,9 +596,9 @@ func (h *CoinHandler) InvestmentBreakdown(c *gin.Context) {
 	userID := c.GetUint("userId")
 	dimension := c.Query("dimension")
 	switch dimension {
-	case repository.InvestmentBreakdownPurchaseMonth, repository.InvestmentBreakdownMaterial:
+	case repository.InvestmentBreakdownPurchaseYear, repository.InvestmentBreakdownMaterial:
 	default:
-		c.JSON(http.StatusBadRequest, gin.H{"error": "dimension must be one of: purchase-month, material"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "dimension must be one of: purchase-year, material"})
 		return
 	}
 
@@ -617,7 +617,7 @@ func (h *CoinHandler) InvestmentBreakdown(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch investment movement"})
 		return
 	}
-	staleValuations, err := h.repo.GetStaleValuationCoins(userID, 10)
+	staleValuations, err := h.repo.GetStaleValuationCoins(userID, 5)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch stale valuations"})
 		return

--- a/src/api/handlers/swagger_types.go
+++ b/src/api/handlers/swagger_types.go
@@ -162,7 +162,7 @@ type StatsResponse struct {
 }
 
 type InvestmentBreakdownResponse struct {
-	Dimension       string                                  `json:"dimension" example:"purchase-month"`
+	Dimension       string                                  `json:"dimension" example:"purchase-year"`
 	Segments        []repository.InvestmentBreakdownSegment `json:"segments"`
 	TopIncreases    []repository.InvestmentMovementCoin     `json:"topIncreases"`
 	TopDrops        []repository.InvestmentMovementCoin     `json:"topDrops"`

--- a/src/api/repository/coin_repository.go
+++ b/src/api/repository/coin_repository.go
@@ -111,8 +111,8 @@ type DistributionCell struct {
 }
 
 const (
-	InvestmentBreakdownPurchaseMonth = "purchase-month"
-	InvestmentBreakdownMaterial      = "material"
+	InvestmentBreakdownPurchaseYear = "purchase-year"
+	InvestmentBreakdownMaterial     = "material"
 )
 
 // InvestmentBreakdownSegment holds one portfolio investment chart segment.
@@ -751,8 +751,8 @@ func (r *CoinRepository) GetDistribution(userID uint) ([]DistributionCell, error
 // GetInvestmentBreakdown returns active-collection investment aggregates for the requested dimension.
 func (r *CoinRepository) GetInvestmentBreakdown(userID uint, dimension string) ([]InvestmentBreakdownSegment, error) {
 	switch dimension {
-	case InvestmentBreakdownPurchaseMonth:
-		return r.getInvestmentBreakdownByPurchaseMonth(userID)
+	case InvestmentBreakdownPurchaseYear:
+		return r.getInvestmentBreakdownByPurchaseYear(userID)
 	case InvestmentBreakdownMaterial:
 		return r.getInvestmentBreakdownByMaterial(userID)
 	default:
@@ -760,12 +760,11 @@ func (r *CoinRepository) GetInvestmentBreakdown(userID uint, dimension string) (
 	}
 }
 
-func (r *CoinRepository) getInvestmentBreakdownByPurchaseMonth(userID uint) ([]InvestmentBreakdownSegment, error) {
+func (r *CoinRepository) getInvestmentBreakdownByPurchaseYear(userID uint) ([]InvestmentBreakdownSegment, error) {
 	var segments []InvestmentBreakdownSegment
 	err := r.db.Model(&models.Coin{}).
 		Select(`
 			CAST(strftime('%Y', purchase_date) AS INTEGER) AS year,
-			CAST(strftime('%m', purchase_date) AS INTEGER) AS month,
 			COALESCE(SUM(purchase_price), 0) AS invested,
 			COALESCE(SUM(COALESCE(current_value, purchase_price, 0)), 0) AS current_value,
 			COALESCE(SUM(COALESCE(current_value, purchase_price, 0)), 0) - COALESCE(SUM(purchase_price), 0) AS gain_loss,
@@ -778,15 +777,15 @@ func (r *CoinRepository) getInvestmentBreakdownByPurchaseMonth(userID uint) ([]I
 			SUM(CASE WHEN purchase_price IS NULL THEN 1 ELSE 0 END) AS missing_purchase_price_count`).
 		Scopes(ActiveCollection(userID)).
 		Where("purchase_date IS NOT NULL").
-		Group("year, month").
-		Order("year ASC, month ASC").
+		Group("year").
+		Order("year ASC").
 		Scan(&segments).Error
 	if err != nil {
 		return nil, err
 	}
 	for i := range segments {
-		if segments[i].Year != nil && segments[i].Month != nil {
-			segments[i].Label = fmt.Sprintf("%s %04d", time.Month(*segments[i].Month).String()[:3], *segments[i].Year)
+		if segments[i].Year != nil {
+			segments[i].Label = fmt.Sprintf("%04d", *segments[i].Year)
 		}
 	}
 	return segments, nil

--- a/src/api/repository/coin_repository_test.go
+++ b/src/api/repository/coin_repository_test.go
@@ -386,16 +386,18 @@ func TestCoinRepository_GetInvestmentBreakdown_MaterialAggregatesConfidenceCount
 	}
 }
 
-func TestCoinRepository_GetInvestmentBreakdown_PurchaseMonthAggregatesConfidenceCounts(t *testing.T) {
+func TestCoinRepository_GetInvestmentBreakdown_PurchaseYearAggregatesConfidenceCounts(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewCoinRepository(db)
 	jan := time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC)
 	feb := time.Date(2024, time.February, 20, 0, 0, 0, 0, time.UTC)
+	nextYear := time.Date(2025, time.March, 20, 0, 0, 0, 0, time.UTC)
 
 	coins := []models.Coin{
 		{Name: "Jan Valued", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1, PurchasePrice: ptrFloat(100), CurrentValue: ptrFloat(120), PurchaseDate: ptrTime(jan)},
 		{Name: "Jan Missing Current", Category: models.CategoryRoman, Material: models.MaterialSilver, UserID: 1, PurchasePrice: ptrFloat(200), CurrentValue: nil, PurchaseDate: ptrTime(jan)},
 		{Name: "Feb Missing Cost", Category: models.CategoryRoman, Material: models.MaterialGold, UserID: 1, PurchasePrice: nil, CurrentValue: ptrFloat(80), PurchaseDate: ptrTime(feb)},
+		{Name: "Next Year", Category: models.CategoryRoman, Material: models.MaterialGold, UserID: 1, PurchasePrice: ptrFloat(50), CurrentValue: ptrFloat(75), PurchaseDate: ptrTime(nextYear)},
 		{Name: "No Date Excluded", Category: models.CategoryRoman, Material: models.MaterialGold, UserID: 1, PurchasePrice: ptrFloat(999), CurrentValue: ptrFloat(999)},
 	}
 	for i := range coins {
@@ -404,32 +406,32 @@ func TestCoinRepository_GetInvestmentBreakdown_PurchaseMonthAggregatesConfidence
 		}
 	}
 
-	segments, err := repo.GetInvestmentBreakdown(1, InvestmentBreakdownPurchaseMonth)
+	segments, err := repo.GetInvestmentBreakdown(1, InvestmentBreakdownPurchaseYear)
 	if err != nil {
 		t.Fatalf("GetInvestmentBreakdown failed: %v", err)
 	}
 	if len(segments) != 2 {
-		t.Fatalf("expected 2 purchase-month segments, got %d: %#v", len(segments), segments)
+		t.Fatalf("expected 2 purchase-year segments, got %d: %#v", len(segments), segments)
 	}
 
-	janSegment := segments[0]
-	if janSegment.Label != "Jan 2024" || janSegment.Year == nil || *janSegment.Year != 2024 || janSegment.Month == nil || *janSegment.Month != 1 {
-		t.Fatalf("unexpected January label/date fields: %#v", janSegment)
+	year2024 := segments[0]
+	if year2024.Label != "2024" || year2024.Year == nil || *year2024.Year != 2024 || year2024.Month != nil {
+		t.Fatalf("unexpected 2024 label/date fields: %#v", year2024)
 	}
-	assertFloatNear(t, janSegment.Invested, 300)
-	assertFloatNear(t, janSegment.CurrentValue, 320)
-	if janSegment.CoinCount != 2 || janSegment.MissingCurrentValueCount != 1 || janSegment.MissingPurchasePriceCount != 0 {
-		t.Fatalf("unexpected January counts: coin=%d missingCurrent=%d missingPurchase=%d", janSegment.CoinCount, janSegment.MissingCurrentValueCount, janSegment.MissingPurchasePriceCount)
+	assertFloatNear(t, year2024.Invested, 300)
+	assertFloatNear(t, year2024.CurrentValue, 400)
+	if year2024.CoinCount != 3 || year2024.MissingCurrentValueCount != 1 || year2024.MissingPurchasePriceCount != 1 {
+		t.Fatalf("unexpected 2024 counts: coin=%d missingCurrent=%d missingPurchase=%d", year2024.CoinCount, year2024.MissingCurrentValueCount, year2024.MissingPurchasePriceCount)
 	}
 
-	febSegment := segments[1]
-	if febSegment.Label != "Feb 2024" || febSegment.Year == nil || *febSegment.Year != 2024 || febSegment.Month == nil || *febSegment.Month != 2 {
-		t.Fatalf("unexpected February label/date fields: %#v", febSegment)
+	year2025 := segments[1]
+	if year2025.Label != "2025" || year2025.Year == nil || *year2025.Year != 2025 || year2025.Month != nil {
+		t.Fatalf("unexpected 2025 label/date fields: %#v", year2025)
 	}
-	assertFloatNear(t, febSegment.Invested, 0)
-	assertFloatNear(t, febSegment.CurrentValue, 80)
-	if febSegment.CoinCount != 1 || febSegment.MissingCurrentValueCount != 0 || febSegment.MissingPurchasePriceCount != 1 {
-		t.Fatalf("unexpected February counts: coin=%d missingCurrent=%d missingPurchase=%d", febSegment.CoinCount, febSegment.MissingCurrentValueCount, febSegment.MissingPurchasePriceCount)
+	assertFloatNear(t, year2025.Invested, 50)
+	assertFloatNear(t, year2025.CurrentValue, 75)
+	if year2025.CoinCount != 1 || year2025.MissingCurrentValueCount != 0 || year2025.MissingPurchasePriceCount != 0 {
+		t.Fatalf("unexpected 2025 counts: coin=%d missingCurrent=%d missingPurchase=%d", year2025.CoinCount, year2025.MissingCurrentValueCount, year2025.MissingPurchasePriceCount)
 	}
 }
 

--- a/src/web/src/api/__tests__/client.test.ts
+++ b/src/web/src/api/__tests__/client.test.ts
@@ -578,9 +578,9 @@ describe('API Client', () => {
 
     it('getInvestmentBreakdown sends GET with dimension param', async () => {
       mockApi.get.mockResolvedValue({ data: [] })
-      await client.getInvestmentBreakdown('purchase-month')
+      await client.getInvestmentBreakdown('purchase-year')
       expect(mockApi.get).toHaveBeenCalledWith('/stats/investment-breakdown', {
-        params: { dimension: 'purchase-month' },
+        params: { dimension: 'purchase-year' },
       })
     })
 

--- a/src/web/src/components/stats/StatsInvestmentBreakdownChart.vue
+++ b/src/web/src/components/stats/StatsInvestmentBreakdownChart.vue
@@ -1,10 +1,10 @@
 <template>
-  <section class="stats-section card investment-chart-card">
-    <div class="investment-chart-header">
+  <section class="stats-section card investment-table-card">
+    <div class="investment-table-header">
       <div>
         <p class="section-label">{{ eyebrow }}</p>
         <h2>{{ title }}</h2>
-        <p v-if="description" class="chart-description">{{ description }}</p>
+        <p v-if="description" class="table-description">{{ description }}</p>
       </div>
       <span v-if="rows.length" class="coin-count">{{ totalCoinCount }} coins</span>
     </div>
@@ -30,7 +30,7 @@
           </strong>
         </div>
         <div class="summary-pill">
-          <span class="summary-label">Return</span>
+          <span class="summary-label">ROI</span>
           <strong :class="summaryGainLossPct >= 0 ? 'positive' : 'negative'">
             {{ summaryGainLossPct >= 0 ? '+' : '' }}{{ summaryGainLossPct.toFixed(1) }}%
           </strong>
@@ -44,116 +44,52 @@
         </p>
       </div>
 
-      <div class="chart-legend" aria-label="Chart legend">
-        <span class="legend-item"><span class="legend-swatch legend-invested"></span> Invested flow</span>
-        <span class="legend-item"><span class="legend-swatch legend-current"></span> Current value marker</span>
-      </div>
-
-      <ZoomableSurface
-        class="flow-layout"
-        :aria-label="`Zoomable ${title} investment flow chart. Use controls, wheel, pinch, drag, or keyboard shortcuts to inspect segments.`"
-      >
-        <svg
-          :viewBox="`0 0 ${SVG_W} ${svgHeight}`"
-          preserveAspectRatio="xMidYMid meet"
-          class="investment-flow-svg"
-          role="img"
-          :aria-label="`${title} flow chart showing invested amount by segment`"
-        >
-          <defs>
-            <linearGradient :id="gradientId" x1="0" x2="1" y1="0" y2="0">
-              <stop offset="0%" stop-color="var(--accent-gold)" stop-opacity="0.45" />
-              <stop offset="100%" stop-color="var(--accent-bronze)" stop-opacity="0.25" />
-            </linearGradient>
-          </defs>
-
-          <rect
-            class="total-node"
-            :x="TOTAL_X"
-            :y="totalNode.y"
-            :width="NODE_W"
-            :height="totalNode.height"
-          />
-          <text
-            class="node-label node-label-left"
-            :x="TOTAL_X - 10"
-            :y="totalNode.y + totalNode.height / 2"
-            dominant-baseline="middle"
-            text-anchor="end"
-          >
-            Total invested
-          </text>
-
-          <path
-            v-for="band in flowBands"
-            :key="band.key"
-            class="flow-band"
-            :d="flowPath(band)"
-            :fill="`url(#${gradientId})`"
-          />
-
-          <g v-for="node in segmentNodes" :key="node.key">
-            <rect
-              class="segment-node"
-              :x="SEGMENT_X"
-              :y="node.y"
-              :width="NODE_W"
-              :height="node.height"
-              :fill="node.color"
-            />
-            <line
-              class="current-value-marker"
-              :x1="SEGMENT_X + NODE_W + 8"
-              :x2="SEGMENT_X + NODE_W + 8 + currentMarkerWidth(node.row)"
-              :y1="node.y + node.height / 2"
-              :y2="node.y + node.height / 2"
-            />
-            <text
-              class="node-label node-label-right"
-              :x="SEGMENT_X + NODE_W + 14"
-              :y="node.y + Math.max(node.height / 2 - 7, 0)"
-              dominant-baseline="middle"
-            >
-              {{ node.label }}
-            </text>
-            <text
-              class="node-value"
-              :x="SEGMENT_X + NODE_W + 14"
-              :y="node.y + node.height / 2 + 9"
-              dominant-baseline="middle"
-            >
-              {{ formatCurrency(node.row.invested) }} invested · {{ formatCurrency(node.row.currentValue) }} current
-            </text>
-          </g>
-        </svg>
-      </ZoomableSurface>
-
-      <div class="mobile-aggregate-summary" aria-label="Investment aggregate summary">
-        Invested: {{ formatCurrency(totals.invested) }} · Current: {{ formatCurrency(totals.currentValue) }} ·
-        <span :class="totals.gainLoss >= 0 ? 'positive' : 'negative'">
-          Gain/Loss: {{ totals.gainLoss >= 0 ? '+' : '' }}{{ formatCurrency(totals.gainLoss) }} ({{ summaryGainLossPct >= 0 ? '+' : '' }}{{ summaryGainLossPct.toFixed(1) }}%)
-        </span>
-      </div>
-
-      <div class="segment-list" aria-label="Investment breakdown segments">
+      <div class="investment-row-list" aria-label="Investment performance rows">
         <article
           v-for="row in displayRows"
           :key="rowKey(row)"
-          class="segment-card"
+          class="investment-row"
         >
-          <div class="segment-card-heading">
-            <span class="segment-name">{{ formatSegmentLabel(row) }}</span>
-            <span class="chip-sm">{{ row.coinCount }} coins</span>
-          </div>
-          <div class="segment-values">
-            <span><strong>{{ formatCurrency(row.invested) }}</strong> invested</span>
-            <span><strong class="gold">{{ formatCurrency(row.currentValue) }}</strong> current</span>
-            <span :class="row.gainLoss >= 0 ? 'positive' : 'negative'">
-              {{ row.gainLoss >= 0 ? '+' : '' }}{{ formatCurrency(row.gainLoss) }}
-              <template v-if="row.gainLossPct !== null">
-                ({{ row.gainLossPct >= 0 ? '+' : '' }}{{ row.gainLossPct.toFixed(1) }}%)
-              </template>
+          <div class="row-main">
+            <div>
+              <h3>{{ formatSegmentLabel(row) }}</h3>
+              <p>{{ row.coinCount }} coins</p>
+            </div>
+            <span class="roi-pill" :class="row.gainLoss >= 0 ? 'positive-bg' : 'negative-bg'">
+              {{ row.gainLoss >= 0 ? '+' : '' }}{{ normalizedPct(row).toFixed(1) }}%
             </span>
+          </div>
+
+          <div class="value-grid">
+            <div>
+              <span class="value-label">Invested</span>
+              <strong>{{ formatCurrency(row.invested) }}</strong>
+            </div>
+            <div>
+              <span class="value-label">Current</span>
+              <strong class="gold">{{ formatCurrency(row.currentValue) }}</strong>
+            </div>
+            <div>
+              <span class="value-label">Gain / Loss</span>
+              <strong :class="row.gainLoss >= 0 ? 'positive' : 'negative'">
+                {{ row.gainLoss >= 0 ? '+' : '' }}{{ formatCurrency(row.gainLoss) }}
+              </strong>
+            </div>
+          </div>
+
+          <div class="allocation-bars" aria-hidden="true">
+            <div class="bar-row">
+              <span>Invested</span>
+              <div class="bar-track">
+                <span class="bar-fill invested" :style="{ width: `${barWidth(row.invested, maxInvested)}%` }"></span>
+              </div>
+            </div>
+            <div class="bar-row">
+              <span>Current</span>
+              <div class="bar-track">
+                <span class="bar-fill current" :style="{ width: `${barWidth(row.currentValue, maxCurrentValue)}%` }"></span>
+              </div>
+            </div>
           </div>
         </article>
       </div>
@@ -163,26 +99,8 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import ZoomableSurface from '@/components/ZoomableSurface.vue'
 import { formatCurrency } from '@/utils/format'
 import type { InvestmentBreakdownSegment } from '@/types'
-
-interface SegmentNode {
-  key: string
-  label: string
-  row: InvestmentBreakdownSegment
-  y: number
-  height: number
-  sourceY: number
-  color: string
-}
-
-interface FlowBand {
-  key: string
-  y0: number
-  y1: number
-  height: number
-}
 
 const props = defineProps<{
   title: string
@@ -191,228 +109,133 @@ const props = defineProps<{
   rows: InvestmentBreakdownSegment[]
 }>()
 
-const SVG_W = 760
-const TOTAL_X = 95
-const SEGMENT_X = 405
-const NODE_W = 16
-const CHART_TOP = 24
-const NODE_GAP = 10
-const MIN_NODE_H = 10
-const PALETTE = [
-  'var(--accent-gold)',
-  'var(--accent-bronze)',
-  'var(--cat-roman)',
-  'var(--cat-greek)',
-  'var(--cat-byzantine)',
-  'var(--cat-modern)',
-  'var(--mat-silver)',
-  'var(--mat-bronze)',
-]
-const MATERIAL_COLORS: Record<string, string> = {
-  gold: 'var(--mat-gold)',
-  silver: 'var(--mat-silver)',
-  bronze: 'var(--mat-bronze)',
-  copper: 'var(--accent-bronze)',
-  electrum: 'var(--accent-gold)',
-  other: 'var(--text-secondary)',
-}
-const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'] as const
+const displayRows = computed(() => props.rows)
 
-const gradientId = computed(() => `investmentFlowGradient-${props.title.replace(/\W+/g, '-')}`)
-const displayRows = computed(() =>
-  [...props.rows]
-    .filter((row) => row.coinCount > 0)
-    .sort((a, b) => {
-      if (a.year == null && b.year != null) return 1
-      if (a.year != null && b.year == null) return -1
-      if (a.year != null && b.year != null && a.year !== b.year) return a.year - b.year
-      if (a.month == null && b.month != null) return 1
-      if (a.month != null && b.month == null) return -1
-      if (a.month != null && b.month != null && a.month !== b.month) return a.month - b.month
-      return b.invested - a.invested
-    }),
-)
-const totalCoinCount = computed(() => displayRows.value.reduce((sum, row) => sum + row.coinCount, 0))
-const totals = computed(() =>
-  displayRows.value.reduce(
-    (sum, row) => ({
-      invested: sum.invested + row.invested,
-      currentValue: sum.currentValue + row.currentValue,
-      gainLoss: sum.gainLoss + row.gainLoss,
-      missingCurrentValueCount: sum.missingCurrentValueCount + row.missingCurrentValueCount,
-      missingPurchasePriceCount: sum.missingPurchasePriceCount + row.missingPurchasePriceCount,
-    }),
-    { invested: 0, currentValue: 0, gainLoss: 0, missingCurrentValueCount: 0, missingPurchasePriceCount: 0 },
-  ),
-)
+const totalCoinCount = computed(() => props.rows.reduce((sum, row) => sum + row.coinCount, 0))
+
+const totals = computed(() => props.rows.reduce(
+  (acc, row) => ({
+    invested: acc.invested + row.invested,
+    currentValue: acc.currentValue + row.currentValue,
+    gainLoss: acc.gainLoss + row.gainLoss,
+  }),
+  { invested: 0, currentValue: 0, gainLoss: 0 },
+))
+
 const summaryGainLossPct = computed(() => {
-  if (!totals.value.invested) return 0
+  if (totals.value.invested === 0) return 0
   return (totals.value.gainLoss / totals.value.invested) * 100
 })
-const hasMissingValues = computed(
-  () => totals.value.missingCurrentValueCount > 0 || totals.value.missingPurchasePriceCount > 0,
-)
+
+const maxInvested = computed(() => Math.max(...props.rows.map((row) => row.invested), 0))
+const maxCurrentValue = computed(() => Math.max(...props.rows.map((row) => row.currentValue), 0))
+
+const hasMissingValues = computed(() => props.rows.some(
+  (row) => row.missingCurrentValueCount > 0 || row.missingPurchasePriceCount > 0,
+))
+
 const missingValueSummary = computed(() => {
+  const missingPurchase = props.rows.reduce((sum, row) => sum + row.missingPurchasePriceCount, 0)
+  const missingCurrent = props.rows.reduce((sum, row) => sum + row.missingCurrentValueCount, 0)
   const parts: string[] = []
-  if (totals.value.missingPurchasePriceCount) {
-    parts.push(`${totals.value.missingPurchasePriceCount} missing purchase price`)
-  }
-  if (totals.value.missingCurrentValueCount) {
-    parts.push(`${totals.value.missingCurrentValueCount} missing current value`)
-  }
+  if (missingPurchase > 0) parts.push(`${missingPurchase} missing purchase price${missingPurchase === 1 ? '' : 's'}`)
+  if (missingCurrent > 0) parts.push(`${missingCurrent} missing current value${missingCurrent === 1 ? '' : 's'}`)
   return parts.join(' and ')
 })
-const maxCurrentValue = computed(() => Math.max(1, ...displayRows.value.map((row) => row.currentValue)))
-const svgHeight = computed(() => Math.max(240, CHART_TOP * 2 + displayRows.value.length * (MIN_NODE_H + NODE_GAP) + 90))
-const chartHeight = computed(() => svgHeight.value - CHART_TOP * 2)
-const investedScale = computed(() => {
-  const gapTotal = Math.max(0, displayRows.value.length - 1) * NODE_GAP
-  const available = Math.max(80, chartHeight.value - gapTotal)
-  return totals.value.invested ? available / totals.value.invested : 1
-})
-const totalNode = computed(() => ({
-  y: CHART_TOP,
-  height: Math.max(80, displayRows.value.reduce((sum, row) => sum + Math.max(MIN_NODE_H, row.invested * investedScale.value), 0)),
-}))
-const segmentNodes = computed<SegmentNode[]>(() => {
-  let y = CHART_TOP
-  let sourceY = totalNode.value.y
-  return displayRows.value.map((row, index) => {
-    const height = Math.max(MIN_NODE_H, row.invested * investedScale.value)
-    const node: SegmentNode = {
-      key: rowKey(row),
-      label: formatSegmentLabel(row),
-      row,
-      y,
-      height,
-      sourceY,
-      color: colorForRow(row, index),
-    }
-    y += height + NODE_GAP
-    sourceY += height
-    return node
-  })
-})
-const flowBands = computed<FlowBand[]>(() =>
-  segmentNodes.value.map((node) => ({
-    key: node.key,
-    y0: node.sourceY,
-    y1: node.y,
-    height: node.height,
-  })),
-)
 
 function rowKey(row: InvestmentBreakdownSegment): string {
-  return `${row.year ?? 'none'}-${row.month ?? 'none'}-${row.label}`
+  return `${row.label}-${row.year ?? 'none'}-${row.month ?? 'none'}`
 }
 
 function formatSegmentLabel(row: InvestmentBreakdownSegment): string {
-  if (row.year != null && row.month != null) {
-    const month = MONTH_LABELS[row.month - 1] ?? `${row.month}`
-    return `${row.year} ${month}`
-  }
-  if (row.year != null) return `${row.year}`
-  return row.label || 'Unspecified'
+  if (row.year) return `${row.year}`
+  return row.label
 }
 
-function colorForRow(row: InvestmentBreakdownSegment, index: number): string {
-  return MATERIAL_COLORS[row.label.toLowerCase()] ?? PALETTE[index % PALETTE.length]!
+function normalizedPct(row: InvestmentBreakdownSegment): number {
+  if (row.gainLossPct !== null) return row.gainLossPct
+  if (row.invested === 0) return 0
+  return (row.gainLoss / row.invested) * 100
 }
 
-function currentMarkerWidth(row: InvestmentBreakdownSegment): number {
-  return Math.max(20, (row.currentValue / maxCurrentValue.value) * 170)
-}
-
-function flowPath(band: FlowBand): string {
-  const sx = TOTAL_X + NODE_W
-  const tx = SEGMENT_X
-  const mid = (sx + tx) / 2
-  const sourceTop = band.y0
-  const sourceBottom = band.y0 + band.height
-  const targetTop = band.y1
-  const targetBottom = band.y1 + band.height
-  return `M ${sx} ${sourceTop} C ${mid} ${sourceTop} ${mid} ${targetTop} ${tx} ${targetTop} L ${tx} ${targetBottom} C ${mid} ${targetBottom} ${mid} ${sourceBottom} ${sx} ${sourceBottom} Z`
+function barWidth(value: number, max: number): number {
+  if (max <= 0 || value <= 0) return 0
+  return Math.max(6, Math.min(100, (value / max) * 100))
 }
 </script>
 
 <style scoped>
-.investment-chart-card {
+.investment-table-card {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  overflow: hidden;
+  padding: 1rem;
 }
 
-.investment-chart-header {
+.investment-table-header {
   display: flex;
-  justify-content: space-between;
   align-items: flex-start;
+  justify-content: space-between;
   gap: 1rem;
 }
 
-.investment-chart-header h2 {
-  margin: 0.15rem 0 0;
-  font-size: 1.4rem;
+.investment-table-header h2 {
+  margin: 0.25rem 0 0;
+  font-size: 1.2rem;
 }
 
-.chart-description {
+.table-description,
+.empty-state p,
+.row-main p {
   margin: 0.35rem 0 0;
   color: var(--text-secondary);
   font-size: 0.85rem;
 }
 
-.coin-count {
-  color: var(--text-muted);
-  font-size: 0.8rem;
+.coin-count,
+.roi-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-full);
+  font-size: 0.75rem;
+  font-weight: 600;
   white-space: nowrap;
 }
 
-.empty-state {
-  padding: 2rem 0;
-  color: var(--text-muted);
-  text-align: center;
+.coin-count {
+  padding: 0.2rem 0.7rem;
+  color: var(--accent-gold);
+  background: var(--accent-gold-dim);
+  border: 1px solid var(--border-accent);
 }
 
 .summary-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.75rem;
 }
 
 .summary-pill {
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 0.25rem;
   padding: 0.75rem;
   background: var(--bg-input);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
 }
 
-.summary-label {
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+.summary-label,
+.value-label,
+.bar-row span {
+  font-size: 0.75rem;
   color: var(--text-muted);
-}
-
-.gold {
-  color: var(--accent-gold);
-}
-
-.positive {
-  color: var(--color-positive);
-}
-
-.negative {
-  color: var(--color-negative);
 }
 
 .confidence-callout {
   padding: 0.75rem;
   background: var(--accent-gold-glow);
-  border: 1px solid var(--border-accent);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
 }
 
@@ -422,131 +245,123 @@ function flowPath(band: FlowBand): string {
   font-size: 0.85rem;
 }
 
-.chart-legend {
+.investment-row-list {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 0.75rem;
-  color: var(--text-secondary);
-  font-size: 0.8rem;
 }
 
-.legend-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.legend-swatch {
-  width: 1.5rem;
-  height: 0.25rem;
-  border-radius: var(--radius-full);
-}
-
-.legend-invested {
-  background: var(--accent-gold);
-}
-
-.legend-current {
-  background: var(--text-secondary);
-}
-
-.investment-flow-svg {
-  width: 100%;
-  min-width: 42rem;
-  height: auto;
-}
-
-.total-node,
-.segment-node {
-  vector-effect: non-scaling-stroke;
-}
-
-.total-node {
-  fill: var(--accent-gold);
-}
-
-.flow-band {
-  vector-effect: non-scaling-stroke;
-}
-
-.current-value-marker {
-  stroke: var(--text-secondary);
-  stroke-width: 4;
-  stroke-linecap: round;
-  vector-effect: non-scaling-stroke;
-}
-
-.node-label {
-  fill: var(--text-secondary);
-  font-size: 0.7rem;
-  font-weight: 600;
-}
-
-.node-value {
-  fill: var(--text-muted);
-  font-size: 0.62rem;
-}
-
-.segment-list {
+.investment-row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
-  gap: 0.75rem;
-}
-
-.segment-card {
+  grid-template-columns: minmax(9rem, 1fr) minmax(16rem, 1.5fr) minmax(13rem, 1fr);
+  gap: 1rem;
+  align-items: center;
   padding: 0.75rem;
   background: var(--bg-input);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
 }
 
-.segment-card-heading {
+.row-main {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: 0.75rem;
+  align-items: flex-start;
 }
 
-.segment-name {
-  color: var(--text-primary);
-  font-weight: 600;
+.row-main h3 {
+  margin: 0;
+  color: var(--text-heading);
+  font-size: 1.2rem;
 }
 
-.segment-values {
+.roi-pill {
+  padding: 0.15rem 0.5rem;
+}
+
+.positive-bg {
+  color: var(--accent-gold);
+  background: var(--accent-gold-dim);
+}
+
+.negative-bg {
+  color: var(--cat-byzantine);
+  background: color-mix(in srgb, var(--cat-byzantine) 18%, transparent);
+}
+
+.value-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.value-grid div {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  color: var(--text-secondary);
-  font-size: 0.8rem;
 }
 
-.mobile-aggregate-summary {
-  display: none;
+.allocation-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-@media (max-width: 768px) {
-  .investment-chart-header {
+.bar-row {
+  display: grid;
+  grid-template-columns: 4.5rem 1fr;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.bar-track {
+  height: 0.45rem;
+  overflow: hidden;
+  background: var(--bg-card);
+  border-radius: var(--radius-full);
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-full);
+}
+
+.bar-fill.invested {
+  background: var(--accent-bronze);
+}
+
+.bar-fill.current {
+  background: var(--accent-gold);
+}
+
+.gold,
+.positive {
+  color: var(--accent-gold);
+}
+
+.negative {
+  color: var(--cat-byzantine);
+}
+
+@media (max-width: 900px) {
+  .summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .investment-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .investment-table-header {
     flex-direction: column;
   }
 
-  .investment-flow-svg {
-    min-width: 34rem;
-  }
-
-  .segment-list {
-    display: none;
-  }
-
-  .mobile-aggregate-summary {
-    display: block;
-    padding: 0.75rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--text-secondary);
-    font-size: 0.85rem;
-    text-align: center;
+  .summary-grid,
+  .value-grid {
+    grid-template-columns: 1fr;
   }
 }
 </style>

--- a/src/web/src/components/stats/__tests__/StatsInvestmentBreakdownChart.test.ts
+++ b/src/web/src/components/stats/__tests__/StatsInvestmentBreakdownChart.test.ts
@@ -20,7 +20,7 @@ function segment(overrides: Partial<InvestmentBreakdownSegment>): InvestmentBrea
 }
 
 describe('StatsInvestmentBreakdownChart', () => {
-  it('renders summary values, legend, flow SVG, and segment cards', () => {
+  it('renders summary values and responsive investment rows', () => {
     const wrapper = mount(StatsInvestmentBreakdownChart, {
       props: {
         title: 'Material',
@@ -35,25 +35,24 @@ describe('StatsInvestmentBreakdownChart', () => {
     expect(wrapper.text()).toContain('Material')
     expect(wrapper.text()).toContain('Invested')
     expect(wrapper.text()).toContain('Current Value')
-    expect(wrapper.text()).toContain('Return')
+    expect(wrapper.text()).toContain('ROI')
     expect(wrapper.text()).toContain('5 coins')
-    expect(wrapper.find('.investment-flow-svg').exists()).toBe(true)
-    expect(wrapper.findAll('.flow-band')).toHaveLength(2)
-    expect(wrapper.findAll('.segment-card')).toHaveLength(2)
+    expect(wrapper.findAll('.investment-row')).toHaveLength(2)
+    expect(wrapper.findAll('.bar-fill.current')).toHaveLength(2)
   })
 
-  it('formats purchase year and month labels', () => {
+  it('formats purchase year labels', () => {
     const wrapper = mount(StatsInvestmentBreakdownChart, {
       props: {
-        title: 'Purchase Year to Month',
-        eyebrow: 'Acquisition Timing',
+        title: 'Acquisition Performance by Year',
+        eyebrow: 'Purchase Timing',
         rows: [
-          segment({ label: '2024-01', year: 2024, month: 1, invested: 150, currentValue: 175, coinCount: 1 }),
+          segment({ label: '2024', year: 2024, invested: 150, currentValue: 175, coinCount: 1 }),
         ],
       },
     })
 
-    expect(wrapper.text()).toContain('2024 Jan')
+    expect(wrapper.text()).toContain('2024')
   })
 
   it('shows confidence callout when price or value data is missing', () => {
@@ -82,10 +81,10 @@ describe('StatsInvestmentBreakdownChart', () => {
     })
 
     expect(wrapper.find('.empty-state').exists()).toBe(true)
-    expect(wrapper.find('.investment-flow-svg').exists()).toBe(false)
+    expect(wrapper.find('.investment-row').exists()).toBe(false)
   })
 
-  it('renders mobile aggregate summary with correct values', () => {
+  it('renders aggregate summary with correct values', () => {
     const wrapper = mount(StatsInvestmentBreakdownChart, {
       props: {
         title: 'Material',
@@ -97,15 +96,15 @@ describe('StatsInvestmentBreakdownChart', () => {
       },
     })
 
-    const mobileSummary = wrapper.find('.mobile-aggregate-summary')
-    expect(mobileSummary.exists()).toBe(true)
-    expect(mobileSummary.text()).toContain('Invested: $500.00')
-    expect(mobileSummary.text()).toContain('Current: $540.00')
-    expect(mobileSummary.text()).toContain('Gain/Loss: +$40.00')
-    expect(mobileSummary.text()).toContain('(+8.0%)')
+    const summary = wrapper.find('.summary-grid')
+    expect(summary.exists()).toBe(true)
+    expect(summary.text()).toContain('$500.00')
+    expect(summary.text()).toContain('$540.00')
+    expect(summary.text()).toContain('+$40.00')
+    expect(summary.text()).toContain('+8.0%')
   })
 
-  it('renders both mobile aggregate summary and segment list in DOM', () => {
+  it('renders row list in DOM', () => {
     const wrapper = mount(StatsInvestmentBreakdownChart, {
       props: {
         title: 'Material',
@@ -116,12 +115,11 @@ describe('StatsInvestmentBreakdownChart', () => {
       },
     })
 
-    expect(wrapper.find('.mobile-aggregate-summary').exists()).toBe(true)
-    expect(wrapper.find('.segment-list').exists()).toBe(true)
-    expect(wrapper.findAll('.segment-card')).toHaveLength(1)
+    expect(wrapper.find('.investment-row-list').exists()).toBe(true)
+    expect(wrapper.findAll('.investment-row')).toHaveLength(1)
   })
 
-  it('displays negative values correctly in mobile aggregate summary', () => {
+  it('displays negative values correctly in aggregate summary', () => {
     const wrapper = mount(StatsInvestmentBreakdownChart, {
       props: {
         title: 'Material',
@@ -132,11 +130,11 @@ describe('StatsInvestmentBreakdownChart', () => {
       },
     })
 
-    const mobileSummary = wrapper.find('.mobile-aggregate-summary')
-    expect(mobileSummary.text()).toContain('Invested: $500.00')
-    expect(mobileSummary.text()).toContain('Current: $400.00')
-    expect(mobileSummary.text()).toContain('Gain/Loss: -$100.00')
-    expect(mobileSummary.text()).toContain('(-20.0%)')
-    expect(mobileSummary.find('.negative').exists()).toBe(true)
+    const summary = wrapper.find('.summary-grid')
+    expect(summary.text()).toContain('$500.00')
+    expect(summary.text()).toContain('$400.00')
+    expect(summary.text()).toContain('-$100.00')
+    expect(summary.text()).toContain('-20.0%')
+    expect(summary.find('.negative').exists()).toBe(true)
   })
 })

--- a/src/web/src/pages/StatsInvestmentBreakdownPage.vue
+++ b/src/web/src/pages/StatsInvestmentBreakdownPage.vue
@@ -5,7 +5,7 @@
         <div>
           <p class="section-label">Collection Insights</p>
           <h1>Investment Breakdown</h1>
-          <p class="page-intro">See where capital is allocated by acquisition timing and material.</p>
+          <p class="page-intro">See valuation movement, acquisition-year performance, and material allocation.</p>
         </div>
         <router-link class="back-button" to="/stats" aria-label="Back to Stats">
           <ArrowLeft :size="20" />
@@ -75,16 +75,16 @@
         </section>
 
         <StatsInvestmentBreakdownChart
-          title="Purchase Year to Month"
-          eyebrow="Acquisition Timing"
-          description="Invested capital grouped by purchase year and month."
-          :rows="purchaseMonthRows"
+          title="Acquisition Performance by Year"
+          eyebrow="Purchase Timing"
+          description="Compare each purchase year's invested capital, current value, gain/loss, and ROI."
+          :rows="purchaseYearRows"
         />
 
         <StatsInvestmentBreakdownChart
           title="Material"
-          eyebrow="Portfolio Composition"
-          description="Invested capital and current value grouped by coin material."
+          eyebrow="Material Allocation"
+          description="Compare invested capital, current value, gain/loss, and ROI by material."
           :rows="materialRows"
         />
       </template>
@@ -108,7 +108,7 @@ import type {
 
 const isLoading = ref(true)
 const errorMessage = ref('')
-const purchaseMonthRows = ref<InvestmentBreakdownSegment[]>([])
+const purchaseYearRows = ref<InvestmentBreakdownSegment[]>([])
 const materialRows = ref<InvestmentBreakdownSegment[]>([])
 const topIncreases = ref<InvestmentMovementCoin[]>([])
 const topDrops = ref<InvestmentMovementCoin[]>([])
@@ -145,13 +145,13 @@ async function loadBreakdowns() {
   isLoading.value = true
   errorMessage.value = ''
   try {
-    const [purchaseMonthRes, materialRes] = await Promise.all([
-      getInvestmentBreakdown('purchase-month'),
+    const [purchaseYearRes, materialRes] = await Promise.all([
+      getInvestmentBreakdown('purchase-year'),
       getInvestmentBreakdown('material'),
     ])
-    purchaseMonthRows.value = normalizeBreakdown(purchaseMonthRes.data)
+    purchaseYearRows.value = normalizeBreakdown(purchaseYearRes.data)
     materialRows.value = normalizeBreakdown(materialRes.data)
-    applyHighlights(purchaseMonthRes.data)
+    applyHighlights(purchaseYearRes.data)
   } catch {
     errorMessage.value = 'Investment breakdown data could not be loaded.'
   } finally {

--- a/src/web/src/pages/__tests__/StatsInvestmentBreakdownPage.test.ts
+++ b/src/web/src/pages/__tests__/StatsInvestmentBreakdownPage.test.ts
@@ -34,10 +34,10 @@ describe('StatsInvestmentBreakdownPage', () => {
   beforeEach(() => {
     mockGetInvestmentBreakdown.mockReset()
     mockGetInvestmentBreakdown.mockImplementation((dimension: string) => {
-      if (dimension === 'purchase-month') {
+      if (dimension === 'purchase-year') {
         return Promise.resolve({
           data: {
-            segments: [segment('2024-01', { year: 2024, month: 1 })],
+            segments: [segment('2024', { year: 2024 })],
             topIncreases: [
               { coinId: 11, name: 'Aureus of Hadrian', initialValue: 1000, currentValue: 1800, changeAmount: 800, changePct: 80 },
             ],
@@ -55,18 +55,18 @@ describe('StatsInvestmentBreakdownPage', () => {
     })
   })
 
-  it('loads purchase-month and material investment breakdowns', async () => {
+  it('loads purchase-year and material investment breakdowns', async () => {
     const wrapper = mount(StatsInvestmentBreakdownPage, {
       global: { stubs: defaultStubs },
     })
     await flushPromises()
 
-    expect(mockGetInvestmentBreakdown).toHaveBeenCalledWith('purchase-month')
+    expect(mockGetInvestmentBreakdown).toHaveBeenCalledWith('purchase-year')
     expect(mockGetInvestmentBreakdown).toHaveBeenCalledWith('material')
     expect(wrapper.text()).toContain('Investment Breakdown')
-    expect(wrapper.text()).toContain('Purchase Year to Month')
-    expect(wrapper.text()).toContain('Material')
-    expect(wrapper.text()).toContain('2024 Jan')
+    expect(wrapper.text()).toContain('Acquisition Performance by Year')
+    expect(wrapper.text()).toContain('Material Allocation')
+    expect(wrapper.text()).toContain('2024')
     expect(wrapper.text()).toContain('Silver')
   })
 
@@ -99,13 +99,12 @@ describe('StatsInvestmentBreakdownPage', () => {
 
   it('renders confidence callouts from missing-value counts returned by the API', async () => {
     mockGetInvestmentBreakdown.mockImplementation((dimension: string) => {
-      if (dimension === 'purchase-month') {
+      if (dimension === 'purchase-year') {
         return Promise.resolve({
           data: {
             segments: [
-              segment('2024-01', {
+              segment('2024', {
                 year: 2024,
-                month: 1,
                 missingCurrentValueCount: 2,
                 missingPurchasePriceCount: 1,
               }),

--- a/src/web/src/types/index.ts
+++ b/src/web/src/types/index.ts
@@ -819,7 +819,7 @@ export interface StatsResponse {
   }
 }
 
-export type InvestmentBreakdownDimension = 'purchase-month' | 'material'
+export type InvestmentBreakdownDimension = 'purchase-year' | 'material'
 
 export interface InvestmentBreakdownSegment {
   label: string


### PR DESCRIPTION
## Summary
- Replace the Investment Breakdown purchase-month flow chart with Acquisition Performance by Year.
- Replace the material flow chart with responsive allocation/performance rows that work on desktop and PWA layouts.
- Reduce stale valuation highlights from 10 coins to 5 coins.
- Regenerate OpenAPI for the purchase-year dimension.

## Implementation details
- /stats/investment-breakdown now accepts purchase-year instead of purchase-month.
- Purchase-year rows aggregate invested/current/gain/loss/ROI by purchase_date year.
- Material rows keep the same backend data but render as compact rows with invested/current bars instead of a zoomable SVG flow chart.
- The top increase/drop cards remain unchanged.

## Validation
- go test ./repository -run "TestCoinRepository_GetInvestment" -count=1
- go test ./handlers -run "TestCoinHandler_InvestmentBreakdown" -count=1
- 
pm.cmd run test -- StatsInvestmentBreakdownPage.test.ts StatsInvestmentBreakdownChart.test.ts --run
- go test ./...
- 
pm.cmd run type-check

## Constitution
- Principle IV + §17