### PR TITLE
feat: add valuation change explanations

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -17497,6 +17497,9 @@
                 "changeAmount": {
                     "type": "number"
                 },
+                "changeExplanation": {
+                    "type": "string"
+                },
                 "changePct": {
                     "type": "number"
                 },

--- a/src/api/docs/docs.go
+++ b/src/api/docs/docs.go
@@ -17504,6 +17504,9 @@ const docTemplate = `{
                 "changeAmount": {
                     "type": "number"
                 },
+                "changeExplanation": {
+                    "type": "string"
+                },
                 "changePct": {
                     "type": "number"
                 },

--- a/src/api/docs/swagger.json
+++ b/src/api/docs/swagger.json
@@ -17497,6 +17497,9 @@
                 "changeAmount": {
                     "type": "number"
                 },
+                "changeExplanation": {
+                    "type": "string"
+                },
                 "changePct": {
                     "type": "number"
                 },

--- a/src/api/docs/swagger.yaml
+++ b/src/api/docs/swagger.yaml
@@ -2439,6 +2439,8 @@ definitions:
     properties:
       changeAmount:
         type: number
+      changeExplanation:
+        type: string
       changePct:
         type: number
       coinId:

--- a/src/api/handlers/coin_handler_test.go
+++ b/src/api/handlers/coin_handler_test.go
@@ -35,6 +35,7 @@ func setupCoinHandlerTestDB(t *testing.T) *gorm.DB {
 		&models.ValueSnapshot{}, &models.CoinJournal{}, &models.Note{},
 		&models.CoinValueHistory{}, &models.CoinComment{},
 		&models.AvailabilityResult{}, &models.AuctionLot{},
+		&models.ValuationRun{}, &models.ValuationResult{},
 		&models.Tag{}, &models.CoinTag{},
 		&models.CoinSet{}, &models.CoinSetMembership{},
 		&models.Showcase{}, &models.ShowcaseCoin{},

--- a/src/api/models/valuation_run.go
+++ b/src/api/models/valuation_run.go
@@ -25,15 +25,16 @@ type ValuationRun struct {
 
 // ValuationResult records the valuation outcome for a single coin in a run.
 type ValuationResult struct {
-	ID             uint      `gorm:"primaryKey" json:"id"`
-	RunID          uint      `gorm:"not null;index" json:"runId"`
-	CoinID         uint      `gorm:"not null" json:"coinId"`
-	CoinName       string    `json:"coinName"`
-	PreviousValue  *float64  `json:"previousValue"`
-	EstimatedValue float64   `json:"estimatedValue"`
-	Confidence     string    `gorm:"type:varchar(20)" json:"confidence"`
-	Reasoning      string    `gorm:"type:text" json:"reasoning"`
-	Status         string    `gorm:"type:varchar(20);not null" json:"status"`
-	ErrorMessage   string    `gorm:"type:text" json:"errorMessage,omitempty"`
-	CheckedAt      time.Time `gorm:"not null" json:"checkedAt"`
+	ID                uint      `gorm:"primaryKey" json:"id"`
+	RunID             uint      `gorm:"not null;index" json:"runId"`
+	CoinID            uint      `gorm:"not null" json:"coinId"`
+	CoinName          string    `json:"coinName"`
+	PreviousValue     *float64  `json:"previousValue"`
+	EstimatedValue    float64   `json:"estimatedValue"`
+	Confidence        string    `gorm:"type:varchar(20)" json:"confidence"`
+	Reasoning         string    `gorm:"type:text" json:"reasoning"`
+	ChangeExplanation *string   `gorm:"type:text" json:"changeExplanation"`
+	Status            string    `gorm:"type:varchar(20);not null" json:"status"`
+	ErrorMessage      string    `gorm:"type:text" json:"errorMessage,omitempty"`
+	CheckedAt         time.Time `gorm:"not null" json:"checkedAt"`
 }

--- a/src/api/repository/coin_repository.go
+++ b/src/api/repository/coin_repository.go
@@ -131,12 +131,13 @@ type InvestmentBreakdownSegment struct {
 
 // InvestmentMovementCoin holds one coin's valuation movement from the first recorded valuation to current value.
 type InvestmentMovementCoin struct {
-	CoinID       uint    `json:"coinId"`
-	Name         string  `json:"name"`
-	InitialValue float64 `json:"initialValue"`
-	CurrentValue float64 `json:"currentValue"`
-	ChangeAmount float64 `json:"changeAmount"`
-	ChangePct    float64 `json:"changePct"`
+	CoinID            uint    `json:"coinId"`
+	Name              string  `json:"name"`
+	InitialValue      float64 `json:"initialValue"`
+	CurrentValue      float64 `json:"currentValue"`
+	ChangeAmount      float64 `json:"changeAmount"`
+	ChangePct         float64 `json:"changePct"`
+	ChangeExplanation *string `json:"changeExplanation"`
 }
 
 // StaleValuationCoin holds one active coin ordered by valuation age.
@@ -845,7 +846,17 @@ func (r *CoinRepository) getInvestmentMovementCoins(userID uint, limit int, incr
 			CASE
 				WHEN first_value.value = 0 THEN 0
 				ELSE ((c.current_value - first_value.value) / first_value.value) * 100
-			END AS change_pct
+			END AS change_pct,
+			(
+				SELECT vr.change_explanation
+				FROM valuation_results vr
+				WHERE vr.coin_id = c.id
+					AND vr.status = 'success'
+					AND vr.change_explanation IS NOT NULL
+					AND vr.change_explanation != ''
+				ORDER BY vr.checked_at DESC, vr.id DESC
+				LIMIT 1
+			) AS change_explanation
 		FROM coins c
 		JOIN coin_value_histories first_value ON first_value.id = (
 			SELECT cvh.id

--- a/src/api/repository/coin_repository_test.go
+++ b/src/api/repository/coin_repository_test.go
@@ -21,6 +21,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		&models.ValueSnapshot{}, &models.CoinJournal{},
 		&models.CoinValueHistory{}, &models.CoinComment{},
 		&models.AvailabilityResult{}, &models.AuctionLot{},
+		&models.ValuationRun{}, &models.ValuationResult{},
 		&models.Tag{}, &models.CoinTag{},
 		&models.CoinSet{}, &models.CoinSetMembership{},
 		&models.QuickCaptureDraft{}, &models.QuickCaptureDraftImage{}, &models.DraftLifecycleEvent{},
@@ -473,6 +474,24 @@ func TestCoinRepository_GetInvestmentMovementStats(t *testing.T) {
 		}
 	}
 
+	run := models.ValuationRun{UserID: 1, Status: "completed", TriggerType: "manual", StartedAt: now}
+	if err := db.Create(&run).Error; err != nil {
+		t.Fatalf("Create valuation run failed: %v", err)
+	}
+	oldExplanation := "Older explanation should not be selected."
+	gainerExplanation := "The value increased because recent comps are stronger than the first valuation."
+	dropExplanation := "The value dropped because recent comps are weaker than the first valuation."
+	results := []models.ValuationResult{
+		{RunID: run.ID, CoinID: coins[0].ID, CoinName: coins[0].Name, PreviousValue: ptrFloat(250), EstimatedValue: 300, Confidence: "high", Reasoning: "Older", ChangeExplanation: &oldExplanation, Status: "success", CheckedAt: now.Add(-2 * time.Hour)},
+		{RunID: run.ID, CoinID: coins[0].ID, CoinName: coins[0].Name, PreviousValue: ptrFloat(250), EstimatedValue: 300, Confidence: "high", Reasoning: "Latest", ChangeExplanation: &gainerExplanation, Status: "success", CheckedAt: now.Add(-time.Hour)},
+		{RunID: run.ID, CoinID: coins[2].ID, CoinName: coins[2].Name, PreviousValue: ptrFloat(200), EstimatedValue: 50, Confidence: "high", Reasoning: "Latest", ChangeExplanation: &dropExplanation, Status: "success", CheckedAt: now.Add(-time.Hour)},
+	}
+	for i := range results {
+		if err := db.Create(&results[i]).Error; err != nil {
+			t.Fatalf("Create valuation result failed: %v", err)
+		}
+	}
+
 	increases, err := repo.GetTopInvestmentIncreases(1, 5)
 	if err != nil {
 		t.Fatalf("GetTopInvestmentIncreases failed: %v", err)
@@ -483,6 +502,9 @@ func TestCoinRepository_GetInvestmentMovementStats(t *testing.T) {
 	assertFloatNear(t, increases[0].InitialValue, 100)
 	assertFloatNear(t, increases[0].CurrentValue, 300)
 	assertFloatNear(t, increases[0].ChangeAmount, 200)
+	if increases[0].ChangeExplanation == nil || *increases[0].ChangeExplanation != gainerExplanation {
+		t.Fatalf("unexpected increase explanation: %#v", increases[0].ChangeExplanation)
+	}
 
 	drops, err := repo.GetTopInvestmentDrops(1, 5)
 	if err != nil {
@@ -494,6 +516,9 @@ func TestCoinRepository_GetInvestmentMovementStats(t *testing.T) {
 	assertFloatNear(t, drops[0].InitialValue, 200)
 	assertFloatNear(t, drops[0].CurrentValue, 50)
 	assertFloatNear(t, drops[0].ChangeAmount, -150)
+	if drops[0].ChangeExplanation == nil || *drops[0].ChangeExplanation != dropExplanation {
+		t.Fatalf("unexpected drop explanation: %#v", drops[0].ChangeExplanation)
+	}
 }
 
 func TestCoinRepository_GetStaleValuationCoins(t *testing.T) {

--- a/src/api/services/valuation_parser.go
+++ b/src/api/services/valuation_parser.go
@@ -9,10 +9,11 @@ import (
 
 // ValueEstimate holds the parsed AI valuation response.
 type ValueEstimate struct {
-	EstimatedValue float64               `json:"estimatedValue"`
-	Confidence     string                `json:"confidence"`
-	Reasoning      string                `json:"reasoning"`
-	Comparables    []ValueEstimateComp   `json:"comparables"`
+	EstimatedValue    float64             `json:"estimatedValue"`
+	Confidence        string              `json:"confidence"`
+	Reasoning         string              `json:"reasoning"`
+	ChangeExplanation string              `json:"changeExplanation"`
+	Comparables       []ValueEstimateComp `json:"comparables"`
 }
 
 // ValueEstimateComp represents a comparable sale found by the AI.
@@ -76,10 +77,11 @@ func tryParseJSONEstimate(text string) *ValueEstimate {
 	jsonStr := strings.TrimSpace(text[start : start+end])
 
 	var parsed struct {
-		EstimatedValue float64 `json:"estimatedValue"`
-		Confidence     string  `json:"confidence"`
-		Reasoning      string  `json:"reasoning"`
-		Comparables    []struct {
+		EstimatedValue    float64 `json:"estimatedValue"`
+		Confidence        string  `json:"confidence"`
+		Reasoning         string  `json:"reasoning"`
+		ChangeExplanation string  `json:"changeExplanation"`
+		Comparables       []struct {
 			Source string `json:"source"`
 			Price  string `json:"price"`
 			URL    string `json:"url"`
@@ -104,10 +106,11 @@ func tryParseJSONEstimate(text string) *ValueEstimate {
 	}
 
 	return &ValueEstimate{
-		EstimatedValue: parsed.EstimatedValue,
-		Confidence:     confidence,
-		Reasoning:      parsed.Reasoning,
-		Comparables:    comps,
+		EstimatedValue:    parsed.EstimatedValue,
+		Confidence:        confidence,
+		Reasoning:         parsed.Reasoning,
+		ChangeExplanation: strings.TrimSpace(parsed.ChangeExplanation),
+		Comparables:       comps,
 	}
 }
 

--- a/src/api/services/valuation_parser_test.go
+++ b/src/api/services/valuation_parser_test.go
@@ -208,3 +208,25 @@ func TestParseValueEstimate_ReasoningExtraction(t *testing.T) {
 		t.Errorf("EstimatedValue = %v, want 300", result.EstimatedValue)
 	}
 }
+
+func TestParseValueEstimate_ChangeExplanation(t *testing.T) {
+	input := "```json\n" +
+		`{"estimatedValue": 325, "confidence": "high", "reasoning": "Recent sales support the estimate.", "changeExplanation": "The value increased because comparable VF examples are selling above the prior estimate."}` +
+		"\n```"
+
+	result := ParseValueEstimate(input)
+	if result.ChangeExplanation != "The value increased because comparable VF examples are selling above the prior estimate." {
+		t.Errorf("ChangeExplanation = %q", result.ChangeExplanation)
+	}
+}
+
+func TestParseValueEstimate_ChangeExplanationBackwardCompatible(t *testing.T) {
+	input := "```json\n" +
+		`{"estimatedValue": 325, "confidence": "high", "reasoning": "Recent sales support the estimate."}` +
+		"\n```"
+
+	result := ParseValueEstimate(input)
+	if result.ChangeExplanation != "" {
+		t.Errorf("ChangeExplanation = %q, want empty", result.ChangeExplanation)
+	}
+}

--- a/src/api/services/valuation_prompt.go
+++ b/src/api/services/valuation_prompt.go
@@ -12,6 +12,7 @@ CRITICAL: Return your response as ONLY a JSON object (wrapped in ` + "```json" +
 - estimatedValue: number (USD, single number not a range)
 - confidence: "high" (3+ comparables), "medium" (1-2), or "low" (general knowledge)
 - reasoning: string (2-3 SHORT sentences only — what you found and how you arrived at the estimate)
+- changeExplanation: string (one concise sentence explaining why the value increased or decreased versus the provided previous value; use "" when no previous value is provided or value is unchanged)
 - comparables: array of { "source": "dealer name", "price": "$X", "url": "listing URL" }
 
 ` + "```json" + `
@@ -19,6 +20,7 @@ CRITICAL: Return your response as ONLY a JSON object (wrapped in ` + "```json" +
   "estimatedValue": 275,
   "confidence": "high",
   "reasoning": "Found 4 comparable Augustus denarii in VF condition listed at $250-300. Grade and strike quality place this coin at mid-range.",
+  "changeExplanation": "The value increased because recent comparable VF examples are closing above the prior estimate.",
   "comparables": [
     { "source": "VCoins - Example Dealer", "price": "$285", "url": "https://www.vcoins.com/..." },
     { "source": "MA-Shops", "price": "$250", "url": "https://www.ma-shops.com/..." }

--- a/src/api/services/valuation_service.go
+++ b/src/api/services/valuation_service.go
@@ -105,6 +105,21 @@ func BuildCoinDescription(coin *models.Coin) string {
 	return strings.Join(parts, "\n")
 }
 
+func valuationChangeContext(previousValue *float64) string {
+	if previousValue == nil || *previousValue <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("\n\nPrevious valuation context:\nPrevious value: $%.2f\nIf your estimate changes from this value, include changeExplanation as one concise sentence.", *previousValue)
+}
+
+func changeExplanationForResult(previousValue *float64, estimatedValue float64, explanation string) *string {
+	trimmed := strings.TrimSpace(explanation)
+	if previousValue == nil || *previousValue <= 0 || estimatedValue <= 0 || estimatedValue == *previousValue || trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
 // coinHasEnoughMetadata returns true if the coin has enough informative fields
 // to produce a meaningful AI valuation.
 func coinHasEnoughMetadata(coin *models.Coin) bool {
@@ -273,8 +288,8 @@ func (s *ValuationService) ValuateCollectionForUser(
 		checked++
 		batchCount++
 		description := BuildCoinDescription(&coin)
-		userMessage := fmt.Sprintf("Estimate the current market value of this coin:\n\n%s\n\n"+
-			"Return ONLY the JSON block as specified in your instructions. No preamble or extra text.", description)
+		userMessage := fmt.Sprintf("Estimate the current market value of this coin:\n\n%s%s\n\n"+
+			"Return ONLY the JSON block as specified in your instructions. No preamble or extra text.", description, valuationChangeContext(coin.CurrentValue))
 
 		proxyReq := PortfolioReviewProxyRequest{
 			LLM: llmCfg,
@@ -328,15 +343,16 @@ func (s *ValuationService) ValuateCollectionForUser(
 		estimate := ParseValueEstimate(aiText)
 
 		result := &models.ValuationResult{
-			RunID:          run.ID,
-			CoinID:         coin.ID,
-			CoinName:       coin.Name,
-			PreviousValue:  coin.CurrentValue,
-			EstimatedValue: estimate.EstimatedValue,
-			Confidence:     estimate.Confidence,
-			Reasoning:      estimate.Reasoning,
-			Status:         "success",
-			CheckedAt:      time.Now(),
+			RunID:             run.ID,
+			CoinID:            coin.ID,
+			CoinName:          coin.Name,
+			PreviousValue:     coin.CurrentValue,
+			EstimatedValue:    estimate.EstimatedValue,
+			Confidence:        estimate.Confidence,
+			Reasoning:         estimate.Reasoning,
+			ChangeExplanation: changeExplanationForResult(coin.CurrentValue, estimate.EstimatedValue, estimate.ChangeExplanation),
+			Status:            "success",
+			CheckedAt:         time.Now(),
 		}
 
 		if estimate.EstimatedValue > 0 {

--- a/src/web/src/components/admin/AdminSchedulesSection.vue
+++ b/src/web/src/components/admin/AdminSchedulesSection.vue
@@ -524,7 +524,7 @@
                       <th>Estimated</th>
                       <th>Confidence</th>
                       <th>Status</th>
-                      <th>Reasoning</th>
+                      <th>Explanation</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -539,7 +539,10 @@
                       <td>
                         <span class="listing-status-badge" :class="'val-result-' + r.status">{{ r.status }}</span>
                       </td>
-                      <td class="avail-reason">{{ r.reasoning || r.errorMessage || '--' }}</td>
+                      <td class="avail-reason">
+                        <div v-if="r.changeExplanation" class="val-change-explanation">{{ r.changeExplanation }}</div>
+                        <div>{{ r.reasoning || r.errorMessage || '--' }}</div>
+                      </td>
                     </tr>
                   </tbody>
                 </table>
@@ -1260,6 +1263,12 @@ onUnmounted(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.val-change-explanation {
+  margin-bottom: 0.35rem;
+  color: var(--accent-gold);
+  font-weight: 500;
 }
 
 .listing-status-badge {

--- a/src/web/src/pages/StatsInvestmentBreakdownPage.vue
+++ b/src/web/src/pages/StatsInvestmentBreakdownPage.vue
@@ -36,6 +36,7 @@
                   <span class="arrow">to</span>
                   <span class="gold">{{ formatCurrency(coin.currentValue) }}</span>
                 </div>
+                <p v-if="coin.changeExplanation" class="change-explanation">{{ coin.changeExplanation }}</p>
               </li>
             </ol>
             <p v-else class="empty-copy">No valuation increases are available yet.</p>
@@ -54,6 +55,7 @@
                   <span class="arrow">to</span>
                   <span class="loss">{{ formatCurrency(coin.currentValue) }}</span>
                 </div>
+                <p v-if="coin.changeExplanation" class="change-explanation">{{ coin.changeExplanation }}</p>
               </li>
             </ol>
             <p v-else class="empty-copy">No valuation declines are available yet.</p>
@@ -278,6 +280,13 @@ onMounted(loadBreakdowns)
   align-items: center;
   gap: 0.35rem;
   flex-wrap: wrap;
+}
+
+.change-explanation {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.4;
 }
 
 .arrow,

--- a/src/web/src/pages/__tests__/StatsInvestmentBreakdownPage.test.ts
+++ b/src/web/src/pages/__tests__/StatsInvestmentBreakdownPage.test.ts
@@ -39,7 +39,15 @@ describe('StatsInvestmentBreakdownPage', () => {
           data: {
             segments: [segment('2024', { year: 2024 })],
             topIncreases: [
-              { coinId: 11, name: 'Aureus of Hadrian', initialValue: 1000, currentValue: 1800, changeAmount: 800, changePct: 80 },
+              {
+                coinId: 11,
+                name: 'Aureus of Hadrian',
+                initialValue: 1000,
+                currentValue: 1800,
+                changeAmount: 800,
+                changePct: 80,
+                changeExplanation: 'The value increased because recent comparable sales are stronger.',
+              },
             ],
             topDrops: [
               { coinId: 12, name: 'Denarius of Trajan', initialValue: 500, currentValue: 350, changeAmount: -150, changePct: -30 },
@@ -80,12 +88,14 @@ describe('StatsInvestmentBreakdownPage', () => {
     expect(wrapper.text()).toContain('Aureus of Hadrian')
     expect(wrapper.text()).toContain('$1,000.00')
     expect(wrapper.text()).toContain('$1,800.00')
+    expect(wrapper.text()).toContain('The value increased because recent comparable sales are stronger.')
     expect(wrapper.find('a[href="/coin/11"]').exists()).toBe(true)
 
     expect(wrapper.text()).toContain('Biggest Value Declines')
     expect(wrapper.text()).toContain('Denarius of Trajan')
     expect(wrapper.text()).toContain('$500.00')
     expect(wrapper.text()).toContain('$350.00')
+    expect(wrapper.text()).not.toContain('undefined')
     expect(wrapper.find('a[href="/coin/12"]').exists()).toBe(true)
 
     expect(wrapper.text()).toContain('Needs Refresh')

--- a/src/web/src/types/index.ts
+++ b/src/web/src/types/index.ts
@@ -841,6 +841,7 @@ export interface InvestmentMovementCoin {
   currentValue: number
   changeAmount: number
   changePct: number
+  changeExplanation?: string | null
 }
 
 export interface StaleValuationCoin {
@@ -1463,6 +1464,7 @@ export interface ValuationResult {
   estimatedValue: number
   confidence: string
   reasoning: string
+  changeExplanation?: string | null
   status: string
   errorMessage?: string
   checkedAt: string


### PR DESCRIPTION
## Summary
- Adds nullable changeExplanation to valuation run results and OpenAPI/TypeScript contracts.
- Updates valuation prompts and parsing so runs can persist one concise explanation when a previous value exists and the estimate changes.
- Surfaces the stored explanation in Admin valuation run history and Investment Breakdown top gain/drop rows, with safe fallback for older runs.
- Resolves #424.

## Constitution
- Principle I: keeps valuation persistence in service/repository layers and report reads in the coin repository.
- Principle IV: simple additive nullable field, no rewrite of valuation history.
- §17: Quality Gate completed locally.

## Validation
- task openapi
- go test ./...
- go build ./...
- go vet ./...
- npm.cmd run type-check
- npm.cmd run test
- npm.cmd run build