### PR TITLE
Fix wishlist search alerts never re-running on their cadence (#483)

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -104,6 +104,8 @@ The API runs three background schedulers that start automatically on server star
 
 3. **Auction Ending Scheduler** — Checks for auction lots ending today and sends consolidated Pushover notifications per user. Configured via `AuctionEndingCheckEnabled`, `AuctionEndingCheckStartTime` (HH:MM), and `AuctionEndingCheckInterval` (minutes). Default: every 24 hours at 08:00. Each run is logged in the `auction_ending_runs` table. Runs can be manually triggered via `/admin/auction-ending/run`.
 
+4. **Wishlist Search Alert Scheduler** — Daily sweep that queues an automatic discovery run for each active `WishlistSearchAlert` whose configured cadence (`daily`/`weekly`/`monthly`) has elapsed since its last run. Configured via `WishlistSearchAlertsCheckEnabled` (default `"false"`) and `WishlistSearchAlertsCheckStartTime` (HH:MM, default `03:00`). Alerts with `cadence: manual` are never auto-run — only "Run Now" processes them. Queued runs are logged in `alert_runs` the same as manual runs, with `triggerType: scheduled`.
+
 All schedulers honor the enabled flag — set to `"false"` to disable. Run history is available via admin endpoints:
 - `GET /admin/availability-runs` — Paginated list of availability check runs
 - `GET /admin/valuation-runs` — Paginated list of valuation runs

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -195,6 +195,7 @@ func main() {
 	availSvc := services.NewAvailabilityService(coinRepo, availRepo, agentProxy, notifSvc, pushoverSvc, userRepoForVal, settingsSvc, logger)
 	wishlistSearchAlertSvc := services.NewWishlistSearchAlertService(wishlistSearchAlertRepo).WithDiscovery(agentProxy, settingsSvc)
 	wishlistSearchAlertSvc.StartWorkers(1)
+	wishlistSearchAlertScheduler := services.NewWishlistSearchAlertScheduler(wishlistSearchAlertSvc, wishlistSearchAlertRepo, settingsSvc, logger)
 	valSvc := services.NewValuationService(coinRepo, valRepo, agentProxy, userRepoForVal, pushoverSvc, notifSvc, settingsSvc, logger)
 	aiJobRepo := repository.NewAIJobRepository(database.DB)
 	aiJobSvc := services.NewAIJobService(aiJobRepo, agentProxy, userRepoForVal, settingsSvc, notifSvc, logger)
@@ -229,6 +230,7 @@ func main() {
 	schedulerRegistry.Register(auctionWatchBidDigestScheduler)
 	schedulerRegistry.Register(auctionAlertScheduler)
 	schedulerRegistry.Register(healthScheduler)
+	schedulerRegistry.Register(wishlistSearchAlertScheduler)
 
 	// Create shared repositories for cross-group access
 	journalRepo := repository.NewJournalRepository(database.DB)

--- a/src/api/repository/wishlist_search_alert_repository.go
+++ b/src/api/repository/wishlist_search_alert_repository.go
@@ -98,6 +98,44 @@ func (r *WishlistSearchAlertRepository) CreateRun(run *models.AlertRun) error {
 	return r.db.Create(run).Error
 }
 
+// cadenceDuration maps a cadence value to the interval that must elapse
+// between scheduled runs. Returns 0 for cadences that are not auto-scheduled.
+func cadenceDuration(cadence models.WishlistAlertCadence) time.Duration {
+	switch cadence {
+	case models.WishlistAlertCadenceDaily:
+		return 24 * time.Hour
+	case models.WishlistAlertCadenceWeekly:
+		return 7 * 24 * time.Hour
+	case models.WishlistAlertCadenceMonthly:
+		return 30 * 24 * time.Hour
+	default:
+		return 0
+	}
+}
+
+// GetDueAlerts returns active alerts with an automatic cadence (daily/weekly/monthly)
+// whose cadence interval has elapsed since LastRunAt (or that have never run).
+func (r *WishlistSearchAlertRepository) GetDueAlerts(now time.Time) ([]models.WishlistSearchAlert, error) {
+	var alerts []models.WishlistSearchAlert
+	err := r.db.Where("deleted_at IS NULL AND is_active = ? AND cadence != ?", true, models.WishlistAlertCadenceManual).
+		Find(&alerts).Error
+	if err != nil {
+		return nil, err
+	}
+
+	due := make([]models.WishlistSearchAlert, 0, len(alerts))
+	for _, alert := range alerts {
+		interval := cadenceDuration(alert.Cadence)
+		if interval == 0 {
+			continue
+		}
+		if alert.LastRunAt == nil || !alert.LastRunAt.Add(interval).After(now) {
+			due = append(due, alert)
+		}
+	}
+	return due, nil
+}
+
 func (r *WishlistSearchAlertRepository) CreateManualRunIfAvailable(run *models.AlertRun, runningSince time.Time) (bool, error) {
 	acquired := false
 	err := r.db.Transaction(func(tx *gorm.DB) error {

--- a/src/api/repository/wishlist_search_alert_repository_test.go
+++ b/src/api/repository/wishlist_search_alert_repository_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"testing"
+	"time"
 
 	"github.com/briandenicola/ancient-coins-api/models"
 	"github.com/glebarez/sqlite"
@@ -59,5 +60,65 @@ func TestWishlistSearchAlertRepository_OwnerScopedAlertCRUD(t *testing.T) {
 	}
 	if deleted.DeletedAt == nil {
 		t.Fatalf("deleted alert missing soft-delete timestamp: %+v", deleted)
+	}
+}
+
+// TestWishlistSearchAlertRepository_GetDueAlerts covers the scheduling gap from
+// issue #483: a per-alert Cadence was stored but nothing ever checked it against
+// LastRunAt to decide whether an alert is due for an automatic run.
+func TestWishlistSearchAlertRepository_GetDueAlerts(t *testing.T) {
+	repo, _ := setupWishlistSearchAlertRepository(t)
+	now := time.Now()
+
+	eightDaysAgo := now.Add(-8 * 24 * time.Hour)
+	twoDaysAgo := now.Add(-2 * 24 * time.Hour)
+	twentyFiveHoursAgo := now.Add(-25 * time.Hour)
+	tenDaysAgo := now.Add(-10 * 24 * time.Hour)
+
+	alerts := []*models.WishlistSearchAlert{
+		{UserID: 1, Name: "manual, never runs automatically", Cadence: models.WishlistAlertCadenceManual, IsActive: true, LastRunAt: &tenDaysAgo},
+		{UserID: 1, Name: "weekly, overdue", Cadence: models.WishlistAlertCadenceWeekly, IsActive: true, LastRunAt: &eightDaysAgo},
+		{UserID: 1, Name: "weekly, not yet due", Cadence: models.WishlistAlertCadenceWeekly, IsActive: true, LastRunAt: &twoDaysAgo},
+		{UserID: 1, Name: "weekly, never run", Cadence: models.WishlistAlertCadenceWeekly, IsActive: true, LastRunAt: nil},
+		{UserID: 1, Name: "daily, overdue", Cadence: models.WishlistAlertCadenceDaily, IsActive: true, LastRunAt: &twentyFiveHoursAgo},
+		{UserID: 1, Name: "monthly, not yet due", Cadence: models.WishlistAlertCadenceMonthly, IsActive: true, LastRunAt: &tenDaysAgo},
+		{UserID: 1, Name: "weekly but inactive", Cadence: models.WishlistAlertCadenceWeekly, IsActive: true, LastRunAt: &eightDaysAgo},
+	}
+	for _, a := range alerts {
+		if err := repo.CreateAlert(a); err != nil {
+			t.Fatalf("create alert %q: %v", a.Name, err)
+		}
+	}
+	// Deactivate via UpdateAlert (Save), matching how production code deactivates
+	// alerts — CreateAlert with IsActive:false at insert time hits GORM's
+	// default-tag zero-value skip and would silently persist as active.
+	inactive := alerts[len(alerts)-1]
+	inactive.IsActive = false
+	if err := repo.UpdateAlert(inactive); err != nil {
+		t.Fatalf("deactivate alert: %v", err)
+	}
+
+	due, err := repo.GetDueAlerts(now)
+	if err != nil {
+		t.Fatalf("GetDueAlerts: %v", err)
+	}
+
+	got := make(map[string]bool, len(due))
+	for _, a := range due {
+		got[a.Name] = true
+	}
+
+	if len(due) != 3 {
+		t.Fatalf("expected 3 due alerts, got %d: %+v", len(due), got)
+	}
+	for _, name := range []string{"weekly, overdue", "weekly, never run", "daily, overdue"} {
+		if !got[name] {
+			t.Errorf("expected %q to be due, but it was not returned", name)
+		}
+	}
+	for _, name := range []string{"manual, never runs automatically", "weekly, not yet due", "monthly, not yet due", "weekly but inactive"} {
+		if got[name] {
+			t.Errorf("expected %q to NOT be due, but it was returned", name)
+		}
 	}
 }

--- a/src/api/services/settings_service.go
+++ b/src/api/services/settings_service.go
@@ -27,6 +27,8 @@ const (
 	SettingWishlistCheckEnabled               = "WishlistCheckEnabled"
 	SettingWishlistCheckInterval              = "WishlistCheckInterval"
 	SettingWishlistCheckStartTime             = "WishlistCheckStartTime"
+	SettingWishlistSearchAlertsCheckEnabled   = "WishlistSearchAlertsCheckEnabled"
+	SettingWishlistSearchAlertsCheckStartTime = "WishlistSearchAlertsCheckStartTime"
 	SettingValuationCheckEnabled              = "ValuationCheckEnabled"
 	SettingValuationCheckInterval             = "ValuationCheckIntervalDays"
 	SettingValuationCheckStartTime            = "ValuationCheckStartTime"
@@ -96,6 +98,8 @@ var settingDefaults = map[string]string{
 	SettingWishlistCheckEnabled:               "false",
 	SettingWishlistCheckInterval:              "120",
 	SettingWishlistCheckStartTime:             "02:00",
+	SettingWishlistSearchAlertsCheckEnabled:   "false",
+	SettingWishlistSearchAlertsCheckStartTime: "03:00",
 	SettingValuationCheckEnabled:              "false",
 	SettingValuationCheckInterval:             "7",
 	SettingValuationCheckStartTime:            "03:00",

--- a/src/api/services/wishlist_search_alert_scheduler.go
+++ b/src/api/services/wishlist_search_alert_scheduler.go
@@ -1,0 +1,155 @@
+package services
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/briandenicola/ancient-coins-api/repository"
+)
+
+// WishlistSearchAlertScheduler runs a daily sweep that enqueues scheduled runs
+// for WishlistSearchAlerts whose per-alert cadence (daily/weekly/monthly) has
+// elapsed since their last run. Cadence was previously stored but never acted
+// on, so alerts with an automatic cadence never ran again after their first
+// manual "Run Now" (see issue #483).
+type WishlistSearchAlertScheduler struct {
+	alertSvc    *WishlistSearchAlertService
+	repo        *repository.WishlistSearchAlertRepository
+	settingsSvc *SettingsService
+	logger      *Logger
+	stopCh      chan struct{}
+	once        sync.Once
+	statusMu    sync.RWMutex
+	isRunning   bool
+}
+
+// NewWishlistSearchAlertScheduler creates a new scheduler.
+func NewWishlistSearchAlertScheduler(
+	alertSvc *WishlistSearchAlertService,
+	repo *repository.WishlistSearchAlertRepository,
+	settingsSvc *SettingsService,
+	logger *Logger,
+) *WishlistSearchAlertScheduler {
+	return &WishlistSearchAlertScheduler{
+		alertSvc:    alertSvc,
+		repo:        repo,
+		settingsSvc: settingsSvc,
+		logger:      logger,
+		stopCh:      make(chan struct{}),
+	}
+}
+
+// Start begins the daily sweep loop. Call from a goroutine.
+func (s *WishlistSearchAlertScheduler) Start() {
+	s.logger.Info("scheduler", "Wishlist search alert scheduler started")
+
+	// Initial delay to let the app finish startup
+	select {
+	case <-time.After(30 * time.Second):
+	case <-s.stopCh:
+		return
+	}
+
+	for {
+		wait := s.timeUntilNextRun()
+		s.logger.Info("scheduler", "Next wishlist search alert sweep in %s", wait)
+
+		select {
+		case <-time.After(wait):
+		case <-s.stopCh:
+			s.logger.Info("scheduler", "Wishlist search alert scheduler stopped")
+			return
+		}
+
+		s.runCycle()
+	}
+}
+
+// Stop signals the scheduler to shut down. Safe to call multiple times.
+func (s *WishlistSearchAlertScheduler) Stop() {
+	s.once.Do(func() { close(s.stopCh) })
+}
+
+// RunNow executes one immediate sweep of due alerts.
+func (s *WishlistSearchAlertScheduler) RunNow() error {
+	s.runCycle()
+	return nil
+}
+
+// GetStatus returns the scheduler runtime status.
+func (s *WishlistSearchAlertScheduler) GetStatus() SchedulerStatus {
+	s.statusMu.RLock()
+	running := s.isRunning
+	s.statusMu.RUnlock()
+
+	enabled := s.settingsSvc.GetSetting(SettingWishlistSearchAlertsCheckEnabled) == "true"
+	return SchedulerStatus{
+		Name:      "wishlist_search_alerts",
+		Enabled:   enabled,
+		IsRunning: running,
+		NextRunIn: s.timeUntilNextRun(),
+	}
+}
+
+// timeUntilNextRun calculates the delay until the next daily sweep, anchored
+// to the configured start time.
+func (s *WishlistSearchAlertScheduler) timeUntilNextRun() time.Duration {
+	now := time.Now()
+	startHour, startMin := s.getStartTime()
+	anchor := time.Date(now.Year(), now.Month(), now.Day(), startHour, startMin, 0, 0, now.Location())
+
+	if anchor.After(now) {
+		return anchor.Sub(now)
+	}
+
+	next := anchor.Add(24 * time.Hour)
+	return next.Sub(now)
+}
+
+// getStartTime parses HH:MM from settings, defaults to 03:00.
+func (s *WishlistSearchAlertScheduler) getStartTime() (int, int) {
+	raw := s.settingsSvc.GetSetting(SettingWishlistSearchAlertsCheckStartTime)
+	var h, m int
+	if _, err := fmt.Sscanf(raw, "%d:%d", &h, &m); err != nil || h < 0 || h > 23 || m < 0 || m > 59 {
+		return 3, 0
+	}
+	return h, m
+}
+
+// runCycle finds every active alert whose cadence interval has elapsed and
+// enqueues a scheduled discovery run for it.
+func (s *WishlistSearchAlertScheduler) runCycle() {
+	enabled := s.settingsSvc.GetSetting(SettingWishlistSearchAlertsCheckEnabled)
+	if enabled != "true" {
+		s.logger.Debug("scheduler", "Wishlist search alert scheduled checks disabled, skipping cycle")
+		return
+	}
+
+	s.statusMu.Lock()
+	s.isRunning = true
+	s.statusMu.Unlock()
+	defer func() {
+		s.statusMu.Lock()
+		s.isRunning = false
+		s.statusMu.Unlock()
+	}()
+
+	alerts, err := s.repo.GetDueAlerts(time.Now())
+	if err != nil {
+		s.logger.Error("scheduler", "Failed to fetch due wishlist search alerts: %s", err)
+		return
+	}
+
+	if len(alerts) == 0 {
+		s.logger.Info("scheduler", "No wishlist search alerts due for a scheduled run")
+		return
+	}
+
+	s.logger.Info("scheduler", "Found %d wishlist search alerts due for a scheduled run", len(alerts))
+	for _, alert := range alerts {
+		if _, err := s.alertSvc.QueueScheduledRun(alert); err != nil {
+			s.logger.Error("scheduler", "Failed to queue scheduled run for alert %d: %s", alert.ID, err)
+		}
+	}
+}

--- a/src/api/services/wishlist_search_alert_scheduler_test.go
+++ b/src/api/services/wishlist_search_alert_scheduler_test.go
@@ -1,0 +1,114 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/briandenicola/ancient-coins-api/models"
+	"github.com/briandenicola/ancient-coins-api/repository"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupWishlistSearchAlertSchedulerDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.AppSetting{}, &models.User{}, &models.WishlistSearchAlert{}, &models.AlertRun{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	return db
+}
+
+func newTestWishlistSearchAlertScheduler(t *testing.T, db *gorm.DB) (*WishlistSearchAlertScheduler, *repository.WishlistSearchAlertRepository) {
+	t.Helper()
+	settingsSvc := NewSettingsService(repository.NewSettingsRepository(db))
+	alertRepo := repository.NewWishlistSearchAlertRepository(db)
+	alertSvc := NewWishlistSearchAlertService(alertRepo)
+	scheduler := NewWishlistSearchAlertScheduler(alertSvc, alertRepo, settingsSvc, NewLogger(100))
+	return scheduler, alertRepo
+}
+
+// TestWishlistSearchAlertScheduler_TimeUntilNextRun verifies the daily anchor
+// calculation used to schedule sweeps.
+func TestWishlistSearchAlertScheduler_TimeUntilNextRun(t *testing.T) {
+	db := setupWishlistSearchAlertSchedulerDB(t)
+	s, _ := newTestWishlistSearchAlertScheduler(t, db)
+
+	future := time.Now().Add(3 * time.Hour)
+	if err := s.settingsSvc.SetSetting(SettingWishlistSearchAlertsCheckStartTime, future.Format("15:04")); err != nil {
+		t.Fatalf("failed to set start time: %v", err)
+	}
+
+	wait := s.timeUntilNextRun()
+	if wait < 2*time.Hour+55*time.Minute || wait > 3*time.Hour+5*time.Minute {
+		t.Errorf("expected ~3h wait, got %v", wait)
+	}
+}
+
+// TestWishlistSearchAlertScheduler_RunCycleDisabledByDefault verifies that a
+// sweep does nothing unless explicitly enabled via settings.
+func TestWishlistSearchAlertScheduler_RunCycleDisabledByDefault(t *testing.T) {
+	db := setupWishlistSearchAlertSchedulerDB(t)
+	s, alertRepo := newTestWishlistSearchAlertScheduler(t, db)
+
+	eightDaysAgo := time.Now().Add(-8 * 24 * time.Hour)
+	alert := &models.WishlistSearchAlert{UserID: 1, Name: "weekly", Cadence: models.WishlistAlertCadenceWeekly, IsActive: true, LastRunAt: &eightDaysAgo}
+	if err := alertRepo.CreateAlert(alert); err != nil {
+		t.Fatalf("create alert: %v", err)
+	}
+
+	s.runCycle()
+
+	var count int64
+	db.Model(&models.AlertRun{}).Count(&count)
+	if count != 0 {
+		t.Fatalf("expected no runs queued while disabled, got %d", count)
+	}
+}
+
+// TestWishlistSearchAlertScheduler_RunCycleQueuesDueAlerts verifies that,
+// once enabled, the scheduler queues a scheduled run for each due alert and
+// leaves ones that aren't due alone. This is the core regression test for
+// issue #483 (cadence was stored but never acted on).
+func TestWishlistSearchAlertScheduler_RunCycleQueuesDueAlerts(t *testing.T) {
+	db := setupWishlistSearchAlertSchedulerDB(t)
+	s, alertRepo := newTestWishlistSearchAlertScheduler(t, db)
+
+	if err := s.settingsSvc.SetSetting(SettingWishlistSearchAlertsCheckEnabled, "true"); err != nil {
+		t.Fatalf("failed to enable scheduler: %v", err)
+	}
+
+	eightDaysAgo := time.Now().Add(-8 * 24 * time.Hour)
+	twoDaysAgo := time.Now().Add(-2 * 24 * time.Hour)
+
+	due := &models.WishlistSearchAlert{UserID: 1, Name: "weekly, overdue", Cadence: models.WishlistAlertCadenceWeekly, IsActive: true, LastRunAt: &eightDaysAgo}
+	notDue := &models.WishlistSearchAlert{UserID: 1, Name: "weekly, not due", Cadence: models.WishlistAlertCadenceWeekly, IsActive: true, LastRunAt: &twoDaysAgo}
+	manual := &models.WishlistSearchAlert{UserID: 1, Name: "manual", Cadence: models.WishlistAlertCadenceManual, IsActive: true, LastRunAt: &eightDaysAgo}
+	for _, a := range []*models.WishlistSearchAlert{due, notDue, manual} {
+		if err := alertRepo.CreateAlert(a); err != nil {
+			t.Fatalf("create alert %q: %v", a.Name, err)
+		}
+	}
+
+	s.runCycle()
+
+	var runs []models.AlertRun
+	if err := db.Find(&runs).Error; err != nil {
+		t.Fatalf("load runs: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected exactly 1 queued run, got %d", len(runs))
+	}
+	if runs[0].AlertID != due.ID {
+		t.Fatalf("expected run queued for the overdue alert %d, got alert %d", due.ID, runs[0].AlertID)
+	}
+	if runs[0].TriggerType != models.AlertRunTriggerScheduled {
+		t.Fatalf("expected scheduled trigger type, got %q", runs[0].TriggerType)
+	}
+	if runs[0].Status != models.AlertRunStatusQueued {
+		t.Fatalf("expected queued status, got %q", runs[0].Status)
+	}
+}

--- a/src/api/services/wishlist_search_alert_service.go
+++ b/src/api/services/wishlist_search_alert_service.go
@@ -248,6 +248,37 @@ func (s *WishlistSearchAlertService) RunNow(alertID, userID uint, input RunAlert
 	return runResult(run, nil), nil
 }
 
+// QueueScheduledRun enqueues an automatic run for an alert that is due per its
+// configured cadence, as determined by the scheduler. Unlike RunNow, this is
+// triggered by the scheduler rather than a direct user request.
+func (s *WishlistSearchAlertService) QueueScheduledRun(alert models.WishlistSearchAlert) (*AlertRunResult, error) {
+	if !alert.IsActive {
+		return nil, ErrWishlistSearchAlertDisabled
+	}
+	snapshot, err := s.CriteriaSnapshot(&alert, AlertResultCapDefault)
+	if err != nil {
+		return nil, fmt.Errorf("build criteria snapshot: %w", err)
+	}
+	run := &models.AlertRun{
+		AlertID:          alert.ID,
+		UserID:           alert.UserID,
+		TriggerType:      models.AlertRunTriggerScheduled,
+		Status:           models.AlertRunStatusQueued,
+		StartedAt:        time.Now(),
+		CriteriaSnapshot: snapshot,
+		RateLimitStatus:  "ok",
+	}
+	acquired, err := s.repo.CreateManualRunIfAvailable(run, time.Now().Add(-wishlistAlertRunningLockWindow))
+	if err != nil {
+		return nil, err
+	}
+	if !acquired {
+		return nil, ErrWishlistSearchAlertRunLimited
+	}
+	s.enqueueRunID(run.ID)
+	return runResult(run, nil), nil
+}
+
 func (s *WishlistSearchAlertService) enqueueRunID(runID uint) {
 	select {
 	case s.queue <- runID:

--- a/src/web/src/components/wishlist-alerts/AlertForm.vue
+++ b/src/web/src/components/wishlist-alerts/AlertForm.vue
@@ -1,6 +1,6 @@
 <template>
   <form class="grid gap-3" @submit.prevent="submit">
-    <p class="m-0 text-body text-text-muted">Search Alerts discover acquisition ideas. They do not check saved wishlist item availability. Cadence is metadata only in v1; use Run Now for manual, in-app review.</p>
+    <p class="m-0 text-body text-text-muted">Search Alerts discover acquisition ideas. They do not check saved wishlist item availability. Use Run Now for an immediate, in-app review, or set a cadence below for automatic runs (if enabled by your admin).</p>
     <label class="grid gap-1 text-base text-text-secondary">
       Name
       <input
@@ -59,13 +59,13 @@
         Cadence
         <select v-model="draft.cadence" class="form-select focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-gold)]">
           <option value="manual">Manual</option>
-          <option value="daily">Daily metadata only</option>
-          <option value="weekly">Weekly metadata only</option>
-          <option value="monthly">Monthly metadata only</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
         </select>
       </label>
     </div>
-    <p class="m-0 text-body text-text-muted">Daily, weekly, and monthly values are saved for future scheduling; this screen does not enable push, email, or digest delivery.</p>
+    <p class="m-0 text-body text-text-muted">Daily, weekly, and monthly alerts run automatically once due, if your admin has enabled scheduled search alert checks. This does not enable push, email, or digest delivery — new candidates only appear in this in-app review queue.</p>
     <label class="grid gap-1 text-base text-text-secondary">
       Source domains
       <input

--- a/src/web/src/pages/WishlistAlertsPage.vue
+++ b/src/web/src/pages/WishlistAlertsPage.vue
@@ -60,7 +60,7 @@
           >
             <h2>{{ alert.name }}</h2>
             <AlertCriteriaSummary :alert="alert" />
-            <p class="mt-1 text-body text-text-muted">Cadence metadata only. Run Now starts manual in-app review.</p>
+            <p class="mt-1 text-body text-text-muted">{{ alert.cadence === 'manual' ? 'Manual cadence. Run Now starts an in-app review.' : `Runs automatically (${alert.cadence}) when scheduled checks are enabled, or any time via Run Now.` }}</p>
           </button>
           <div class="mt-4 flex flex-wrap items-start justify-between gap-3">
             <button class="btn btn-secondary btn-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-gold)]" type="button" @click="edit(alert)"><Pencil :size="14" /> Edit</button>


### PR DESCRIPTION
Cadence (daily/weekly/monthly) was stored on WishlistSearchAlert but
nothing ever checked it — only a manual "Run Now" click created an
AlertRun. Add a WishlistSearchAlertScheduler that sweeps daily and
queues a scheduled run for any active alert whose cadence interval has
elapsed since LastRunAt, gated behind a new
WishlistSearchAlertsCheckEnabled setting (off by default, matching the
other schedulers). Update the alert UI copy, which previously stated
cadence was "metadata only."